### PR TITLE
[MANOPD-71614]Changing the location path of the busybox image

### DIFF
--- a/kubetool/resources/configurations/defaults.yaml
+++ b/kubetool/resources/configurations/defaults.yaml
@@ -545,7 +545,7 @@ plugins:
       is-default: "false"
     volume-dir: /opt/local-path-provisioner
     image: rancher/local-path-provisioner:v0.0.20
-    helper-pod-image: busybox:1.34.1
+    helper-pod-image: library/busybox:1.34.1
 
 rbac:
   account_defaults:


### PR DESCRIPTION
### Description
*Incorrect work of kubetool when using images with artifactors*

### Fixes # (issue)
*Fixed the location path of the busybox image*

### How the code changes were tested (Test plan):

1) Change the code in kubetool
2) Install new cluster
3) Test by colleagues from QA

### Checklist
- [ ] Test build case 
- [ ] Test in QA
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflictss


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
