### PR TITLE
[MANOPD-70009]Fix modprobe for KVM core kernel

### DIFF
--- a/kubetool/resources/configurations/defaults.yaml
+++ b/kubetool/resources/configurations/defaults.yaml
@@ -105,10 +105,6 @@ services:
 
   modprobe:
     - br_netfilter
-    - ip_vs
-    - ip_vs_rr
-    - ip_vs_wrr
-    - ip_vs_sh
     - '{% if not nodes[0]["internal_address"]|isipv4 %}ip6table_filter{% endif %}'
     - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_conntrack_ipv6{% endif %}'
     - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_nat_masquerade_ipv6{% endif %}'


### PR DESCRIPTION
### Description
MANOPD-70009
*Fix modprobe for KVM core kernel*. It has been identified that *ip_vs* is not used and installing related modules causes an issue on KVM based kernel.

### Solution
Remove loading of *ip_vs* modules

### How to apply 
- None or remove modules ip_vs, ip_vs_rr, ip_vs_wrr, ip_vs_sh manually.
- In case *ip_vs* is used provide loading related modules by OS modprobe 

### Test cases

### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
