### PR TITLE
MANOPD-78266 Fix exit code for incorrect procedure

### DIFF
--- a/kubemarine/__main__.py
+++ b/kubemarine/__main__.py
@@ -137,11 +137,12 @@ def main():
                 previous_group = group
             for description in descriptions:
                 descriptions_print_list.append(' ' + description)
-        return print('''The following procedures available:
+        print('''The following procedures available:
 %s
 
 Usage: kubemarine <procedure> <arguments>
 ''' % '\n'.join(descriptions_print_list))
+        sys.exit(1)
 
     result = import_procedure(arguments[0]).main(arguments[1:])
     if result is not None:


### PR DESCRIPTION
### Description
If Kubemarine is run inside job and incorrect procedure is specified, it exits successfully and does not interrupt the job.

### Solution
Exit with non-zero exit code if incorrect procedure is specified.

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: None
- OS: None
- Inventory: None

Steps:

1. Run `kubemarine some_incorrect_procedure`

Results:

| Before | After |
| ------ | ------ |
| Prints usage and exits with 0 | Prints usage and exits with 1 |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [X] There is no merge conflicts