### PR TITLE
[MANOPD-70594] Fix ETCD health validation issue

### DIFF
--- a/kubetool/core/group.py
+++ b/kubetool/core/group.py
@@ -713,8 +713,10 @@ class NodeGroup:
         return self.get_member(-1, provide_node_configs=provide_node_configs, apply_filter=apply_filter)
 
     def get_any_member(self, provide_node_configs=False, apply_filter=None):
-        return random.choice(self.get_ordered_members_list(provide_node_configs=provide_node_configs,
-                                                           apply_filter=apply_filter))
+        member = random.choice(self.get_ordered_members_list(provide_node_configs=provide_node_configs,
+                                                             apply_filter=apply_filter))
+        self.cluster.log.verbose(f'Selected node {str(member)}')
+        return member
 
     def get_member_by_name(self, name, provide_node_configs=False):
         return self.get_first_member(provide_node_configs=provide_node_configs, apply_filter={"name": name})

--- a/kubetool/etcd.py
+++ b/kubetool/etcd.py
@@ -1,6 +1,10 @@
 import io
 import json
 import time
+
+import fabric.connection
+
+from kubetool.core.cluster import KubernetesCluster
 from kubetool.core.group import NodeGroup
 
 
@@ -37,10 +41,12 @@ def remove_members(group: NodeGroup):
         else:
             log.verbose(f"Skipping {node_name} as it is not among etcd members.")
 
-# the method checks etcd endpoints health until all endpoints are healthy or retries are exhausted
-# if all member are healthy the method checks the leader
-def wait_for_health(cluster, connection):
 
+def wait_for_health(cluster: KubernetesCluster, connection: fabric.connection.Connection) -> list[dict]:
+    """
+    The method checks etcd endpoints health until all endpoints are healthy or retries are exhausted
+    if all member are healthy the method checks the leader.
+    """
     log = cluster.log
     init_timeout = cluster.globals['etcd']['health']['init_timeout']
     timeout = cluster.globals['etcd']['health']['timeout']
@@ -50,8 +56,8 @@ def wait_for_health(cluster, connection):
     time.sleep(init_timeout)
     while retries > 0:
         start_time = time.time()
-        etcd_health_raw = connection.sudo('etcdctl endpoint health --cluster -w json'
-                                           , is_async=False, hide=True).get_simple_out()
+        etcd_health_raw = connection.sudo('etcdctl endpoint health --cluster -w json',
+                                          is_async=False, hide=True).get_simple_out()
         end_time = time.time()
         sudo_time = int(end_time - start_time)
         log.verbose(etcd_health_raw)
@@ -73,8 +79,8 @@ def wait_for_health(cluster, connection):
             retries -= 1
 
     if is_healthy:
-        etcd_status_raw = connection.sudo('etcdctl endpoint status --cluster -w json'
-                                           , is_async=False, hide=True).get_simple_out()
+        etcd_status_raw = connection.sudo('etcdctl endpoint status --cluster -w json',
+                                          is_async=False, hide=True).get_simple_out()
         log.verbose(etcd_status_raw)
         etcd_status_list = json.load(io.StringIO(etcd_status_raw.lower().strip()))
         elected_leader = None
@@ -91,3 +97,5 @@ def wait_for_health(cluster, connection):
         raise Exception('ETCD cluster is still not healthy!')
       
     log.verbose('ETCD cluster is healthy!')
+
+    return etcd_status_list

--- a/kubetool/procedures/restore.py
+++ b/kubetool/procedures/restore.py
@@ -211,8 +211,7 @@ def import_etcd(cluster: KubernetesCluster):
 
     # After restore check db size equal, cluster health and leader elected
     # Checks should be changed
-    master_conn = cluster.nodes['master'].get_first_member()
-    etcd.wait_for_health(cluster, cluster.nodes['master'])
+    cluster_status = etcd.wait_for_health(cluster, cluster.nodes['master'].get_any_member())
 
     # Check DB size is correct
     backup_source = cluster.context['backup_descriptor'].get('etcd', {}).get('source')


### PR DESCRIPTION
### Description
* When restoring cluster, the following exception thrown:
```
13:01:03 2021-11-22 09:58:22.788118 N | etcdserver/membership: set the initial cluster version to 3.0
13:01:03 2021-11-22 09:58:22.788264 I | etcdserver/api: enabled capabilities for version 3.0
13:01:03 2021-11-22 09:58:22.790689 I | embed: ready to serve client requests
13:01:03 2021-11-22 09:58:22.791021 I | embed: ready to serve client requests
13:01:03 2021-11-22 09:58:22.792918 I | embed: serving client requests on 192.168.181.18:2379
13:01:03 2021-11-22 09:58:22.793008 I | etcdserver: published {Name:qaminiha-3 ClientURLs:[https://192.168.181.18:2379]} to cluster 580bc6bee32a2db0
13:01:03 2021-11-22 09:58:22.793280 I | embed: serving client requests on 127.0.0.1:2379
13:01:03 2021-11-22 09:58:22.820806 I | etcdserver: 73be5fbb48e5cf05 initialized peer connection; fast-forwarding 8 ticks (election ticks 10) with 2 active peer(s)
13:04:10 CRITICAL FAILURE!
13:04:10 CRITICAL TASK FAILED import.etcd
13:04:10 CRITICAL Unexpected exception
13:04:10 Traceback (most recent call last):
13:04:10   File "/opt/kubetools/kubetool/core/flow.py", line 192, in run_flow
13:04:10     task(cluster)
13:04:10   File "/opt/kubetools/kubetool/procedures/restore.py", line 215, in import_etcd
13:04:10     etcd.wait_for_health(cluster, cluster.nodes['master'])
13:04:10   File "/opt/kubetools/kubetool/etcd.py", line 53, in wait_for_health
13:04:10     etcd_health_raw = connection.sudo('etcdctl endpoint health --cluster -w json'
13:04:10   File "/opt/kubetools/kubetool/core/group.py", line 56, in get_simple_out
13:04:10     raise NotImplementedError("Simple output can be returned only for NodeGroupResult consisted of "
13:04:10 NotImplementedError: Simple output can be returned only for NodeGroupResult consisted of exactly one node, but [<Connection host=10.102.2.210 user=ubuntu>, <Connection host=10.102.2.118 user=ubuntu>, <Connection host=10.102.2.132 user=ubuntu>] were provided.
13:04:10 
```

Fixes MANOPD-70594


### Solution
* Changed group to connection in method parameters


### How to apply
Nothing to apply


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: Full-HA cluster
- OS: Any
- Inventory: Default

Steps:

1. Run restore procedure

Results:

| Before | After |
| ------ | ------ |
| Procedure failed | Procedure finished |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
No new unit tests


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
