### PR TITLE
Changing the path of calicoctl in default.yaml

### DIFF
--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -86,7 +86,7 @@ services:
       sha1: '{{ globals.compatibility_map.software.kubectl[services.kubeadm.kubernetesVersion].sha1 }}'
       group: master
     /usr/bin/calicoctl:
-      source: 'https://github.com/projectcalico/calicoctl/releases/download/{{ plugins.calico.version }}/calicoctl-linux-amd64'
+      source: 'https://github.com/projectcalico/calico/releases/download/{{ plugins.calico.version }}/calicoctl-linux-amd64'
       sha1: '{{ globals.compatibility_map.software.calico[services.kubeadm.kubernetesVersion|minorversion].sha1 }}'
       group: master
     # "crictl" is installed by default ONLY if "containerRuntime != docker", otherwise it is removed programmatically


### PR DESCRIPTION
### Description
* In the new version of calicoctl, the path of its placement on github was changed, so installation from the Internet was not possible 

### Solution
* Fix path calicoctl in default.yaml


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
