### PR TITLE
MANOPD-74982 Paas check failed 

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -826,7 +826,7 @@ def check_extra_volumes(cluster, static_pod):
         for volumeMount in volume_mounts:
             if volumeMount['mountPath'] == original_volume['mountPath'] and \
                     volumeMount['name'] == original_volume['name'] and \
-                    volumeMount.get('readOnly', False ) == original_volume.get('readOnly', ''):
+                    volumeMount.get('readOnly', False ) == original_volume.get('readOnly', False):
                 correct_volume = True
                 break
         if not correct_volume:


### PR DESCRIPTION
### Description
paas_check fails on control-plane configuration status

RC: 
1. paas_check procedure validates Volume parameters in kubeapi pod
2. Default value for Volume readOnly parameter is false.
3. False param is not specified in running pod. get pod kubeapi ` {
                        "mountPath": "/var/log/kubernetes/",
                        "name": "audit-log"
                    },
`
4. KubeMarine defaults explicitly sets False https://github.com/Netcracker/KubeMarine/blob/14f9c988a6c8593c7a00c5dac5fffe3c2a0fcd55/kubemarine/resources/configurations/defaults.yaml#L44
5. paas_check fails comparing False and None, because of value comparasion issue (boolean vs string) 

Fixes # MANOPD-74982


### Solution
* despite the fact that default readOnly value for Volumes is False and no need to set in default.yaml , anyway  it is worth to support such case for future and set default kubeapi param to False if not speciafied in kubeapi pod 


### How to apply
None

### Test Cases


**TestCase 1**


Steps:

1. run Run paas_check

Results:

| Before | After |
| ------ | ------ |
|  220 configuration status failed|  220 configuration status ok|


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
