### PR TITLE
[PSUPCLPL-8829] Increase node reboot timeout up to 600s

### DIFF
--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -70,7 +70,7 @@ nodes:
   boot:
     reboot_command: 'reboot 2>/dev/null >/dev/null &'
     defaults:
-      timeout: 180
+      timeout: 600
       delay_period: 5
   drain:
     timeout: 10


### PR DESCRIPTION
### Description
Default timeout for node reboot was 180s and it cannot be overwritten during deployment. 
Sometimes 180s may be not enough (especially for bare metal servers) to finish reboot. 

Fixes # (issue)
Precedent ticket: PSUPCLPL-8829

### Solution
In `kubemarine/resources/configurations/globals.yaml` `nodes:boot:defaults:timeout` is changed from 180 to 600 (seconds).

### How to apply
Use fresh version of KubeMarine to deploy/maintain cluster.

### Test Cases
Run any job requiring node reboot (for example, add_node).
Check debug.log for lines like
```
2022-01-17 06:52:33,774 8 139723163273024 test1-kubernetes.openshift.sdntest.netcracker.com VERBOSE [group._await_rebooted_nodes] Nodes ['10.101.95.77', '10.101.95.75', '10.101.95.72', '10.101.95.69', '10.101.95.96'] are not ready yet, remaining time to wait 168
```
First "time to wait" should be something a little less than 600.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests

### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
