### PR TITLE
[MANOPD-71187] Fix containerd version detection error

### DIFF
--- a/kubetool/core/cluster.py
+++ b/kubetool/core/cluster.py
@@ -292,7 +292,9 @@ class KubernetesCluster(Environment):
                 detected_package_versions = list(detected_packages[package].keys())
                 for version in detected_package_versions:
                     # add package version to list only if it was found as installed
-                    if "not installed" not in version:
+                    # skip version, which ended with special symbol = or -
+                    # (it is possible in some cases to receive "containerd=" version)
+                    if "not installed" not in version and version[-1] != '=' and version[-1] != '-':
                         final_packages_list.append(version)
 
                 # if there no versions detected, then set package version to default
@@ -315,7 +317,9 @@ class KubernetesCluster(Environment):
                 package_versions_list = []
                 detected_package_versions = list(detected_packages[package].keys())
                 for version in detected_package_versions:
-                    if "not installed" not in version:
+                    # skip version, which ended with special symbol = or -
+                    # (it is possible in some cases)
+                    if "not installed" not in version and version[-1] != '=' and version[-1] != '-':
                         # add package version to list only if it was found as installed
                         package_versions_list.append(version)
                 # if there no versions detected, then set package version to default


### PR DESCRIPTION
### Description
Please include a summary of the change and describe issue. Please also include relevant motivation and context.
* On adding new node to cluster the following exception occurs:
```
2021-12-03 15:26:53.924 +0400 INFO *** TASK prepare.cri.install ***
2021-12-03 15:26:53.925 +0400 DEBUG Running kubetool.cri.install: 
2021-12-03 15:26:53.925 +0400 DEBUG Installing latest containerd and podman on qa-fullha-worker3 node
2021-12-03 15:26:56.878 +0400 CRITICAL FAILURE!
2021-12-03 15:26:56.878 +0400 CRITICAL TASK FAILED prepare.cri.install
2021-12-03 15:26:56.879 +0400 CRITICAL Remote group exception
2021-12-03 15:26:56.879 +0400 CRITICAL 10.102.2.125:
2021-12-03 15:26:56.880 +0400 CRITICAL Encountered a bad command exit code!
2021-12-03 15:26:56.880 +0400 CRITICAL 
2021-12-03 15:26:56.880 +0400 CRITICAL Command: 'sudo -S -p \'[sudo] password: \' DEBIAN_FRONTEND=noninteractive apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y containerd= podman=100:3.1.2-1 && echo "=_=-=_=-_=_==-==_-___-==-=-=___=" && echo $? && echo "=_=-=_=-_=_==-==_-___-==-=-=___=" && echo "=_=-=_=-_=_==-==_-___-==-=-=___=" 1>&2 && sudo rm -f /etc/containerd/config.toml && sudo systemctl restart containerd && echo "=_=-=_=-_=_==-==_-___-==-=-=___=" && echo $? && echo "=_=-=_=-_=_==-==_-___-==-=-=___=" && echo "=_=-=_=-_=_==-==_-___-==-=-=___=" 1>&2 && sudo systemctl enable containerd --now'
2021-12-03 15:26:56.884 +0400 CRITICAL 
2021-12-03 15:26:56.884 +0400 CRITICAL Exit code: 100
2021-12-03 15:26:56.884 +0400 CRITICAL 
2021-12-03 15:26:56.884 +0400 CRITICAL Stdout:
2021-12-03 15:26:56.884 +0400 CRITICAL 
2021-12-03 15:26:56.884 +0400 CRITICAL Ign:5 https://artifactorycn.netcracker.com/nc.thirdparty.deb.repub focal InRelease
2021-12-03 15:26:56.885 +0400 CRITICAL Hit:6 https://artifactorycn.netcracker.com/nc.thirdparty.deb.repub focal Release
2021-12-03 15:26:56.885 +0400 CRITICAL Ign:7 https://artifactorycn.netcracker.com/nc.thirdparty.deb.repub focal Release.gpg
2021-12-03 15:26:56.886 +0400 CRITICAL Reading package lists...
2021-12-03 15:26:56.886 +0400 CRITICAL Building dependency tree...
2021-12-03 15:26:56.887 +0400 CRITICAL Reading state information...
2021-12-03 15:26:56.887 +0400 CRITICAL 135 packages can be upgraded. Run 'apt list --upgradable' to see them.
2021-12-03 15:26:56.888 +0400 CRITICAL Reading package lists...
2021-12-03 15:26:56.888 +0400 CRITICAL Building dependency tree...
2021-12-03 15:26:56.888 +0400 CRITICAL Reading state information...
2021-12-03 15:26:56.888 +0400 CRITICAL 
2021-12-03 15:26:56.889 +0400 CRITICAL Stderr:
2021-12-03 15:26:56.889 +0400 CRITICAL 
2021-12-03 15:26:56.889 +0400 CRITICAL 
2021-12-03 15:26:56.889 +0400 CRITICAL WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
2021-12-03 15:26:56.890 +0400 CRITICAL 
2021-12-03 15:26:56.890 +0400 CRITICAL 
2021-12-03 15:26:56.890 +0400 CRITICAL WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
2021-12-03 15:26:56.892 +0400 CRITICAL 
2021-12-03 15:26:56.893 +0400 CRITICAL E: Version '' for 'containerd' was not found
2021-12-03 15:26:56.893 +0400 CRITICAL 
2021-12-03 15:26:56.893 +0400 CRITICAL 
2021-12-03 15:26:56.893 +0400 
2021-12-03 15:26:56.893 +0400 An unexpected error occurred. It is failed to solve the problem automatically. Follow the instructions from the Troubleshooting Guide available to you. If it is impossible to solve the problem, provide the dump and the technical information above to the support team.
2021-12-03 15:26:56.895 +0400 You can restart the script from the last task with the following command: /opt/kubetools/kubetools.py --tasks="prepare.cri.install"
2021-12-03 15:26:57.117 +0400 Build step 'Execute shell' marked build as failure
2021-12-03 15:26:57.168 +0400 [PostBuildScript] - Executing post build scripts.
2021-12-03 15:26:57.178 +0400 [maintenance] $ /bin/sh -xe /tmp/jenkins415108212147592815.sh
2021-12-03 15:26:57.181 +0400 + echo 'Stoping container'
2021-12-03 15:26:57.181 +0400 Stoping container
2021-12-03 15:26:57.182 +0400 + docker stop kubetools_1869136878
2021-12-03 15:26:57.233 +0400 kubetools_1869136878
2021-12-03 15:26:57.240 +0400 + echo 'Copying data from container'
2021-12-03 15:26:57.241 +0400 Copying data from container
2021-12-03 15:26:57.241 +0400 + docker cp kubetools_1869136878:/opt/kubetools/dump /opt/jenkins/msk2/workspace/CLPL.kubernetes/maintenance/dump
2021-12-03 15:26:57.363 +0400 + docker cp kubetools_1869136878:/opt/kubetools/ansible-inventory.ini /opt/jenkins/msk2/workspace/CLPL.kubernetes/maintenance/ansible-inventory.ini
2021-12-03 15:26:57.519 +0400 + docker cp kubetools_1869136878:/opt/kubetools/backup.tar.gz /opt/jenkins/msk2/workspace/CLPL.kubernetes/maintenance/backup.tar.gz
2021-12-03 15:26:57.643 +0400 Error: No such container:path: kubetools_1869136878:/opt/kubetools/backup.tar.gz
2021-12-03 15:26:57.648 +0400 + true
2021-12-03 15:26:57.648 +0400 + echo 'Removing container'
2021-12-03 15:26:57.648 +0400 Removing container
2021-12-03 15:26:57.648 +0400 + docker rm kubetools_1869136878
2021-12-03 15:26:58.672 +0400 kubetools_1869136878
2021-12-03 15:26:58.676 +0400 + '[' -f /opt/kubetools/backup.tar.gz ']'
2021-12-03 15:26:58.707 +0400 Archiving artifacts
2021-12-03 15:26:58.839 +0400 [BFA] Scanning build for known causes...
2021-12-03 15:26:59.950 +0400 [BFA] No failure causes found
2021-12-03 15:26:59.950 +0400 [BFA] Done. 1s
2021-12-03 15:26:59.977 +0400 Notifying upstream projects of job completion
2021-12-03 15:27:00.004 +0400 Finished: FAILURE
```

Fixes MANOPD-71187


### Solution
Describe solution. List all changes that you made during implementation.
* On nodes where already installed `containerd.io` there available `containerd` CLI. When polling remote system for `containerd` package it responses with `containerd=` result, which means package installed, but version can not be detected because this artifact is a part of another package. For this packages added special logic, which ignores this results and sets package version to default.


### How to apply
Provide steps how to apply on top previous Kubetools version to execute on existing clusters
* Rerun failed tasks


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: `containerd.io` installed on old nodes and `containerd` specified as CRI package for new nodes

Steps:

1. Perform `add_node` procedure with specific inventory

Results:

| Before | After |
| ------ | ------ |
| Installation failed | Installation finished without errors |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
No unit tests modified or added


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
