### PR TITLE
[PSUPCLPL-9491] Masked templates in plugins breakage

### DIFF
--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -921,8 +921,8 @@ def _apply_file(cluster, config, file_type) -> None or NodeGroupResult:
     files = glob.glob(source)
 
     if len(files) == 0:
-        raise Exception('Cannot find any %s files matching this '
-                        'source value: %s' % (source, file_type))
+        raise ValueError('Cannot find any %s files matching this '
+                         'source value: %s' % (source, file_type))
 
     for file in files:
         source_filename = os.path.basename(file)
@@ -966,7 +966,7 @@ def _apply_file(cluster, config, file_type) -> None or NodeGroupResult:
             if use_sudo:
                 method = apply_common_group.sudo
             cluster.log.debug("Applying yaml...")
-            return method(apply_command, hide=False)
+            method(apply_command, hide=False)
         else:
             cluster.log.debug('Apply is not required')
 

--- a/test/unit/plugins/test_template.py
+++ b/test/unit/plugins/test_template.py
@@ -70,17 +70,19 @@ class TestTemplate(unittest.TestCase):
         test_cases = [
             {
                 "name": "One yaml template",
-                "create_files": ["./test_templates/test_template.yaml"],
+                "apply_files": ["test_template1.yaml"],
                 "source": "../test/unit/plugins/test_templates/test_template1.yaml",
                 "valid": True,
             },
             {
                 "name": "Wildcard path matching three yaml templates",
+                "apply_files": ["test_template1.yaml", "test_template2.yaml", "test_template3.yaml"],
                 "source": "../test/unit/plugins/test_templates/*.yaml",
                 "valid": True,
             },
             {
-                "name": "Directory wildcard path matching two yaml templates",
+                "name": "Directory wildcard path matching three yaml templates",
+                "apply_files": ["test_template1.yaml", "test_template2.yaml", "test_template3.yaml"],
                 "source": "../test/unit/plugins/test_templates/*",
                 "valid": True,
             },
@@ -105,16 +107,24 @@ class TestTemplate(unittest.TestCase):
                 # Create new test config with the source value
                 config = {
                     "source": tc["source"],
-                    'apply_required': False,
                 }
 
                 if tc["valid"]:
+                    for file in tc["apply_files"]:
+                        result = demo.create_nodegroup_result(cluster.nodes["master"])
+                        cluster.fake_shell.add(result, "sudo", [f"kubectl apply -f /etc/kubernetes/{file}"], usage_limit=1)
+
                     # If test case is valid just run the function
                     apply_template(cluster, config)
+
+                    for file in tc["apply_files"]:
+                        history = cluster.fake_shell.history_find("sudo", [f"kubectl apply -f /etc/kubernetes/{file}"])
+                        self.assertEqual(1, len(history))
+                        self.assertEqual(1, history[0]["used_times"])
                 else:
                     # If test case is not valid check for exception raise
                     self.assertRaises(
-                        Exception,
+                        ValueError,
                         apply_template,
                         cluster, config
                     )


### PR DESCRIPTION
### Description
Masked templates (*) in plugins installation procedure process only the first found file.

### Solution
Breakage after #74. Installation procedure returns after first processed file. Revert the change.

### How to apply
Reproduced for new installed plugins.


### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: any plugin with `template` installation procedure type, whose `source` is masked (*) and identifies two or more files.
Steps:

1. Run `install`.

Results:

| Before | After |
| ------ | ------ |
| Only one file identified by `source` is applied | All files identified by `source` are applied |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Changed TestTemplate.test_apply_template. Now it counts all applied files and verifies them.


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
