### PR TITLE
Fix yaml load

### DIFF
--- a/kubemarine/admission.py
+++ b/kubemarine/admission.py
@@ -370,7 +370,7 @@ def restart_pods_task(cluster, disable_eviction=False):
         first_master.sudo("kubectl uncordon %s" % node["name"], hide=False)
 
     cluster.log.debug("Restarting daemon-sets...")
-    daemon_sets = yaml.safe_load(list(first_master.sudo("kubectl get ds -A -o yaml").values())[0].stdout)
+    daemon_sets = ruamel.yaml.YAML().load(list(first_master.sudo("kubectl get ds -A -o yaml").values())[0].stdout)
     for ds in daemon_sets["items"]:
         first_master.sudo("kubectl rollout restart ds %s -n %s" % (ds["metadata"]["name"], ds["metadata"]["namespace"]))
 


### PR DESCRIPTION
### Description
manage_psp procedure fails
```
2022-04-05 14:18:20.576 +0300 CRITICAL FAILURE!
2022-04-05 14:18:20.585 +0300 CRITICAL TASK FAILED restart_pods
2022-04-05 14:18:20.586 +0300 CRITICAL KME0001: Unexpected exception
2022-04-05 14:18:20.586 +0300 Traceback (most recent call last):
2022-04-05 14:18:20.586 +0300   File "/opt/kubemarine/kubemarine/core/flow.py", line 207, in run_flow
2022-04-05 14:18:20.587 +0300     task(cluster)
2022-04-05 14:18:20.587 +0300   File "/opt/kubemarine/kubemarine/admission.py", line 373, in restart_pods_task
2022-04-05 14:18:20.588 +0300     daemon_sets = yaml.load(list(first_master.sudo("kubectl get ds -A -o yaml").values())[0].stdout)
2022-04-05 14:18:20.589 +0300 TypeError: load() missing 1 required positional argument: 'Loader'
```
RC:  yaml load() function is unsafe and fails in latest PyYAML  6.0


Fixes # MANOPD-75149

### Solution
use safe_load() as recommended


### How to apply
None


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 

Steps:

1. 

Results:

| Before | After |
| ------ | ------ |
|  |  |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
