### PR TITLE
MANOPD-76852 Update check_paas.py

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -452,7 +452,7 @@ def kubernetes_nodes_condition(cluster, condition_type):
 
 def get_not_running_pods(cluster):
     # Completed pods should be excluded from the list as well
-    get_pods_cmd = 'kubectl get pods -A --field-selector status.phase!=Running | awk \'{ print $1" "$2" "$4 }\' | grep -vw Completed'
+    get_pods_cmd = 'kubectl get pods -A --field-selector status.phase!=Running | awk \'{ print $1" "$2" "$4 }\' | grep -vw Completed || true'
     result = cluster.nodes['control-plane'].get_any_member().sudo(get_pods_cmd)
     cluster.log.verbose(result)
     return list(result.values())[0].stdout.strip()


### PR DESCRIPTION
### Description
#166 regression , grep return error code 1 in case nothing is processed. 
 

Fixes # MANOPD-76852


### Solution
to exit success(0) even in case 1 is returned. Common case for grep.


### How to apply
None

### Test Cases

PSUPCLPL-9700 and MANOPD-76852

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


