### PR TITLE
[PSUPCLPL-9776] change default podSubnet for IPv6

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -182,7 +182,7 @@ The actual information about the supported versions can be found at [global.yaml
 * Internal network bandwidth not less than 1GBi/s.
 * Dedicated internal address, IPv4, and IPv6 are supported as well, for each VM.
 * Any network security policies are disabled or whitelisted. This is especially important for OpenStack environments.
-  * Traffic is allowed for pod subnet. Search for address at`services.kubeadm.networking.podSubnet`. By default, `10.128.0.0/14` for IPv4 or `fd02::/80` for IPv6.
+  * Traffic is allowed for pod subnet. Search for address at`services.kubeadm.networking.podSubnet`. By default, `10.128.0.0/14` for IPv4 or `fd02::/48` for IPv6.
   * Traffic is allowed for service subnet. Search for address at `services.kubeadm.networking.serviceSubnet`. By default `172.30.0.0/16` for IPv4 or `fd03::/112` for IPv6).
 
 **Warning**: `Kubemarine` works only with `firewalld` as an IP firewall, and switches it off during the installation.
@@ -952,7 +952,7 @@ By default, the installer uses the following parameters:
 |---|---|
 |kubernetesVersion|`v1.20.3`|
 |controlPlaneEndpoint|`{{ cluster_name }}:6443`|
-|networking.podSubnet|`10.128.0.0/14` for IPv4 or `fd02::/80` for IPv6|
+|networking.podSubnet|`10.128.0.0/14` for IPv4 or `fd02::/48` for IPv6|
 |networking.serviceSubnet|`172.30.0.0/16` for IPv4 or `fd03::/112` for IPv6|
 |apiServer.certSANs|List with all nodes internal IPs, external IPs and names|
 |apiServer.extraArgs.enable-admission-plugins|`NodeRestriction`|

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -20,7 +20,7 @@ services:
     kubernetesVersion: v1.24.0
     controlPlaneEndpoint: '{{ cluster_name }}:6443'
     networking:
-      podSubnet: '{% if nodes[0]["internal_address"]|isipv4 %}10.128.0.0/14{% else %}fd02::/80{% endif %}'
+      podSubnet: '{% if nodes[0]["internal_address"]|isipv4 %}10.128.0.0/14{% else %}fd02::/48{% endif %}'
       serviceSubnet: '{% if nodes[0]["internal_address"]|isipv4 %}172.30.0.0/16{% else %}fd03::/112{% endif %}'
     apiServer:
       certSANs: []
@@ -466,7 +466,7 @@ plugins:
       DATASTORE_TYPE: kubernetes
       WAIT_FOR_DATASTORE: true
       CLUSTER_TYPE: k8s,bgp
-      CALICO_ROUTER_ID: ''
+      CALICO_ROUTER_ID: '{% if not services.kubeadm.networking.podSubnet|isipv4 %}hash{% endif %}'
       IP: '{% if services.kubeadm.networking.podSubnet|isipv4 %}autodetect{% else %}none{% endif %}'
       IP_AUTODETECTION_METHOD: first-found
       CALICO_IPV4POOL_IPIP: '{% if plugins.calico.mode | default("vxlan") == "ipip" and services.kubeadm.networking.podSubnet|isipv4 %}Always{% else %}Never{% endif %}'
@@ -495,7 +495,7 @@ plugins:
           assign_ipv4: 'false'
           assign_ipv6: 'true'
           ipv6_pools:
-            - '{% if not services.kubeadm.networking.podSubnet|isipv4 %}{{ services.kubeadm.networking.podSubnet }}{% else %}fd02::/80{% endif %}'
+            - '{% if not services.kubeadm.networking.podSubnet|isipv4 %}{{ services.kubeadm.networking.podSubnet }}{% else %}fd02::/48{% endif %}'
             - default-ipv6-ippool
           type: calico-ipam
     node:


### PR DESCRIPTION
### Description
In case of ipv6 usage kubernetes uses /64 for pod subnet per node by default. Accordingly pod subnet for the cluster should be not less than pod subnet per node. Current default podSubnet is fd02::/80 which leads to error during installation procedure.
There are flags for controller-manager which allow to reduce this network but kubeadm fails to run some command during cluster installation. So it's better to use the default kubernetes settings. 

Fixes # (issue)
PSUPCLPL-9776

### Solution
* change mask for ipv6 default podSubnet from /80 to /48.
* adjust default setting for CALICO_ROUTER_ID so it would be `hash` in case of ipv6 podSubnet (this setting is already described in the installation documentation, but making it default helps to avoid errors in case users don't read all the documentation).

### How to apply
Deploy cluster in ipv6 network environment.

### Test Cases
1) Deploy cluster in ipv6 network environment.
Check that no errors about podSubnet appear during the installation and calico is up&running.

2) Deploy cluster with default calico settings in ipv4 environment.
Check that calico-node pods are up&running.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


### Reviewers
@koryaga @iLeonidze @zaborin @alexarefev @Yaroslav-Lahtachev @dmyar21
