### PR TITLE
[MANOPD-66192] add --backup flag to mv in case of backup_repo

### DIFF
--- a/kubetool/apt.py
+++ b/kubetool/apt.py
@@ -16,7 +16,7 @@ def backup_repo(group, repo_filename="*") -> NodeGroupResult or None:
     # all files in directory will be renamed: xxx.repo -> xxx.repo.bak
     # if there already any files with ".bak" extension, they should not be renamed to ".bak.bak"!
     return group.sudo(
-        "find %s -type f -name '%s.list' | sudo xargs -t -iNAME mv -f NAME NAME.bak" % ("/etc/apt/", repo_filename))
+        "find %s -type f -name '%s.list' | sudo xargs -t -iNAME mv -bf NAME NAME.bak" % ("/etc/apt/", repo_filename))
 
 
 def add_repo(group, repo_data="", repo_filename="predefined") -> NodeGroupResult:

--- a/kubetool/yum.py
+++ b/kubetool/yum.py
@@ -12,7 +12,7 @@ def backup_repo(group, repo_filename="*"):
         return
     # all files in directory will be renamed: xxx.repo -> xxx.repo.bak
     # if there already any files with ".bak" extension, they should not be renamed to ".bak.bak"!
-    return group.sudo("find /etc/yum.repos.d/ -type f -name '%s.repo' | sudo xargs -iNAME mv -f NAME NAME.bak" % repo_filename)
+    return group.sudo("find /etc/yum.repos.d/ -type f -name '%s.repo' | sudo xargs -t -iNAME mv -bf NAME NAME.bak" % repo_filename)
 
 
 def add_repo(group, repo_data="", repo_filename="predefined"):


### PR DESCRIPTION
### Description
* The `--backup` flag should prevent the loss of an already existing file with the target name.

### Solution
* `-b` flag for `mv` command added.
* `-t` flag for `xargs` command added for yum. 

### Checklist
- [x] Integration CI passed
- [x] There is no merge conflicts

### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
