### PR TITLE
[MANOPD-76427] Upgrade procedure fails

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -173,10 +173,16 @@ def enrich_inventory(inventory, cluster):
                 # TODO if-else case should be revised for future Kubernetes releases
                 minor_version = int(inventory["services"]["kubeadm"]["kubernetesVersion"].split('.')[1])
                 if minor_version < 24:
-                    node["taints"].append("node-role.kubernetes.io/master:NoSchedule-")
+                    # Do not add taints for upgrade procedure
+                    if cluster.context.get('initial_procedure') != 'upgrade':
+                        node["taints"].append("node-role.kubernetes.io/master:NoSchedule-")
                 else:
-                    node["taints"].append("node-role.kubernetes.io/control-plane:NoSchedule-")
-                    node["taints"].append("node-role.kubernetes.io/master:NoSchedule-")
+                    # For Kubernetes v1.24 taints for upgrade procedure and installation procedure should be different
+                    if cluster.context.get('initial_procedure') != 'upgrade':
+                        node["taints"].append("node-role.kubernetes.io/control-plane:NoSchedule-")
+                        node["taints"].append("node-role.kubernetes.io/master:NoSchedule-")
+                    else:
+                        node["taints"].append("node-role.kubernetes.io/control-plane:NoSchedule-")
 
     if not any_worker_found:
         raise KME("KME0004")


### PR DESCRIPTION
### Description
* Upgrade to Kubernetes v1.24 fails because of `node-role.kubernetes.io/control-plane:NoSchedule` `taint`. It's applicable only for `miniHA` scheme.

Fixes # MANOPD-75988


### Solution
* Change enrichment procedure and add code that remove `node-role.kubernetes.io/control-plane:NoSchedule`


### How to apply
Not applicable

### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**
`Taints` patch is working

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 20.04
- Inventory: miniHA

Steps:

1. Install Kubernetes v1.23
2. Upgrade 

Results:

| Before | After |
| ------ | ------ |
| Fail | Success |

**TestCase 2**
Typical installation is working

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 20.04
- Inventory: miniHA

Steps:

1. Install Kubernetes v1.24

Results:

| Before | After |
| ------ | ------ |
| Success | Success |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts



### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @dmyar21
