### PR TITLE
Migration cri improvements

### DIFF
--- a/kubetool/procedures/migrate_cri.py
+++ b/kubetool/procedures/migrate_cri.py
@@ -146,8 +146,9 @@ def _migrate_cri(cluster, node_group):
                                     f"kube-apiserver-{node['name']} "
                                     f"kube-controller-manager-{node['name']} "
                                     f"kube-scheduler-{node['name']} "
-                                    f"$(kubectl describe node {node['name']} | grep -E 'kube-system\s+kube-proxy-[a-z,0-9]{5}' | \
-                                        awk '{{print $2}}')", is_async=False, hide=False).get_simple_out()
+                                    f"$(sudo kubectl describe node {node['name']} | \
+                                        grep -E 'kube-system\s+kube-proxy-[a-z,0-9]{{5}}' | awk '{{print $2}}')"
+                                    , is_async=False, hide=False).get_simple_out()
 
         kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
         kubeadm_flags = node["connection"].sudo(f"cat {kubeadm_flags_file}",


### PR DESCRIPTION
### Description ###
*  `kube-proxy` is needed to be reboot during the migration procedure.

### Solution  ###
*  Find out the `kube-proxy` pod name for current `master`. 
*  Add `kube-proxy` pod to the list of system pods for explicit deletion.


### How to apply ###
Not applicable


### How Has This Been Tested?

**TestCase 1**

Test Configuration:

- Hardware: 5 slow VMs
- OS: CentOS
- Inventory: -

Steps:

1. Run the `cri` migration procedure

Results:

| Before | After |
| ------ | ------ |
| kube-proxy pods are not renewed | kube-proxy pods are renewed |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


### Reviewers ###
@koryaga @iLeonidze @zaborin @Yaroslav-Lahtachev @dmyar21
