### PR TITLE
[MANOPD-70215]Kubetools not works with ssh key generated with use ssh-keygen.

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -287,9 +287,6 @@ Example:
 ```
 ssh-keygen -t rsa -b 4096
 ```
-
-
-
 # Inventory Preparation
 
 Before you begin, select the deployment scheme and prepare the inventory.


### PR DESCRIPTION
### Description
*Fix Installation.md, Adding an item about ssh keys*

Fixes # (issue)

*Add info in dock*



### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
