### PR TITLE
[PSUPCLPL-10163]Upgrade procedure with jenkins job failed

### DIFF
--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -165,7 +165,6 @@ def system_prepare_policy(cluster):
                 control_plane['connection'].call(utils.wait_command_successful,
                                                  command="docker stop $(sudo docker ps -q -f 'name=k8s_kube-apiserver'"
                                                          " | awk '{print $1}')")
-            cluster.nodes['control-plane'].call(utils.wait_command_successful, command="kubectl get pod -n kube-system")
             control_plane['connection'].call(utils.wait_command_successful, command="kubectl get pod -n kube-system")
             control_plane['connection'].sudo("kubeadm init phase upload-config kubeadm "
                                              "--config=/etc/kubernetes/audit-on-config.yaml")


### PR DESCRIPTION
### Description

* Unable to complete cluster upgrade process with jekins job
Because api-server is not available at the time of audit configuration


### Solution
* Adding check for api-server state

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


