### PR TITLE
[MANOPD-77690] fix check_paas: Dashboard availability check

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -505,7 +505,10 @@ def kubernetes_dashboard_status(cluster):
                        cluster.log.debug(f'Can not resolve dashboard IP: {result.stderr} ')
                        raise TestFailure("not available",hint=f"Please verify the following Kubernetes Dashboard status and fix this issue")
                 found_url = result.stdout
-                check_url = cluster.nodes['control-plane'].get_first_member().sudo(f'curl -k -I https://{found_url}:443', warn=True)
+                if ipaddress.ip_address(found_url).version == 4:
+                    check_url = cluster.nodes['control-plane'].get_first_member().sudo(f'curl -k -I https://{found_url}:443', warn=True)
+                else:
+                    check_url = cluster.nodes['control-plane'].get_first_member().sudo(f'curl -g -k -I https://[{found_url}]:443', warn=True)
                 status = list(check_url.values())[0].stdout
                 if '200' in status:
                     cluster.log.debug(status)


### PR DESCRIPTION
### Description
Check_paas procedure fails on Dashboard availability check in the ipv6 environment.

Fixes # (issue)
MANOPD-77690

### Solution
The root cause is that curl string being used to connect to the dashboard is not suitable for v6 ip address. Flag "-g" should be added to curl and ip address must be enclosed in square brackets.

### How to apply
none


### Test Cases
Run check_paas procedure against ipv4 and ipv6 clusters.
In both cases the result should contain
```
        Plugins      OK     208  Dashboard Availability ................................................ available
```

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests


