### PR TITLE
[MANOPD-45474]Installation when no workers in cluster scheme

### DIFF
--- a/kubemarine/kubernetes.py
+++ b/kubemarine/kubernetes.py
@@ -160,6 +160,9 @@ def enrich_inventory(inventory, cluster):
             if "labels" not in node:
                 node["labels"] = {}
             node["labels"]["node-role.kubernetes.io/worker"] = "worker"
+        else:
+            raise Exception("There are no workers in the cluster")
+
 
             if "master" in node["roles"]:
                 # node is both master and worker, thus we remove NoSchedule taint


### PR DESCRIPTION
### Description
*Problem setting up cluster without workers*

### Solution
*Fix in all kubetools code with `cluster.nodes['worker']` on `cluster.nodes.get ['worker']`*
*Add exception when installing without workers*


### Checklist
- [ ] Test in QA
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflictss


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
