### PR TITLE
[PSUPCLPL-8895] Fix backup.py - add random resource separator; fix Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN apt update && apt install -y wget && \
     rm -f /etc/apt/sources.list && \
     rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT ["python3", "-m" "kubemarine"]
+ENTRYPOINT ["python3", "-m", "kubemarine"]

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -18,6 +18,7 @@ import datetime
 import io
 import json
 import os
+import random
 import shutil
 import tarfile
 import time
@@ -263,9 +264,11 @@ def download_resources(log, resources, location, master: NodeGroup, namespace=No
         return actual_resources
 
     cmd = ''
+    resource_separator = ''.join(random.choice('=-_') for _ in range(32))
+
     for resource in resources:
         if cmd != '':
-            cmd += ' && echo \'\n------------------------\n\' && '
+            cmd += ' && echo \'\n' + resource_separator + '\n\' && '
         if namespace:
             cmd += 'sudo kubectl -n %s get --ignore-not-found %s -o yaml' % (namespace, resource)
         else:
@@ -274,7 +277,7 @@ def download_resources(log, resources, location, master: NodeGroup, namespace=No
     result = master.sudo(cmd).get_simple_out()
     master.cluster.log.verbose(result)
 
-    found_resources_results = result.split('------------------------')
+    found_resources_results = result.split(resource_separator)
     for i, result in enumerate(found_resources_results):
         resource = resources[i]
         resource_file_path = os.path.join(location, '%s.yaml' % resource)


### PR DESCRIPTION
### Description
1. Backup procedure fails if any of resources being backed up contains the hardcoded resource separator (24 hyphens).
2. Docker containerd built from the Docker file fails with error due to typo in the entrypoint line.

Fixes # (issue)
PSUPCLPL-8895

### Solution
1. Add randomly created line as a resource separator to kubemarine/procedures/backup.py.
2. Add missed comma to the entrypoint line in the Dockerfile.

### How to apply
1. Run backup procedure against the existing cluster with the new version of KubeMarine.
2. Rebuild docker image with updated Dockerfile.

### Test Cases
1. Run backup job 
2. Build docker image for Kubemarine and try to run it with "selftest" parameter.

### Checklist
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [X] There is no merge conflicts


#### Unit tests

### Reviewers
@koryaga @iLeonidze 
