### PR TITLE
[MANOPD-75427] Bulky labels setting

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -779,13 +779,16 @@ pss:
     runtimeClasses: ["example-class-1", "example-class-2"]
     namespaces: ["kube-system", "example-namespace-1", "example-namespace-2"]
   namespaces:
-    example-namespace-2:
-      enforce: privileged/baseline/restricted
-      enforce-version: latest
-      audit: privileged/baseline/restricted
-      audit-version: latest
-      warn: privileged/baseline/restricted
-      warn-version: latest
+    - example-namespace-1
+    - example-namespace-2:
+        enforce: privileged/baseline/restricted
+        enforce-version: latest
+        audit: privileged/baseline/restricted
+        audit-version: latest
+        warn: privileged/baseline/restricted
+        warn-version: latest
+    - example-namespace-3
+    - example-namespace-4
   namespaces_defaults:
     enforce: privileged/baseline/restricted
     enforce-version: latest

--- a/kubemarine/admission.py
+++ b/kubemarine/admission.py
@@ -632,12 +632,15 @@ def manage_pss_enrichment(inventory, cluster):
                 inventory["rbac"]["pss"]["exemptions"][item] = procedure_config["exemptions"][item]
     if "namespaces" in procedure_config:
         for namespace in procedure_config["namespaces"]:
-            if procedure_config["namespaces"][namespace]:
-                for item in procedure_config["namespaces"][namespace]:
-                    if item.endswith("version"):
-                        verify_version(item, procedure_config["namespaces"][namespace][item], minor_version)
-                    else:
-                        verify_parameter(item, procedure_config["namespaces"][namespace][item], valid_profiles)
+            # check if the namespace has its own profiles
+            if type(namespace) is dict:
+                for item in namespace:
+                    # exclude name of namespace
+                    if namespace[item]:
+                        if item.endswith("version"):
+                            verify_version(item, namespace[item], minor_version)
+                        else:
+                            verify_parameter(item, namespace[item], valid_profiles)
     if "namespaces_defaults" in procedure_config:
         for item in procedure_config["namespaces_defaults"]:
             if item.endswith("version"):
@@ -916,35 +919,52 @@ def label_namespace_pss(cluster, manage_type):
     namespaces = procedure_config.get("namespaces")
     # get the list of namespaces that should be labeled then set/delete labels
     if namespaces:
+        default_modes = {}
         # check if procedure config has default values for labels
         namespaces_defaults = procedure_config.get("namespaces_defaults")
         if namespaces_defaults:
-            default_modes = {}
             for default_mode in namespaces_defaults:
                  default_modes[default_mode] = namespaces_defaults[default_mode]
         for namespace in namespaces:
             if manage_type in ["apply", "install"]:
+                # define name of namespace
+                if type(namespace) is dict:
+                    for item in namespace:
+                        if not namespace[item]:
+                            ns_name = item
+                else:
+                    ns_name = namespace
                 if default_modes:
                     # set labels that are set in default section
-                    cluster.log.debug("Set PSS labels on namespace from defaults %s" % namespace)
+                    cluster.log.debug("Set PSS labels on %s namespace from defaults" % ns_name)
                     for mode in default_modes:
                         first_master.sudo("kubectl label ns %s pod-security.kubernetes.io/%s=%s --overwrite" 
-                                          % (namespace, mode, default_modes[mode]))
-                if namespaces[namespace]:
+                                          % (ns_name, mode, default_modes[mode]))
+                if type(namespace) is dict:
                     # set labels that are set in namespaces section
-                    cluster.log.debug("Set PSS labels on namespace %s" % namespace)
-                    for mode in namespaces[namespace]:
-                        first_master.sudo("kubectl label ns %s pod-security.kubernetes.io/%s=%s --overwrite" 
-                                          % (namespace, mode, namespaces[namespace][mode]))
+                    cluster.log.debug("Set PSS labels on %s namespace" % ns_name)
+                    for mode in namespace: 
+                        if namespace[mode]:
+                            first_master.sudo("kubectl label ns %s pod-security.kubernetes.io/%s=%s --overwrite" 
+                                              % (ns_name, mode, namespace[mode]))
             elif manage_type == "delete":
+                # define name of namespace
+                if type(namespace) is dict:
+                    for item in namespace:
+                        if not namespace[item]:
+                            ns_name = item
+                else:
+                    ns_name = namespace
                 # delete labels that are set in default section
-                cluster.log.debug("Delete PSS labels on namespace from defaults %s" % namespace)
+                cluster.log.debug("Delete PSS labels on %s namespace from defaults" % ns_name)
                 for mode in default_modes:
-                    first_master.sudo("kubectl label ns %s pod-security.kubernetes.io/%s=%s-" % (namespace, mode))
+                    first_master.sudo("kubectl label ns %s pod-security.kubernetes.io/%s-" % (ns_name, mode))
                 # delete labels that are set in namespaces section
-                cluster.log.debug("Delete PSS labels on namespace %s" % namespace)
-                for mode in namespaces[namespace]:
-                    first_master.sudo("kubectl label ns %s pod-security.kubernetes.io/%s-" % (namespace, mode))
+                cluster.log.debug("Delete PSS labels on %s namespace" % ns_name)
+                if type(namespace) is dict:
+                    for mode in namespace:
+                        if namespace[mode]:
+                            first_master.sudo("kubectl label ns %s pod-security.kubernetes.io/%s-" % (ns_name, mode))
 
 
 def check_inventory(cluster):


### PR DESCRIPTION
### Description
*  Need to implement approach bulk setting labels for namespaces

Fixes # MANOPD-75505

### Solution
* The new `procedure.yaml` structure is the following:
```
pss:
  pod-security: enabled
  namespaces:
    - ns1
    - ns2:
      enforce: "baseline"
    - ns3
    - ns4
  namespaces_defaults:
    enforce: "privileged"
    enforce-version: latest
restart-pods: false

```
`namespaces_defaults` section defines the settings for all namespaces from the list above if settings are not set in namespaces description (eg `ns2`). In this case `ns1`, `ns3`, and `ns4` namespaces will be labeled `enforce: "privileged"` and `ns2` will be labeled `enforce: "baseline"`. Also `ns1`, `ns2`, `ns3`, and `ns4` namespaces will be labeled `enforce-version: latest`.

### How to apply
Set `admission: psp` option in `cluster.yaml` if PSP is enabled in cluster.


### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 20.04
- Inventory: miniHA

Steps:

1. Run `manage_pss` procedure with the `procedure.yaml` above on PSS enabled cluster

Results:

| Before | After |
| ------ | ------ |
| Not applicable | Success |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
