### PR TITLE
[MANOPD-70520] Rework default registry for nginx-ingress

### DIFF
--- a/kubetool/resources/configurations/defaults.yaml
+++ b/kubetool/resources/configurations/defaults.yaml
@@ -423,6 +423,7 @@ plugins:
     version: '{{ globals.compatibility_map.software["nginx-ingress-controller"][services.kubeadm.kubernetesVersion|minorversion].version }}'
     install: true
     installation:
+      registry: k8s.gcr.io
       priority: 1
       procedures:
         - python:

--- a/kubetool/resources/configurations/globals.yaml
+++ b/kubetool/resources/configurations/globals.yaml
@@ -265,15 +265,15 @@ compatibility_map:
         sha1: 4c5aec4da45c6ce45e03df2f36abb0010909b7db
     nginx-ingress-controller:
       v1.20:
-        image-name: k8s.gcr.io/ingress-nginx/controller
+        image-name: ingress-nginx/controller
         version: v1.0.3
         pod-name: ingress-nginx-controller
       v1.21:
-        image-name: k8s.gcr.io/ingress-nginx/controller
+        image-name: ingress-nginx/controller
         version: v1.0.3
         pod-name: ingress-nginx-controller
       v1.22:
-        image-name: k8s.gcr.io/ingress-nginx/controller
+        image-name: ingress-nginx/controller
         version: v1.0.3
         pod-name: ingress-nginx-controller
     kubernetes-dashboard:


### PR DESCRIPTION
### Description
* When installing cluster from scratch in closed env, nginx-ingress cluster installation failed. Exception occurred because of invalid image location.

Fixes MANOPD-70520


### Solution
* Changed nginx-ingress image location. Reworked defaults calculation for plugins.


### How to apply
Nothing to apply


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Enabled nginx-ingress

Steps:

1. Run cluster installation or nginx-ingress cluster deployment

Results:

| Before | After |
| ------ | ------ |
| Installation failed | Installation finished |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
No new unit tests


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
