### PR TITLE
'control-plane' and 'master' replacement in check_paas

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -393,12 +393,14 @@ def kubernetes_nodes_roles(cluster):
             for node_description in nodes_description['items']:
                 node_name = node_description['metadata']['name']
                 if node['name'] == node_name:
-                    if 'master' in node['roles']:
-                        if 'node-role.kubernetes.io/master' not in node_description['metadata']['labels']:
+                    if 'control-plane' in node['roles']:
+                        # TODO check label accordingly to Kubernetes version
+                        if 'node-role.kubernetes.io/master' not in node_description['metadata']['labels'] and \
+                           'node-role.kubernetes.io/control-plane' not in node_description['metadata']['labels']:
                             nodes_with_bad_roles.append(node['name'])
-                            cluster.log.error("Node \"%s\" has to be master, but has invalid role" % node['name'])
+                            cluster.log.error("Node \"%s\" has to be control-plane, but has invalid role" % node['name'])
                         else:
-                            cluster.log.debug("Node \"%s\" has correct master role" % node['name'])
+                            cluster.log.debug("Node \"%s\" has correct control-plane role" % node['name'])
                     elif 'worker' in node['roles']:
                         if 'node-role.kubernetes.io/worker' not in node_description['metadata']['labels']:
                             nodes_with_bad_roles.append(node['name'])


### PR DESCRIPTION
### Description
* Since `master` role has been excluded in Kubernetes v1.24 PaaS check should be changed

Fixes # Kubernetes node roles check (210)


### Solution
* The new check consider both `master` and `control-plane` roles in the cluster


### How to apply
Not applicable


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts



### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @dmyar21
