### PR TITLE
[PSUPCLPL-9700] fix running pods check in paas_check

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -451,7 +451,8 @@ def kubernetes_nodes_condition(cluster, condition_type):
 
 
 def get_not_running_pods(cluster):
-    get_pods_cmd = 'kubectl get pods -A --field-selector status.phase!=Running | awk \'{ print $1" "$2" "$4 }\''
+    # Completed pods should be excluded from the list as well
+    get_pods_cmd = 'kubectl get pods -A --field-selector status.phase!=Running | awk \'{ print $1" "$2" "$4 }\' | grep -vw Completed'
     result = cluster.nodes['control-plane'].get_any_member().sudo(get_pods_cmd)
     cluster.log.verbose(result)
     return list(result.values())[0].stdout.strip()


### PR DESCRIPTION
### Description
Check of non-running pods in system namespaces considered completed pods as non-running so a warning was generated in case there were completed pods in these namespaces.

This PR allows to avoid warnings in case of any completed pods exist in system namespaces.

Fixes # (issue)
PSUPCLPL-9700

### Solution
add `grep -vw Completed` to the command getting list of non-running pods.

### How to apply
-

### Test Cases
Run paas_check job against a healthy cluster where completed pods exist in namespaces ["kube-system", "ingress-nginx", "kube-public", "kubernetes-dashboard", "default"].
There should be no warning about non-running pods. 

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests



### Reviewers
@koryaga @zaborin @alexarefev @dmyar21
