### PR TITLE
fix legacy podman run

### DIFF
--- a/kubetool/resources/scripts/etcdctl.sh
+++ b/kubetool/resources/scripts/etcdctl.sh
@@ -70,7 +70,7 @@ if [ -n "${ETCD_POD_CONFIG}" ]; then
 
   if [ "$CONT_RUNTIME" == "podman" ]; then
     podman pull ${ETCD_IMAGE} &> /dev/null
-    podman run --rm ${ETCD_MOUNTS} -e ETCDCTL_API=3 ${ETCD_IMAGE} etcdctl --cert=${ETCD_CERT} --key=${ETCD_KEY} --cacert=${ETCD_CA} "${USER_ARGS[@]}"
+    podman run --network=host --rm ${ETCD_MOUNTS} -e ETCDCTL_API=3 ${ETCD_IMAGE} etcdctl --cert=${ETCD_CERT} --key=${ETCD_KEY} --cacert=${ETCD_CA} "${USER_ARGS[@]}"
   else
     docker run --rm ${ETCD_MOUNTS} -e ETCDCTL_API=3 ${ETCD_IMAGE} etcdctl --cert=${ETCD_CERT} --key=${ETCD_KEY} --cacert=${ETCD_CA} "${USER_ARGS[@]}"
   fi


### PR DESCRIPTION
### Description ###
Fixes MANOPD-68736
Legacy _podman-1.4.4_ (not higher) during run command uses k8s cni plugin by default, because k8s is installed  , which causes _podman run_ failed  

> 2021-09-28 07:43:49.613 [INFO][377437] k8s.go 71: Extracted identifiers for CmdAddK8s ContainerID="bded58b13e6a404f006a89d97e0dbc4d07138cf65334404716b1b920318a91e2" Namespace="nifty_pasteur" Pod="nifty_pasteur" WorkloadEndpoint="qaminiha--2-k8s-nifty_pasteur-eth0"
> 2021-09-28 07:43:49.618 [ERROR][377437] plugin.go 119: Final result of CNI ADD was an error. error=namespaces "nifty_pasteur" not found
> ERRO[0000] Error adding network: namespaces "nifty_pasteur" not found
> ERRO[0000] Error while adding pod to CNI network "k8s-pod-network": namespaces "nifty_pasteur" not found
> Error: error configuring network namespace for container bded58b13e6a404f006a89d97e0dbc4d07138cf65334404716b1b920318a91e2: namespaces "nifty_pasteur" not found

> $ ls /etc/cni/net.d/
> 10-calico.conflist  87-podman-bridge.conflist  calico-kubeconfig
> $ cat /etc/cni/net.d/10-calico.conflist
> {
>   "name": "k8s-pod-network",

### Solution  ###
add host network directly to podman run.  This works OK for legacy and latest podman version


### How to apply ###
* None for update
* Fresh install


### How Has This Been Tested?


**TestCase 1**

Test Configuration:
Run etcdctl manually 


- OS: Oracle 7


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts



### Reviewers ###
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
