### PR TITLE
Fix possible zero group_size in images_grouped_prepull() function

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -1069,7 +1069,8 @@ def images_grouped_prepull(group: NodeGroup, group_size: int = None):
 
     nodes = group.get_ordered_members_list()
 
-    if len(nodes) < group_size:
+    # group_size should be greater than 0
+    if len(nodes) != 0 and len(nodes) < group_size:
         group_size = len(nodes)
 
     groups_amount = math.ceil(len(nodes) / group_size)


### PR DESCRIPTION
### Description
If upgrade job runs against a cluster which has already upgraded kubernetes, the following error appears:
```
2022-02-09 09:19:02.992 +0300 DEBUG Prepulling Kubernetes images...
2022-02-09 09:19:03.962 +0300 DEBUG Running kubemarine.kubernetes.images_grouped_prepull: 
2022-02-09 09:19:03.963 +0300 CRITICAL FAILURE!
2022-02-09 09:19:03.963 +0300 CRITICAL TASK FAILED prepull_images
2022-02-09 09:19:03.964 +0300 CRITICAL Unexpected exception
2022-02-09 09:19:03.964 +0300 Traceback (most recent call last):
2022-02-09 09:19:03.965 +0300   File "/opt/kubemarine/kubemarine/core/flow.py", line 206, in run_flow
2022-02-09 09:19:03.965 +0300     task(cluster)
2022-02-09 09:19:03.965 +0300   File "/opt/kubemarine/kubemarine/procedures/upgrade.py", line 41, in prepull_images
2022-02-09 09:19:03.966 +0300     upgrade_group.call(kubernetes.images_grouped_prepull)
2022-02-09 09:19:03.966 +0300   File "/opt/kubemarine/kubemarine/core/group.py", line 548, in call
2022-02-09 09:19:03.966 +0300     return self.call_batch([action], **{"%s.%s" % (action.__module__, action.__name__): kwargs})
2022-02-09 09:19:03.967 +0300   File "/opt/kubemarine/kubemarine/core/group.py", line 562, in call_batch
2022-02-09 09:19:03.967 +0300     results[action] = action(self, **action_kwargs)
2022-02-09 09:19:03.967 +0300   File "/opt/kubemarine/kubemarine/kubernetes.py", line 1067, in images_grouped_prepull
2022-02-09 09:19:03.968 +0300     groups_amount = math.ceil(len(nodes) / group_size)
2022-02-09 09:19:03.968 +0300 ZeroDivisionError: division by zero
```
This may happen if the first run of the upgrade job failed somewhere after kubernetes upgrade (e.g. at `deploy.plugin` task) and then the upgrade job restarted with the same parameters.

Fixes # (issue)
PSUPCLPL-8993

### Solution
Add a check of the non-zero length of the nodes array during `group_size` defining in the `images_grouped_prepull()` function.

### How to apply
Run upgrade job with the fixed version of KubeMarine

### Test Cases
Run upgrade job at a cluster with procedure.yaml like:
```
upgrade_plan:
  - <THE_SAME_VERSION_OF_K8S_AS_IT_IS_AT_THE_CLUSTER>
```
To test this fix `kubernetesVersion` parameter in cluster.yaml should be set to an older version than the one in procedure.yaml.

Expected result: upgrade job should run smoothly through k8s upgrade, for all the nodes debug message "DEBUG First master <NODENAME> upgrade is not required" should appear in the log.


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests

### Reviewers
@koryaga @iLeonidze 