### PR TITLE
[MANOPD-76880] Fix cache package version

### DIFF
--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -309,11 +309,11 @@ class KubernetesCluster(Environment):
             packages_list = []
             final_packages_list = []
             if isinstance(associated_packages, str):
-                packages_list.append(packages.get_package_name(self.nodes['all'], associated_packages))
+                packages_list.append(packages.get_package_name(os_family, associated_packages))
             elif isinstance(associated_packages, list):
                 associated_packages_clean = []
                 for package in associated_packages:
-                     associated_packages_clean.append(packages.get_package_name(self.nodes['all'], package))
+                     associated_packages_clean.append(packages.get_package_name(os_family, package))
                 packages_list = packages_list + associated_packages_clean
             else:
                 raise Exception('Unsupported associated packages object type')
@@ -358,7 +358,6 @@ class KubernetesCluster(Environment):
                     package_versions_list = [package]
                 final_packages_list = final_packages_list + package_versions_list
             self.inventory['services']['packages']['install']['include'] = list(set(final_packages_list))
-        self.log.debug("PACKAGES: %s" % detected_packages)
         return detected_packages
 
     def dump_finalized_inventory(self):

--- a/kubemarine/packages.py
+++ b/kubemarine/packages.py
@@ -29,10 +29,24 @@ def enrich_inventory_associations(inventory, cluster):
         return inventory
 
     os_specific_associations = deepcopy(associations[os_family])
-    # set 'skip_caching' for customer association
-    if cluster.raw_inventory.get('services', {}).get('packages', {}).get('associations', {}):
-        for package in cluster.raw_inventory['services']['packages']['associations']:
-            os_specific_associations[package]['skip_caching'] = "true"
+    # Cache packages versions only if the option is set in configuration, so we cut the version from 'package_name'
+    if not cluster.inventory['services']['packages']['cache_versions']:
+        for association in os_specific_associations:
+            if type(os_specific_associations[association]['package_name']) is list:
+                for item, package in enumerate(os_specific_associations[association]['package_name']):
+                    os_specific_associations[association]['package_name'][item] = \
+                            os_specific_associations[association]['package_name'][item].split('-{{')[0]
+            elif type(os_specific_associations[association]['package_name']) is str:
+                    os_specific_associations[association]['package_name'] = \
+                            os_specific_associations[association]['package_name'].split('-{{')[0]
+            else:
+                raise Exception('Unexpected value for association')
+
+    else:
+        # set 'skip_caching' for customer association
+        if cluster.raw_inventory.get('services', {}).get('packages', {}).get('associations', {}):
+            for package in cluster.raw_inventory['services']['packages']['associations']:
+                os_specific_associations[package]['skip_caching'] = "true"
 
     os_specific_associations['debian'] = deepcopy(associations['debian'])
     os_specific_associations['rhel'] = deepcopy(associations['rhel'])
@@ -101,9 +115,10 @@ def detect_installed_package_version(group: NodeGroup, package: str, warn=True) 
     (for example docker-ce* returns docker-ce and docker-ce-cli).
     """
 
-    package_name = get_package_name(group, package)
+    os_family = group.get_nodes_os()
+    package_name = get_package_name(os_family, package)
 
-    if group.get_nodes_os() in ["rhel", "rhel8"]:
+    if os_family in ["rhel", "rhel8"]:
         cmd = r"rpm -q %s" % package_name
     else:
         cmd = r"dpkg-query -f '${Package}=${Version}\n' -W %s" % package_name
@@ -134,23 +149,23 @@ def detect_installed_packages_versions(group: NodeGroup, packages_list: List or 
         for association_name, associated_params in cluster.inventory['services']['packages']['associations'].items():
             associated_packages = associated_params.get('package_name', [])
             if isinstance(associated_packages, str):
-                packages_list.append(get_package_name(group, associated_packages))
+                packages_list.append(get_package_name(group.get_nodes_os(), associated_packages))
             else:
                 associated_packages_clean = []
                 for package in associated_packages:
-                     associated_packages_clean.append(get_package_name(group, package))
+                     associated_packages_clean.append(get_package_name(group.get_nodes_os(), package))
                 packages_list = packages_list + associated_packages_clean
             if associated_params.get('skip_caching', False):
                 # replace packages with associated version that shoud be excluded from cache
                 for excluded_package in associated_params['package_name']:
-                    excluded_dict[get_package_name(group, excluded_package)] = excluded_package
+                    excluded_dict[get_package_name(group.get_nodes_os(), excluded_package)] = excluded_package
 
     # dedup
     packages_list = list(set(packages_list))
 
     with RemoteExecutor(cluster) as exe:
         for package in packages_list:
-            package_name = get_package_name(group, package)
+            package_name = get_package_name(group.get_nodes_os(), package)
             detect_installed_package_version(group, package_name, warn=True)
 
     raw_result = exe.get_last_results()
@@ -204,9 +219,9 @@ def detect_installed_packages_version_groups(group: NodeGroup, packages_list: Li
     return grouped_packages
 
 
-def get_package_name(group: NodeGroup, package: str) -> str:
+def get_package_name(os_family: str, package: str) -> str:
     """
-
+    Return the pure package name, whithout any part of version
     """
 
     import re
@@ -214,7 +229,7 @@ def get_package_name(group: NodeGroup, package: str) -> str:
     package_name = ""
     
     if package:
-        if group.get_nodes_os() in ["rhel", "rhel8"]:
+        if os_family in ["rhel", "rhel8"]:
             # regexp is needed to split package and its version, the pattern start with '-' then should be number or '*'
             package_name = re.split(r'-[\d,\*]', package)[0]
         else:


### PR DESCRIPTION
### Description
* `cache_version` options does not work for packages from 'associations' section. For instance: `add_node` procedure does not fail if there are several versions of the `containerd` package in the cluster.

Fixes # [MANOPD-76880]


### Solution
* Change detecting packages versions procedure to use regexp to distinguish package name


### How to apply
Not applicable


### Test Cases

**TestCase 1**
`cache_versions: true` works properly during `add_node` procedure

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 20.04; CentOS7
- Inventory: fullHA

Steps:

1. Install cluster.
2. Upgrade `containerd` package on one node up to version that has different minor (eg. `1.4` becomes `1.5`)
3. Run `add_node` procedure.

Results:

| Before | After |
| ------ | ------ |
| Success | Fail |

**TestCase 2**
`cache_versions: false` works properly during `add_node` procedure.

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 20.04; CentOS7
- Inventory: fullHA

Steps:

1. Install cluster.
2. Upgrade `containerd` package on one node up to version that has different minor (eg. `1.4` becomes `1.5`)
3. Run `add_node` procedure.

Results:

| Before | After |
| ------ | ------ |
| Success; Installed version comes from `associations` section | Success; Installed version is latest |

**TestCase 3**
`package.associations` in `cluster.yaml` works properly during `add_node` procedure.

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 20.04; CentOS7
- Inventory: fullHA

Steps:

1. Install cluster. `cluster.yaml` should have `package.associations` and `cache_versions: false`
2. Upgrade `containerd` package on one node up to version that has different minor (eg. `1.4` becomes `1.5`)
3. Run `add_node` procedure.
4. Change `cache_versions: true` in `cluster.yaml`.
5. Run `add_node` procedure.

Results:

| Before | After |
| ------ | ------ |
| Success; Installed version is latest | Success; Installed version comes from `associations` section |
| Fail | Success; Installed version comes from `associations` section |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

