### PR TITLE
[MANOPD-70825]Paas check Centos failed

### DIFF
--- a/kubetool/procedures/check_paas.py
+++ b/kubetool/procedures/check_paas.py
@@ -458,8 +458,6 @@ def kubernetes_pods_condition(cluster):
             split_description = pod_description.split(' ')
             if split_description[0] in system_namespaces and split_description[2] in critical_states:
                 critical_system_failed_amount += 1
-            else:
-                raise TestFailure("Pods status off %s" % (pod_description))
 
         if critical_system_failed_amount > 0:
             s = ''


### PR DESCRIPTION
### Description
*Incorrect completion of the test due to failure of one of the tests to check the version of the operating system*

### Solution
*Adding a new check to exclude incorrect completion of the test*


### Checklist
- [x] Test build case 
- [ ] Test in QA
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
