### PR TITLE
[MANOPD-76403]Nginx ingresses are unavailable on cluster deployed

### DIFF
--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -154,7 +154,6 @@ tasks = OrderedDict({
     "verify_upgrade_versions": kubernetes.verify_upgrade_versions,
     "thirdparties": system_prepare_thirdparties,
     "prepull_images": prepull_images,
-    "configure_policy": install.system_prepare_policy,
     "kubernetes": kubernetes_upgrade,
     "kubernetes_cleanup": kubernetes_cleanup_nodes_versions,
     "packages": upgrade_packages,


### PR DESCRIPTION
### Description
* The problem with ingress nginx controllers in version 1.2, the impossibility of nginx to work correctly without using the `kubernetes.io/ingress.class: "nginx"` annotation in `IngressClass` applications

### Solution

* Adding a new annotation parameter `ingressclass.kubernetes.io/is-default-class: "true"` to IngressClass and parameter args - `--watch-ingress-without-class=true` to DaemonSet which sets to  apps class `nginx` 


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
