### PR TITLE
[MANOPD-70825]Paas check Centos failed

### DIFF
--- a/kubetool/procedures/check_paas.py
+++ b/kubetool/procedures/check_paas.py
@@ -115,10 +115,16 @@ def recommended_system_packages_versions(cluster):
                 "containerd": compatibility["containerd"][k8s_version][version_key]
             }
         elif "containerd" in cluster.inventory["services"]["cri"]["containerRuntime"]:
-            expected_system_packages["containerd"] = {
-                "containerd": compatibility["containerd"][k8s_version][version_key],
-                "podman": compatibility["podman"][k8s_version][version_key]
-            }
+            if version_key == "version_rhel":
+                expected_system_packages["containerd"] = {
+                    "containerdio": compatibility["containerdio"][k8s_version][version_key],
+                    "podman": compatibility["podman"][k8s_version][version_key]
+                }
+            else:
+                expected_system_packages["containerd"] = {
+                    "containerd": compatibility["containerd"][k8s_version][version_key],
+                    "podman": compatibility["podman"][k8s_version][version_key]
+                }
 
         good_results = set()
         bad_results = []


### PR DESCRIPTION
### Description
*Incorrect completion of the test due to failure of one of the tests to check the version of the operating system*

### Solution
*Adding a new check to exclude incorrect completion of the test*


### Checklist
- [ ] Test build case 
- [ ] Test in QA
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
