### PR TITLE
[MANOPD-76335]Kubemarine upgrade failed due to an audit error for cluster that was deployed by kubemarine early

### DIFF
--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -154,6 +154,7 @@ tasks = OrderedDict({
     "verify_upgrade_versions": kubernetes.verify_upgrade_versions,
     "thirdparties": system_prepare_thirdparties,
     "prepull_images": prepull_images,
+    "configure_policy": install.system_prepare_policy,
     "kubernetes": kubernetes_upgrade,
     "kubernetes_cleanup": kubernetes_cleanup_nodes_versions,
     "packages": upgrade_packages,


### PR DESCRIPTION
### Description

* Inability to upgrade on a cluster with an old version of kubemarine installed without kubernetes audit support using the newest version of kubemarine.
When trying to upgrade with a new version of kubemarine, the upgade procedure fails.
Because there is no support for automatically enabling kubernetes audit in the upgrade procedure.


### Solution

* Added support for installing kubernetes audit in the upgrade procedure, which allows you to upgrade without errors

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts



### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
