### PR TITLE
MANOPD-69670 Revert removed supported kubernetes versions in globals

### DIFF
--- a/kubetool/resources/configurations/defaults.yaml
+++ b/kubetool/resources/configurations/defaults.yaml
@@ -16,7 +16,7 @@ services:
   kubeadm:
     apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
-    kubernetesVersion: v1.20.11
+    kubernetesVersion: v1.22.2
     controlPlaneEndpoint: '{{ cluster_name }}:6443'
     networking:
       podSubnet: '{% if nodes[0]["internal_address"]|isipv4 %}10.128.0.0/14{% else %}fd02::/80{% endif %}'

--- a/kubetool/resources/configurations/globals.yaml
+++ b/kubetool/resources/configurations/globals.yaml
@@ -96,7 +96,15 @@ workaround:
 compatibility_map:
   software:
     docker:
+      v1.20.2:
+        version_rhel: 19.03*
+        version_rhel8: 19.03*
+        version_debian: 5:19.03.*
       v1.20.11:
+        version_rhel: 19.03*
+        version_rhel8: 19.03*
+        version_debian: 5:19.03.*
+      v1.21.2:
         version_rhel: 19.03*
         version_rhel8: 19.03*
         version_debian: 5:19.03.*
@@ -109,7 +117,15 @@ compatibility_map:
         version_rhel8: 19.03*
         version_debian: 5:19.03.*
     containerd:
+      v1.20.2:
+        version_rhel: 1.4.6*
+        version_rhel8: 1.4.8*
+        version_debian: 1.4.6*
       v1.20.11:
+        version_rhel: 1.4.6*
+        version_rhel8: 1.4.8*
+        version_debian: 1.4.6*
+      v1.21.2:
         version_rhel: 1.4.6*
         version_rhel8: 1.4.8*
         version_debian: 1.4.6*
@@ -122,7 +138,15 @@ compatibility_map:
         version_rhel8: 1.4.8*
         version_debian: 1.4.6*
     podman:
+      v1.20.2:
+        version_rhel: 1.6.4*
+        version_rhel8: 3.0.1*
+        version_debian: 100:3.1.2*
       v1.20.11:
+        version_rhel: 1.6.4*
+        version_rhel8: 3.0.1*
+        version_debian: 100:3.1.2*
+      v1.21.2:
         version_rhel: 1.6.4*
         version_rhel8: 3.0.1*
         version_debian: 100:3.1.2*
@@ -135,7 +159,15 @@ compatibility_map:
         version_rhel8: 3.0.1*
         version_debian: 100:3.1.2*
     haproxy:
+      v1.20.2:
+        version_rhel: 1.8*
+        version_rhel8: 1.8*
+        version_debian: 2.0.*
       v1.20.11:
+        version_rhel: 1.8*
+        version_rhel8: 1.8*
+        version_debian: 2.0.*
+      v1.21.2:
         version_rhel: 1.8*
         version_rhel8: 1.8*
         version_debian: 2.0.*
@@ -148,7 +180,15 @@ compatibility_map:
         version_rhel8: 1.8*
         version_debian: 2.0.*
     keepalived:
+      v1.20.2:
+        version_rhel: 1.3*
+        version_rhel8: 2.1*
+        version_debian: 1:2.0.*
       v1.20.11:
+        version_rhel: 1.3*
+        version_rhel8: 2.1*
+        version_debian: 1:2.0.*
+      v1.21.2:
         version_rhel: 1.3*
         version_rhel8: 2.1*
         version_debian: 1:2.0.*
@@ -161,7 +201,13 @@ compatibility_map:
         version_rhel8: 2.1*
         version_debian: 1:2.0.*
     crictl:
+      v1.20.2:
+        version: v1.20.0
+        sha1: eaf4ffa1cfac5c69ec522d9562c8ee6ddd873f3e
       v1.20.11:
+        version: v1.20.0
+        sha1: eaf4ffa1cfac5c69ec522d9562c8ee6ddd873f3e
+      v1.21.2:
         version: v1.20.0
         sha1: eaf4ffa1cfac5c69ec522d9562c8ee6ddd873f3e
       v1.21.5:
@@ -171,22 +217,34 @@ compatibility_map:
         version: v1.22.0
         sha1: b840ddd1a8a35b12fd22d2657c7d17cb2f6f2e05
     kubeadm:
+      v1.20.2:
+        sha1: 4c025ebf29eb7aa32012a1c8f81e7b85df2bf92f
       v1.20.11:
         sha1: 59f904f50ea10cbc69007891301a2169f42f3537
+      v1.21.2:
+        sha1: cbb07d380de4ef73d43d594a1055839fa9753138
       v1.21.5:
         sha1: 2ee056ac1d0b9c2289bdb03cb7bb0cd21ee29a8b
       v1.22.2:
         sha1: 190703cfe16ad00d0f91487d00bece9667cd5903
     kubelet:
+      v1.20.2:
+        sha1: 25ca655cce261cdbeb7c3337185f669ee0b53cc3
       v1.20.11:
         sha1: 00c0b6a8dda55616343baafee9e9aa2775bc3c22
+      v1.21.2:
+        sha1: 024e458aa0f74cba6b773401b779590437812fc6
       v1.21.5:
         sha1: 61da22475b977cb678cca8cf7249bf727d72ee89
       v1.22.2:
         sha1: 41a2980963427a17c4fbce74aee6bb0bcf08b9ff
     kubectl:
+      v1.20.2:
+        sha1: 202e00c35fa2a4085135061e5d0965ebbffed19c
       v1.20.11:
         sha1: 0feee9301e7f6cb6fba1d841a6fd8f378589145f
+      v1.21.2:
+        sha1: 2c7a7de9fff41ac49f7c2546a9b1aff2c1d9c468
       v1.21.5:
         sha1: c4648e31ca16fb00e3826f8ab7c653da81eff367
       v1.22.2:


### PR DESCRIPTION
### Description
* Default Kubernetes version is out of date
* When running the upgrade from `v1.20.2` or `v1.21.2` the following exception occurred, but this versions are still supported:
```
10:41:09 FAILURE! - Failed to proceed inventory file
10:41:09 Unexpected exception
10:41:09 
10:41:09 Traceback (most recent call last):
10:41:09   File "/opt/kubetools/kubetool/core/flow.py", line 105, in load_inventory
10:41:09     cluster = cluster_obj(inventory_filepath,
10:41:09   File "/opt/kubetools/kubetool_ee/core/cluster.py", line 7, in __init__
10:41:09     super().__init__(*args, **kwargs)
10:41:09   File "/opt/kubetools/kubetool/core/cluster.py", line 63, in __init__
10:41:09     self.gather_facts('before')
10:41:09   File "/opt/kubetools/kubetool/core/cluster.py", line 155, in gather_facts
10:41:09     defaults.enrich_inventory(t_cluster, t_cluster.raw_inventory, make_dumps=False, custom_fns=self.get_facts_enrichment_fns())
10:41:09   File "/opt/kubetools/kubetool/core/defaults.py", line 362, in enrich_inventory
10:41:09     inventory = getattr(mod, fn_method_name)(inventory, cluster)
10:41:09   File "/opt/kubetools/kubetool/core/defaults.py", line 386, in compile_inventory
10:41:09     inventory = compile_object(cluster.log, inventory, root)
10:41:09   File "/opt/kubetools/kubetool/core/defaults.py", line 414, in compile_object
10:41:09     struct[k] = compile_object(log, v, root, ignore_jinja_escapes=ignore_jinja_escapes)
10:41:09   File "/opt/kubetools/kubetool/core/defaults.py", line 414, in compile_object
10:41:09     struct[k] = compile_object(log, v, root, ignore_jinja_escapes=ignore_jinja_escapes)
10:41:09   File "/opt/kubetools/kubetool/core/defaults.py", line 414, in compile_object
10:41:09     struct[k] = compile_object(log, v, root, ignore_jinja_escapes=ignore_jinja_escapes)
10:41:09   [Previous line repeated 1 more time]
10:41:09   File "/opt/kubetools/kubetool/core/defaults.py", line 416, in compile_object
10:41:09     struct = compile_string(log, struct, root, ignore_jinja_escapes=ignore_jinja_escapes)
10:41:09   File "/opt/kubetools/kubetool/core/defaults.py", line 426, in compile_string
10:41:09     struct = jinja.new(log, root).from_string(struct).render(**root)
10:41:09   File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 1090, in render
10:41:09     self.environment.handle_exception()
10:41:09   File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 832, in handle_exception
10:41:09     reraise(*rewrite_traceback_stack(source=source))
10:41:09   File "/usr/local/lib/python3.9/site-packages/jinja2/_compat.py", line 28, in reraise
10:41:09     raise value.with_traceback(tb)
10:41:09   File "<template>", line 1, in top-level template code
10:41:09   File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 471, in getattr
10:41:09     return getattr(obj, attribute)
10:41:09 jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'v1.21.2'
10:41:09 
10:41:09 
10:41:10 Build step 'Execute shell' marked build as failure
10:41:10 [PostBuildScript] - Executing post build scripts.
10:41:10 Stopping container
10:41:10 Copying data from container
10:41:10 Removing container
10:41:10 Archiving artifacts
10:41:10 RTP: Started!
10:41:10 RTP: Done!
10:41:10 Finished: FAILURE
```

Fixes MANOPD-69670


### Solution
* Updated default Kubernetes version to latest
* Reverted previous commit and added back supported `v1.20.2` and `v1.21.2` versions to globals


### How to apply
Nothing to apply


### Test Cases
* Perform upgrade from `v1.20.2` or `v1.21.2` to new versions. There no exceptions should be thrown.


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
