### PR TITLE
Change kubernetes ttl and PodAntiAffinity for coredns

### DIFF
--- a/kubetool/resources/configurations/defaults.yaml
+++ b/kubetool/resources/configurations/defaults.yaml
@@ -162,8 +162,16 @@ services:
               node-role.kubernetes.io/worker: worker
             affinity:
               podAntiAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                  - topologyKey: "kubernetes.io/hostname"
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                      - key: k8s-app
+                        operator: In
+                        values:
+                        - kube-dns
+                    topologyKey: kubernetes.io/hostname
+                  weight: 100
     configmap:
       Corefile:
         '.:53':
@@ -193,7 +201,7 @@ services:
                 fallthrough:
                   - in-addr.arpa
                   - ip6.arpa
-                ttl: 30
+                ttl: 5
           template:
             default:
               priority: 1


### PR DESCRIPTION
### Description
This PR is created for fixing 2 issues:
1) In some cases (for example, for headless services) 30 seconds are too much for kubernetes's resource records in CoreDNS cache. Default value is 5 seconds (https://coredns.io/plugins/kubernetes/).
2) CoreDNS is an important service for kubernetes clusters so it makes sense to place its pods to different nodes. Now some coredns pods could be placed to the same node.

Fixes # (issue)
PSUPCLFRM-2228

### Solution
Default parameters are changed in ./kubetool/resources/configurations/defaults.yaml -> services -> coredns:
1) changed ttl from 30 to 5 in the configmap 
2) changed podAntiAffinity in the deployment 

### How to apply
redeploy kubernetes 

### Test Cases
1. Deploy cluster with more than 1 nodes. Check that coredns pods are placed to different nodes if possible.
2. Resolve any service name and check TTL for the answer - it shouldn't be more than 5.
### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
