### PR TITLE
[MANOPD-76880] Package cache doesnt work during procedure add_node 

### DIFF
--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -310,7 +310,6 @@ class KubernetesCluster(Environment):
             final_packages_list = []
             if isinstance(associated_packages, str):
                 packages_list.append(packages.get_package_name(self.nodes['all'].get_nodes_os(), associated_packages))
-                pack = packages.get_package_name(os_family, associated_packages)
             elif isinstance(associated_packages, list):
                 associated_packages_clean = []
                 for package in associated_packages:

--- a/kubemarine/packages.py
+++ b/kubemarine/packages.py
@@ -34,11 +34,19 @@ def enrich_inventory_associations(inventory, cluster):
         for association in os_specific_associations:
             if type(os_specific_associations[association]['package_name']) is list:
                 for item, package in enumerate(os_specific_associations[association]['package_name']):
-                    os_specific_associations[association]['package_name'][item] = \
-                            os_specific_associations[association]['package_name'][item].split('-{{')[0]
+                    if os_family in ["rhel", "rhel8"]:
+                        os_specific_associations[association]['package_name'][item] = \
+                                os_specific_associations[association]['package_name'][item].split('-{{')[0]
+                    else:
+                        os_specific_associations[association]['package_name'][item] = \
+                                os_specific_associations[association]['package_name'][item].split('={{')[0]
             elif type(os_specific_associations[association]['package_name']) is str:
-                    os_specific_associations[association]['package_name'] = \
+                    if os_family in ["rhel", "rhel8"]:
+                        os_specific_associations[association]['package_name'] = \
                             os_specific_associations[association]['package_name'].split('-{{')[0]
+                    else:
+                        os_specific_associations[association]['package_name'] = \
+                            os_specific_associations[association]['package_name'].split('={{')[0]
             else:
                 raise Exception('Unexpected value for association')
 


### PR DESCRIPTION
### Description
* Fix for `check_paas` procedure
* Fix for OS family dependency


### Solution
* Change definition order for variable
* 'package_name' detachment should work for different OS families


### How to apply
Not applicable


### Test Cases

**TestCase 1**
Check if `check_paas` works properly

Test Configuration:

- Hardware: 4CPU/8GB
- OS: CentoOS
- Inventory: miniHA

Steps:

1. Run cluster installation
2. Run `check_paas`

Results:

| Before | After |
| ------ | ------ |
| Fail | Success |


**TestCase 2**
Check if `add_node` procedure works properly

Test Configuration:

- Hardware: 4CPU/8GB
- OS: CentoOS, Ubuntu 20.04
- Inventory: fullHA

Steps:

1. Run cluster installation with `association` section
2. Run `add_node` procedure

Results:

| Before | After |
| ------ | ------ |
| package version depends on `cache_versions` switcher | package version depends on `association` |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts



