### PR TITLE
fix IN example of preflight errors usage

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -1030,7 +1030,6 @@ Example:
 
 ```yaml
 services:
-  kubeadm:
   kubeadm_flags:
     ignorePreflightErrors: Port-6443,CoreDNSUnsupportedPlugins,DirAvailable--var-lib-etcd
 ```
@@ -1039,7 +1038,6 @@ services:
 
 ```yaml
 services:
-  kubeadm:
   kubeadm_flags:
     ignorePreflightErrors: Port-6443,CoreDNSUnsupportedPlugins
 ```


### PR DESCRIPTION
### Description
Example of preflight errors usage in IN is rather incomrehensible. Have to be fixed

Fixes # (issue)
-

### Solution
To remove `kubeadm` section from the preflight errors usage examples.

### How to apply
-

### Test Cases
-
### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
-


