### PR TITLE
[PSUPCLPL-9073]Update TG - add Long Recovery after a Node Goes Offline paragraph

### DIFF
--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -14,7 +14,7 @@ This section provides troubleshooting information for Kubemarine and Kubernetes 
   - [Packets between nodes in different networks are lost](#packets-between-nodes-in-different-networks-are-lost)
   - [`kubectl apply` fails with error "metadata annotations: Too long"](#kubectl-apply-fails-with-error-metadata-annotations-too-long)
   - [`kube-apiserver` requests throttling](#kube-apiserver-requests-throttling)
-  - [Long Recovery after a Node Goes Offline](#long-recovery-after-a-node-goes-offline)
+  - [Long Recovery after a Node goes Offline](#long-recovery-after-a-node-goes-offline)
 - [Troubleshooting Kubemarine](#troubleshooting-kubemarine)
   - [Failures During Kubernetes Upgrade Procedure](#failures-during-kubernetes-upgrade-procedure)
   - [Numerous generation of auditd system messages ](#numerous-generation-of-auditd-system)
@@ -356,21 +356,21 @@ data:
 
 ```
 
-## Long Recovery after a Node Goes Offline
+## Long Recovery after a Node goes Offline
 
-**Symptoms**: When for any reason a cluster node goes offline pods from this node will be redeployed in almost 6 minutes. For some installations it might be too long and this time needs be reduced.
+**Symptoms**: If for any reason, a cluster node goes offline, the pods from that node are redeployed in almost 6 minutes. For some installations, it might be too long and this time needs to be reduced.
 
-**Root Cause**: When a node goes offline kubernetes needs time to discover that the node is unavalable (up to 10 seconds), then waits for the node returns or a timeout expires (40 seconds), then marks pods at this node as to be deleted and wait for the situation recovers or a timeout expires (5 minutes). After that the pods are being redeployed to healthy nodes.
+**Root Cause**: When a node goes offline, Kubernetes takes time to discover that the node is unavailable (up to 10 seconds). It then waits till the node returns or the timeout expires (40 seconds), then marks the pods at this node to be deleted, and waits for the situation to recover or for the timeout to expire (5 minutes). After that, the pods are redeployed to healthy nodes.
 
-**Solution**: Reduce timeouts related to a node status discovery and pods eviction.
+**Solution**: Reduce the timeouts related to the node status discovery and pods eviction.
 
-It can be done by the following variables tuning:
-- `nodeStatusUpdateFrequency` - a kubelet's variable, meaning the frequency that kubelet computes node status and posts it to master. Default value is 10s. It should be twice more than `node-monitor-period`.
-- `node-monitor-period` - a kube-controller-manager's variable meaning the period for syncing NodeStatus in NodeController. Default value is 5s. It should be twice less than `nodeStatusUpdateFrequency`.
-- `node-monitor-grace-period` - a kube-controller-manager's variable meaning the amount of time which a running Node is allowed to be unresponsive before marking it unhealthy. Default value is 40s. Must be (N-1) times more than kubelet's `nodeStatusUpdateFrequency`, where N means number of retries allowed for kubelet to post node status. Currently N is hardcoded to 5. 
-- `pod-eviction-timeout` - a kube-controller-manager's variable meaning the grace period for deleting pods on failed nodes. Default value is 5min.
+It can be done by tuning the following variables:
+- `nodeStatusUpdateFrequency` - A kubelet's variable that specifies the frequency kubelet computes the node status and posts it to master. The default value is 10s. It should be twice the value of `node-monitor-period`.
+- `node-monitor-period` - A kube-controller-manager's variable that specifies the period for syncing NodeStatus in NodeController. The default value is 5s. It should be half the value of `nodeStatusUpdateFrequency`.
+- `node-monitor-grace-period` - A kube-controller-manager's variable that specifies the amount of time that a running node is allowed to be unresponsive before marking it unhealthy. The default value is 40s. It must be (N-1) times more than kubelet's `nodeStatusUpdateFrequency`, where N is the number of retries allowed for kubelet to post the node status. Currently N is hardcoded to 5. 
+- `pod-eviction-timeout` - A kube-controller-manager's variable that specifies the grace period for deleting pods on failed nodes. The default value is 5 min.
 
-These variables can be redefined in cluster.yaml during cluster deploy or upgrade. For example:
+These variables can be redefined in cluster.yaml during the cluster deployment or upgrade. For example:
 
 ```
 services:
@@ -384,9 +384,9 @@ services:
         pod-eviction-timeout: "30s"
 ```
 
-The exact numbers should be chosen according to the environment state. If network or hosts may be unstable, these values should cover short nodes unavailability without pods redeployment, otherwise often redeployment may cause significant load increase and the cluster instability.
+The exact numbers should be chosen according to the environment state. If the network or hosts are unstable, these values should cover short nodes unavailability without redeployment of the pods. Often redeployment may cause significant load increase and cluster instability.
 
-At working clusters these variables can be adjusted manually by updating `/var/lib/kubelet/config.yaml` (for kubelet, at all the nodes) and `/etc/kubernetes/manifests/kube-controller-manager.yaml` (for controller-manager, at the masters).
+At working clusters, these variables can be adjusted manually by updating `/var/lib/kubelet/config.yaml` (for kubelet, at all the nodes) and `/etc/kubernetes/manifests/kube-controller-manager.yaml` (for controller-manager, at the masters).
 
 
 ## `kube-controller-manager` unable to sync caches for garbage collector


### PR DESCRIPTION
### Description
TG update. Added paragraph how to tune kubernetes if default time of pod redeployment in case of a node failure is unacceptably long.

Fixes # (issue)
PSUPCLPL-9073

### Solution
Doc update describes which kubernetes variables may be tuned to reduce time of pods redeployment and how it may be configured via cluster.yaml.

### How to apply
None

### Test Cases
None

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [X] There is no merge conflicts


#### Unit tests
None

### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
