### PR TITLE
[MANOPD-75332] Procedure remove shutdowned node failed

### DIFF
--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -218,7 +218,7 @@ class KubernetesCluster(Environment):
         self.remove_invalid_cri_config(self.inventory)
         # Method "kubemarine.system.is_multiple_os_detected" is not used because it detects OS family for new nodes
         # only, while package versions caching performs on all nodes.
-        if self.nodes['all'].get_nodes_os(suppress_exceptions=True, force_all_nodes=True) != 'multiple':
+        if self.nodes['all'].get_accessible_nodes().get_nodes_os(suppress_exceptions=True, force_all_nodes=True) != 'multiple':
             self.cache_package_versions()
             self.log.verbose('Package versions detection finished')
         else:


### PR DESCRIPTION
### Description
`remove_node` procedure fails for shutdowned node.

### Solution
Fix gathering of package versions. Use only accessible nodes to detect package versions, the same as system.detect_os_family works.

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Any with more than one node.

Steps:

1. Shutdown one of nodes.
2. Call `remove_node` procedure to remove this node.

Results:

| Before | After |
| ------ | ------ |
| Procedure fails right after all tasks are executed. | Procedure successful. |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
