### PR TITLE
[MANOPD-76632] Publish finalized inventory for reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ config
 ansible-inventory.ini
 admin.conf
 account-tokens.yaml
+cluster_finalized.yaml
 ca.csr
 ca.pem
 ca-key.pem

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -4836,9 +4836,11 @@ $ install --disable-dump-cleanup
 
 ### Finalized Dump
 
-After the procedure is completed, a final dump with all the missing variable values is needed, which is pulled from the finished cluster environment.
-This dump of the final inventory can be found in the `dump/cluster_finalized.yaml` file. In the file, you can see not only the compiled inventory, but also some converted values depending on what is installed on the cluster.
+After any procedure is completed, a final inventory with all the missing variable values is needed, which is pulled from the finished cluster environment.
+This inventory can be found in the `cluster_finalized.yaml` file in the working directory,
+and can be passed as a source inventory in future runs of Kubemarine procedures.
 
+In the file, you can see not only the compiled inventory, but also some converted values depending on what is installed on the cluster.
 For example, consider the following package's origin configuration:
 
 ```yaml
@@ -4877,12 +4879,13 @@ services:
         service_name: 'docker'
         config_location: '/etc/docker/daemon.json'
     install:
-      - conntrack
-      - ethtool-4.8-10.el7.x86_64
-      - ebtables-2.0.10-16.el7.x86_64
-      - socat-1.7.3.2-2.el7.x86_64
-      - unzip-6.0-21.el7.x86_64
-      - policycoreutils-python-utils
+      include:
+        - conntrack
+        - ethtool-4.8-10.el7.x86_64
+        - ebtables-2.0.10-16.el7.x86_64
+        - socat-1.7.3.2-2.el7.x86_64
+        - unzip-6.0-21.el7.x86_64
+        - policycoreutils-python-utils
 ```
 
 **Note**: Some of the packages are impossible to be detected in the system, therefore such packages remain unchanged.

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -369,7 +369,11 @@ class KubernetesCluster(Environment):
         prepared_inventory = defaults.prepare_for_dump(prepared_inventory, copy=False)
         prepared_inventory = self.escape_jinja_characters_for_inventory(prepared_inventory)
         inventory_for_dump = controlplane.controlplane_finalize_inventory(self, prepared_inventory)
-        utils.dump_file(self, yaml.dump(inventory_for_dump), "cluster_finalized.yaml")
+        data = yaml.dump(inventory_for_dump)
+        finalized_filename = "cluster_finalized.yaml"
+        utils.dump_file(self, data, finalized_filename)
+        with open(finalized_filename, 'w') as f:
+            f.write(data)
 
     def preserve_inventory(self):
         self.log.debug("Start preserving of the information about the procedure.")


### PR DESCRIPTION
### Description
There are no strict declaration which enriched inventory file can be reused in future runs of Kubemarine procedures.

### Solution
* cluster_finalized.yaml is now additionally copied to working directory.
* Announce in documentation that the file can be reused in future runs of Kubemarine procedures.
* Other fixes of documentation.

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Any

Steps:

1. Install cluster.
2. Find `cluster_finalized.yaml` in working directory and run `check_paas` procedure with this file used as a source inventory.

Results:

| Before | After |
| ------ | ------ |
| There are no  `cluster_finalized.yaml` file in working directory | Check is successful |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [X] There is no merge conflicts
