### PR TITLE
[PSUPCLPL-10121] fix expect_pods function

### DIFF
--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -410,9 +410,7 @@ def expect_pods(cluster, pods, namespace=None, timeout=None, retries=None,
                     stdout_line_allowed = True
 
             if stdout_line_allowed:
-                if 'Running' in stdout_line:
-                    running_pods_stdout += stdout_line + '\n'
-                elif is_critical_state_in_stdout(cluster, stdout_line):
+                if is_critical_state_in_stdout(cluster, stdout_line):
                     cluster.log.verbose("Failed pod detected: %s\n" % stdout_line)
 
                     if not failure_found:
@@ -422,6 +420,9 @@ def expect_pods(cluster, pods, namespace=None, timeout=None, retries=None,
                     # just in case, skip the error a couple of times, what if it comes out of the failure state?
                     if failures > cluster.globals['pods']['allowed_failures']:
                         raise Exception('Pod entered a state of error, further proceeding is impossible')
+                else:
+                # we have to take into account any pod in not a critical state
+                    running_pods_stdout += stdout_line + '\n'
 
         pods_ready = False
         if running_pods_stdout and running_pods_stdout != "" and "0/1" not in running_pods_stdout:


### PR DESCRIPTION
### Description
Sometimes `expect:pods` considers required pods ready even if some instances of these pods are not ready. Like in PSUPCLPL-10121 where calico-node pods were considered ready when only 8 our of 13 pods were really ready. 
This can lead to different errors in the further work of kubemarine.

Fixes # (issue)
PSUPCLPL-10121

### Solution
Looks like it happens due to the logic here: https://github.com/Netcracker/KubeMarine/blob/main/kubemarine/plugins/__init__.py#:~:text=if%20%27Running%27,is%20impossible%27)

We don't count pods in states like ContainerCreating, Init, etc (not Running and not critical states).

So it's better to change sequence of conditions like that:
```
if in critical_state:
  # count failure and raise exception if necessary
else:
 # add the pod to the line of pods to be checked
```

### How to apply
none

### Test Cases
Deploy/upgrade kubernetes with plugins. There shouldn't be errors and in the log for every `expect_pods` call the list of ready pods should contain all the instances of the required pods.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


