### PR TITLE
[PSUPCLPL-8206] Fix list index out of range exception for non-complete size of nodes in group

### DIFF
--- a/kubetool/kubernetes.py
+++ b/kubetool/kubernetes.py
@@ -1051,7 +1051,8 @@ def images_grouped_prepull(group: NodeGroup, group_size: int = None):
             log.verbose('Prepulling images for group #%s...' % group_i)
             # RemoteExecutor used for future cases, when some nodes will require another/additional actions for prepull
             for node_i in range(group_i*group_size, (group_i*group_size)+group_size):
-                images_prepull(nodes[node_i])
+                if node_i < len(nodes):
+                    images_prepull(nodes[node_i])
 
     return exe.get_last_results_str()
 


### PR DESCRIPTION
### Description ###
When running images prepull in amount of node with non-complete size of nodes in group (e.g. 27 nodes with group_size=20), the following exception occurred:
```
10:18:13 INFO *** TASK prepull_images ***
10:18:13 DEBUG Prepulling Kubernetes images...
10:18:13 DEBUG Running kubetool.kubernetes.images_grouped_prepull: 
10:19:45 CRITICAL FAILURE!
10:19:45 CRITICAL TASK FAILED prepull_images
10:19:45 CRITICAL Unexpected exception
10:19:45 Traceback (most recent call last):
10:19:45   File "/opt/kubetools/kubetool/core/flow.py", line 167, in run_flow
10:19:45     task(cluster)
10:19:45   File "/opt/kubetools/kubetool/procedures/upgrade.py", line 26, in prepull_images
10:19:45     upgrade_group.call(kubernetes.images_grouped_prepull)
10:19:45   File "/opt/kubetools/kubetool/core/group.py", line 347, in call
10:19:45     return self.call_batch([action], **{"%s.%s" % (action.__module__, action.__name__): kwargs})
10:19:45   File "/opt/kubetools/kubetool/core/group.py", line 361, in call_batch
10:19:45     results[action] = action(self, **action_kwargs)
10:19:45   File "/opt/kubetools/kubetool/kubernetes.py", line 1054, in images_grouped_prepull
10:19:45     images_prepull(nodes[node_i])
10:19:45 IndexError: list index out of range
```


### Solution  ###
Range calculated for the whole group (e.g. 20...40 for the second group) and there were no `node_i` limit check in `nodes` list. Added check before pulling.


### How to apply ###
Re-run last procedure, where you faced an exception described in this PR, otherwise no actions required.


### How Has This Been Tested?

**TestCase 1**

Test Configuration:

- Hardware: 7 VM
- OS: Centos
- Inventory: custom `prepull_group_size=10`parameter was set

Steps:

1. Run installation with specific inventory

Results:

| Before | After |
| ------ | ------ |
| An exception thrown | Installation completed successfully |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


### Reviewers ###
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21

PSUPCLPL-8206