### PR TITLE
[MANOPD-70499] Fix audit installation skip for Ubuntu nodes

### DIFF
--- a/kubetool/audit.py
+++ b/kubetool/audit.py
@@ -54,7 +54,7 @@ def install(group: NodeGroup, enable_service: bool = True, force: bool = False) 
         log.verbose(audit_installed_results)
 
         # Reduce nodes amount for installation
-        install_group = audit_installed_results.get_nonzero_nodes_group()
+        install_group = audit_installed_results.get_nodes_group_where_value_in_stderr("no packages found matching")
 
         if install_group.nodes_amount() == 0:
             log.debug('Auditd is already installed on all nodes')

--- a/kubetool/core/annotations.py
+++ b/kubetool/core/annotations.py
@@ -2,8 +2,14 @@ from kubetool.core.group import NodeGroup
 
 
 def restrict_multi_os_group(fn):
+    """
+    Method is an annotation that does not allow origin method to use different OS families in the same group.
+    :param fn: Origin function to apply annotation validation to
+    :return: Validation wrapper function
+    """
     def wrapper(group: NodeGroup, *args, **kwargs):
+        # TODO: walk through all nodes in *args, check isinstance NodeGroup and perform validation
         if group.is_multi_os():
-            raise Exception('Method do not supports multi-os group')
+            raise Exception(f'Method "{str(fn)}" do not supports multi-os group')
         return fn(group, *args, **kwargs)
     return wrapper

--- a/kubetool/core/group.py
+++ b/kubetool/core/group.py
@@ -132,8 +132,8 @@ class NodeGroupResult(fabric.group.GroupResult, Dict[fabric.connection.Connectio
 
     def get_excepted_nodes_list(self) -> List[fabric.connection.Connection]:
         """
-        Returns a list of node connections, for which the result is an exception
-        :return: Boolean
+        Returns a list of nodes connections, for which the result is an exception
+        :return: List with nodes connections
         """
         failed_nodes: List[fabric.connection.Connection] = []
         for conn, result in self.items():
@@ -144,16 +144,16 @@ class NodeGroupResult(fabric.group.GroupResult, Dict[fabric.connection.Connectio
     def get_excepted_nodes_group(self) -> NodeGroup:
         """
         Forms and returns new NodeGroup of nodes, for which the result is an exception
-        :return: Boolean
+        :return: NodeGroup:
         """
         nodes_list = self.get_excepted_nodes_list()
         return self.cluster.make_group(nodes_list)
 
     def get_exited_nodes_list(self) -> List[fabric.connection.Connection]:
         """
-        Returns a list of node connections, for which the result is the completion of the command and the formation of
+        Returns a list of nodes connections, for which the result is the completion of the command and the formation of
         the Fabric Result
-        :return: Boolean
+        :return: List with nodes connections
         """
         failed_nodes: List[fabric.connection.Connection] = []
         for conn, result in self.items():
@@ -165,15 +165,15 @@ class NodeGroupResult(fabric.group.GroupResult, Dict[fabric.connection.Connectio
         """
         Forms and returns new NodeGroup of nodes, for which the result is the completion of the command and the
         formation of the Fabric Result
-        :return: Boolean
+        :return: NodeGroup:
         """
         nodes_list = self.get_exited_nodes_list()
         return self.cluster.make_group(nodes_list)
 
     def get_failed_nodes_list(self) -> List[fabric.connection.Connection]:
         """
-        Returns a list of node connections that either exited with an exception, or the exit code is equals 1
-        :return: Boolean
+        Returns a list of nodes connections that either exited with an exception, or the exit code is equals 1
+        :return: List with nodes connections
         """
         failed_nodes: List[fabric.connection.Connection] = []
         for conn, result in self.items():
@@ -184,28 +184,49 @@ class NodeGroupResult(fabric.group.GroupResult, Dict[fabric.connection.Connectio
     def get_failed_nodes_group(self) -> NodeGroup:
         """
         Forms and returns new NodeGroup of nodes that either exited with an exception, or the exit code is equals 1
-        :return: Boolean
+        :return: NodeGroup:
         """
         nodes_list = self.get_failed_nodes_list()
         return self.cluster.make_group(nodes_list)
 
     def get_nonzero_nodes_list(self) -> List[fabric.connection.Connection]:
         """
-        Returns a list of node connections that exited with non-zero exit code
-        :return: Boolean
+        Returns a list of nodes connections that exited with non-zero exit code
+        :return: List with nodes connections
         """
-        failed_nodes: List[fabric.connection.Connection] = []
+        nonzero_nodes: List[fabric.connection.Connection] = []
         for conn, result in self.items():
             if isinstance(result, Exception) or result.exited != 0:
-                failed_nodes.append(conn)
-        return failed_nodes
+                nonzero_nodes.append(conn)
+        return nonzero_nodes
 
     def get_nonzero_nodes_group(self) -> NodeGroup:
         """
         Forms and returns new NodeGroup of nodes that exited with non-zero exit code
-        :return: Boolean
+        :return: NodeGroup:
         """
         nodes_list = self.get_nonzero_nodes_list()
+        return self.cluster.make_group(nodes_list)
+
+    def get_nodes_list_where_value_in_stderr(self, value: str) -> List[fabric.connection.Connection]:
+        """
+        Returns a list of node connections that contains the given string value in results stderr
+        :param value: The string value to be found in the nodes results stderr.
+        :return: List with nodes connections
+        """
+        nodes_with_stderr_value: List[fabric.connection.Connection] = []
+        for conn, result in self.items():
+            if isinstance(result, fabric.runners.Result) and value in result.stderr:
+                nodes_with_stderr_value.append(conn)
+        return nodes_with_stderr_value
+
+    def get_nodes_group_where_value_in_stderr(self, value: str) -> NodeGroup:
+        """
+        Forms and returns new NodeGroup of nodes that contains the given string value in results stderr
+        :param value: The string value to be found in the nodes results stderr.
+        :return: NodeGroup
+        """
+        nodes_list = self.get_nodes_list_where_value_in_stderr(value)
         return self.cluster.make_group(nodes_list)
 
     def __eq__(self, other) -> bool:


### PR DESCRIPTION
### Description
* When running clean install on Ubuntu cluster the following error occurred:
```
15:43:24 CRITICAL 10.102.2.125:
15:43:24 CRITICAL Encountered a bad command exit code!
15:43:24 CRITICAL 
...
15:43:24 CRITICAL 
15:43:24 CRITICAL Exit code: 1
15:43:24 CRITICAL 
15:43:24 CRITICAL Stdout:
15:43:24 CRITICAL 
15:43:24 CRITICAL 
15:43:24 CRITICAL 
15:43:24 CRITICAL Stderr:
15:43:24 CRITICAL 
15:43:24 CRITICAL ls: cannot access '/etc/audit/rules.d/predefined.rules*': No such file or directory
15:43:24 CRITICAL cp: cannot stat '/etc/audit/rules.d/predefined.rules': No such file or directory
15:43:24 CRITICAL mv: cannot move '/tmp/aed2c09ea3aa4490a14f3514f772878f' to '/etc/audit/rules.d/predefined.rules': No such file or directory
```

Fixes MANOPD-70499


### Solution
* Fixed a bug that mistakenly decided that when polling for the presence of a package on the nodes, all the nodes answered without errors, thereby skipping the audit installation, that caused audit configuring failure.


### How to apply
Nothing to apply


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: FullHA
- OS: Ubuntu 20.04
- Inventory: Default inventory

Steps:

1. Run clean install

Results:

| Before | After |
| ------ | ------ |
| Installation failed  | Installation finished without exceptions |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
No new unit tests.


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
