### PR TITLE
[MANOPD-70825]Paas check Centos failed

### DIFF
--- a/kubetool/procedures/check_paas.py
+++ b/kubetool/procedures/check_paas.py
@@ -110,20 +110,23 @@ def recommended_system_packages_versions(cluster):
             "keepalived": {"keepalived": compatibility["keepalived"][k8s_version][version_key]}
         }
         containerd_name = "containerd"
+        containerd_name_last = "containerd"
         if "docker" in cluster.inventory['services']['cri']['containerRuntime']:
             if version_key == "version_rhel":
                 containerd_name = "containerd.io"
+                containerd_name_last = "containerdio"
 
             expected_system_packages["docker"] = {
-                containerd_name: compatibility[containerd_name][k8s_version][version_key],
-                "docker": compatibility["docker"][k8s_version][version_key]
-            }
+                "docker": compatibility["docker"][k8s_version][version_key],
+                containerd_name: compatibility[containerd_name_last][k8s_version][version_key]
+                }
         elif "containerd" in cluster.inventory["services"]["cri"]["containerRuntime"]:
             if version_key == "version_rhel":
                 containerd_name = "containerd.io"
+                containerd_name_last = "containerdio"
 
             expected_system_packages["containerd"] = {
-                containerd_name: compatibility[containerd_name][k8s_version][version_key],
+                containerd_name: compatibility[containerd_name_last][k8s_version][version_key],
                 "podman": compatibility["podman"][k8s_version][version_key]
             }
 


### PR DESCRIPTION
### Description
*Incorrect completion of the test due to failure of one of the tests to check the version of the operating system*

### Solution
*Adding a new check to exclude incorrect completion of the test*


### Checklist
- [x] Test build case 
- [x] Test in QA
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
