### PR TITLE
[MANOPD-70207] Fix installation from internet issues

### DIFF
--- a/kubetool/resources/configurations/globals.yaml
+++ b/kubetool/resources/configurations/globals.yaml
@@ -265,15 +265,15 @@ compatibility_map:
         sha1: 4c5aec4da45c6ce45e03df2f36abb0010909b7db
     nginx-ingress-controller:
       v1.20:
-        image-name: ingress-nginx/controller
+        image-name: k8s.gcr.io/ingress-nginx/controller
         version: v1.0.3
         pod-name: ingress-nginx-controller
       v1.21:
-        image-name: ingress-nginx/controller
+        image-name: k8s.gcr.io/ingress-nginx/controller
         version: v1.0.3
         pod-name: ingress-nginx-controller
       v1.22:
-        image-name: ingress-nginx/controller
+        image-name: k8s.gcr.io/ingress-nginx/controller
         version: v1.0.3
         pod-name: ingress-nginx-controller
     kubernetes-dashboard:


### PR DESCRIPTION
### Description
* When installing from internet there is no `podman` in defaults repos with the version, specified in defaults
* When installing from internet it is not possible to install `nginx-ingress-controller` out of the box

Fixes MANOPD-70207


### Solution
* Removed fixed `podman` version from defaults. We decided it is not such important for installation.
* Fixed `nginx-ingress-controller` image name


### How to apply
Nothing to apply


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Nothing changed or added


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
