### PR TITLE
[PSUPCLPL-9824] add custom CA root cert info to IN

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -327,13 +327,20 @@ ssh-keygen -t rsa -b 4096
 In internal environments, certificates signed by the custom CA root certificate can be used, for example, in a private repository. 
 In this case, the custom CA root certificate should be added to all the cluster nodes.
 
-Example:
+Examples:
+* CentOS/RHEL/Oracle
 ```
 # yum install ca-certificates
 # curl -o /etc/pki/ca-trust/source/anchors/Custom_CA.crt http://example.com/misc/Custom_CA.crt
 # update-ca-trust extract
 ```
-
+* Ubuntu/Debian:
+```
+# apt install ca-certificates
+# curl -o /usr/share/ca-certificates/Custom_CA.crt http://example.com/misc/Custom_CA.crt
+# echo "Custom_CA.crt" >> /etc/ca-certificates.conf
+# update-ca-certificates
+```
 # Inventory Preparation
 
 Before you begin, select the deployment scheme and prepare the inventory.


### PR DESCRIPTION
### Description
In private environments custom CA root certificates can be used, for example, in private repository. There is no information about how to add such a certificate to the cluster nodes in the documentation.

Fixes # (issue)
PSUPCLPL-9824

### Solution
Update Installation.md with "Private Certificate Authority" chapter.

### How to apply
-

### Test Cases
-

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
-


