### PR TITLE
[MANOPD-69810] Fix system selinux validation issue for Debian installation

### DIFF
--- a/kubetool/selinux.py
+++ b/kubetool/selinux.py
@@ -125,6 +125,10 @@ def get_selinux_status(group):
 def is_config_valid(group, state=None, policy=None, permissive=None):
     log = group.cluster.log
 
+    if system.get_os_family(group.cluster) == 'debian':
+        log.debug("Skipped - selinux is not supported on Ubuntu/Debian os family")
+        return
+
     log.verbose('Verifying selinux configs...')
 
     if state is None:

--- a/kubetool/system.py
+++ b/kubetool/system.py
@@ -594,8 +594,9 @@ def is_modprobe_valid(group):
 
 def verify_system(group):
     log = group.cluster.log
+    os_family = get_os_family(group.cluster)
 
-    if group.cluster.is_task_completed('prepare.system.setup_selinux'):
+    if group.cluster.is_task_completed('prepare.system.setup_selinux') and os_family in ['rhel', 'rhel8']:
         log.debug("Verifying Selinux...")
         selinux_configured, selinux_result, selinux_parsed_result = \
             selinux.is_config_valid(group,
@@ -608,13 +609,13 @@ def verify_system(group):
     else:
         log.debug('Selinux verification skipped - origin task was not completed')
 
-    if group.cluster.is_task_completed('prepare.system.setup_apparmor'):
-        log.debug("Verifying Apparmor...")
-        # TODO: support apparmor validation
-        # if not apparmor_configured:
-        #     raise Exception("Selinux is still not configured")
-    else:
-        log.debug('Apparmor verification skipped - origin task was not completed')
+    # TODO: support apparmor validation
+    # if group.cluster.is_task_completed('prepare.system.setup_apparmor') and os_family == 'debian':
+    #     log.debug("Verifying Apparmor...")
+    #     if not apparmor_configured:
+    #         raise Exception("Selinux is still not configured")
+    # else:
+    #     log.debug('Apparmor verification skipped - origin task was not completed')
 
     if group.cluster.is_task_completed('prepare.system.disable_firewalld'):
         log.debug("Verifying FirewallD...")


### PR DESCRIPTION
### Description
Predefined environment (VMs): Ubuntu Image 2004 LTS that relates to the tested schema should be prepared in the Openstack
TC:
1. Prepare yml file with kubernetes configuration (VMs, volumes, kube services...)
2. Run Kubernetes installer DVM
ER: Kubernetes should be successfully installed,
dashboard should be available
smoke-tests passed.
AR job failed with the following stacktrace:
```
13:39:15 INFO *** CUMULATIVE POINT kubetool.system.verify_system ***
13:39:15 DEBUG Running kubetool.system.verify_system: 
13:39:15 DEBUG Verifying Selinux...
13:39:20 Traceback (most recent call last):
13:39:20   File "/opt/kubetools/kubetools.py", line 6, in <module>
13:39:20     __main__.main()
13:39:20   File "/opt/kubetools/kubetool_ee/__main__.py", line 22, in main
13:39:20     __main__.main()
13:39:20   File "/opt/kubetools/kubetool/__main__.py", line 123, in main
13:39:20     result = import_procedure(arguments[0]).main(arguments[1:])
13:39:20   File "/opt/kubetools/kubetool/procedures/install.py", line 543, in main
13:39:20     flow.run(
13:39:20   File "/opt/kubetools/kubetool/core/flow.py", line 52, in run
13:39:20     run_flow(filtered_tasks, cluster, cumulative_points)
13:39:20   File "/opt/kubetools/kubetool/core/flow.py", line 179, in run_flow
13:39:20     run_flow(task, cluster, cumulative_points, __task_path)
13:39:20   File "/opt/kubetools/kubetool/core/flow.py", line 179, in run_flow
13:39:20     run_flow(task, cluster, cumulative_points, __task_path)
13:39:20   File "/opt/kubetools/kubetool/core/flow.py", line 167, in run_flow
13:39:20     proceed_cumulative_point(cluster, cumulative_points, __task_path)
13:39:20   File "/opt/kubetools/kubetool/core/flow.py", line 282, in proceed_cumulative_point
13:39:20     call_result = cluster.nodes["all"].get_new_nodes_or_self().call(func)
13:39:20   File "/opt/kubetools/kubetool/core/group.py", line 347, in call
13:39:20     return self.call_batch([action], **{"%s.%s" % (action.__module__, action.__name__): kwargs})
13:39:20   File "/opt/kubetools/kubetool/core/group.py", line 361, in call_batch
13:39:20     results[action] = action(self, **action_kwargs)
13:39:20   File "/opt/kubetools/kubetool/system.py", line 601, in verify_system
13:39:20     selinux.is_config_valid(group,
13:39:20   File "/opt/kubetools/kubetool/selinux.py", line 139, in is_config_valid
13:39:20     result, parsed_result = get_selinux_status(group)
13:39:20   File "/opt/kubetools/kubetool/selinux.py", line 114, in get_selinux_status
13:39:20     result = group.sudo("sestatus && sudo semanage permissive -l")
13:39:20   File "/opt/kubetools/kubetool/core/group.py", line 139, in sudo
13:39:20     return self.do("sudo", *args, **kwargs)
13:39:20   File "/opt/kubetools/kubetool/core/group.py", line 252, in do
13:39:20     group_results = self._make_result_or_fail(raw_results, lambda host, result: isinstance(result, Exception))
13:39:20   File "/opt/kubetools/kubetool/core/group.py", line 131, in _make_result_or_fail
13:39:20     raise fabric.group.GroupException(group_result)
13:39:20 fabric.exceptions.GroupException: 	10.102.2.84: code=1
13:39:20 		STDOUT: SELinux status:                 disabled
13:39:20 		        
13:39:20 		STDERR: ValueError: SELinux policy is not managed or store cannot be accessed.
13:39:20 		        
13:39:20 	10.102.1.39: code=1
13:39:20 		STDOUT: SELinux status:                 disabled
13:39:20 		        
13:39:20 		STDERR: ValueError: SELinux policy is not managed or store cannot be accessed.
13:39:20 		        
13:39:20 	10.102.1.202: code=1
13:39:20 		STDOUT: SELinux status:                 disabled
13:39:20 		        
13:39:20 		STDERR: ValueError: SELinux policy is not managed or store cannot be accessed.
13:39:20 		        
13:39:20 	10.102.0.53: code=1
13:39:20 		STDOUT: SELinux status:                 disabled
13:39:20 		        
13:39:20 		STDERR: ValueError: SELinux policy is not managed or store cannot be accessed.
13:39:20 		        
13:39:20 	10.102.2.190: code=1
13:39:20 		STDOUT: SELinux status:                 disabled
13:39:20 		        
13:39:20 		STDERR: ValueError: SELinux policy is not managed or store cannot be accessed.
13:39:20 		        
13:39:20 	10.102.2.112: code=1
13:39:20 		STDOUT: SELinux status:                 disabled
13:39:20 		        
13:39:20 		STDERR: ValueError: SELinux policy is not managed or store cannot be accessed.
13:39:20 		        
13:39:20 	10.102.1.11: code=1
13:39:20 		STDOUT: SELinux status:                 disabled
13:39:20 		        
13:39:20 		STDERR: ValueError: SELinux policy is not managed or store cannot be accessed.
13:39:20 		        
13:39:20 	10.102.2.125: code=1
13:39:20 		STDOUT: SELinux status:                 disabled
13:39:20 		        
13:39:20 		STDERR: ValueError: SELinux policy is not managed or store cannot be accessed.
13:39:20 		        
13:39:20 Build step 'Execute shell' marked build as failure
13:39:20 [PostBuildScript] - Executing post build scripts.
13:39:20 Stopping container
13:39:21 Copying data from container
13:39:21 Removing container
13:39:21 Archiving artifacts
13:39:21 Finished: FAILURE
```

Fixes MANOPD-69810


### Solution
* Added checks for os family before selinux-related actions proceeding.


### How to apply
Nothing to apply


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
