### PR TITLE
[MANOPD-69639] Messages about deprecated flags

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,25 +2,16 @@ name: Publish Artifacts
 on:
   release:
     types: [created]
-<<<<<<< HEAD
-=======
   push:
     branches:
       - 'main'
 env:
   TAG_NAME: ${{ github.event.release.tag_name || (github.ref == 'refs/heads/main' && 'main') }}
->>>>>>> d7fe4ef43b40838d41fd9e0bf287162c2110881d
 jobs:
   publish-docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-<<<<<<< HEAD
-      - run: docker build . -t ghcr.io/netcracker-technology/kubetool:${{ github.event.release.tag_name }}
-      - run: echo ${{secrets.GITHUB_TOKEN}} | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
-      - run: docker push ghcr.io/netcracker-technology/kubetool:${{ github.event.release.tag_name }}
-=======
       - run: docker build . -t ghcr.io/netcracker-technology/kubetool:${{ env.TAG_NAME }}
       - run: echo ${{secrets.GITHUB_TOKEN}} | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
       - run: docker push ghcr.io/netcracker-technology/kubetool:${{ env.TAG_NAME }}
->>>>>>> d7fe4ef43b40838d41fd9e0bf287162c2110881d

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,11 +3,7 @@ name = kubetool
 # Version should not be hard-coded here.
 # It should be calculated dynamically in "setup.py" in integration with CI during build/publication process.
 # We do not have integration with build/publication process, so effectively we do not use version.
-<<<<<<< HEAD
-version = 1.0.0
-=======
 version = 0.0.1
->>>>>>> d7fe4ef43b40838d41fd9e0bf287162c2110881d
 
 [options]
 packages = find:


### PR DESCRIPTION
### Description
After some procedures `debug.log` has warning messages:
```
11:35:23 Flag --delete-local-data has been deprecated, This option is deprecated and will be deleted. Use --delete-emptydir-data.
```

Fixes MANOPD-69639


### Solution
Change flag for `kubectl drain`


### How to apply
Not applicable


### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: Ubuntu or CentOS
- Inventory: 

Steps:

1. Run the upgrade procedure on an existing cluster

Results:

| Before | After |
| ------ | ------ |
| warning message exists | no warning message |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts

### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
