### PR TITLE
[MANOPD-78524] - add checking presence of SA secret during its deleting by index

### DIFF
--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -46,8 +46,10 @@ def enrich_inventory(inventory, cluster):
         # It has only 'ServiceAccount' and 'ClusterRoleBinding'
         minor_version = int(inventory["services"]["kubeadm"]["kubernetesVersion"].split('.')[1])
         if minor_version < 24:
-            rbac["accounts"][i]['configs'].pop(2)
-            rbac["accounts"][i]['configs'][0].pop('secrets')
+            if len(rbac["accounts"][i]['configs']) > 2:
+                rbac["accounts"][i]['configs'].pop(2)
+            if rbac["accounts"][i]['configs'][0].get('secrets') is not None:
+                rbac["accounts"][i]['configs'][0].pop('secrets')
         else:
            # This part is applicable for Kubernetes v1.24 and higher
            # It has 'Secret' in addition 


### PR DESCRIPTION
### Description
For version 1.24 we create secrets manually for service-accounts, but for fewer versions they are created automatically during SA creation. For this reason we remove their descriptions for old versions.
But this secrets don't exist in cluster_finalyzed.yaml,  if they didn't applied. As result it can raise an out-of-index exception, if we use it as input for kubemarine procedures.

### Solution
Special checks was added before deleting secrets constructions from inventory.

### Test Cases

**TestCase 1**

Steps:
1.  Run kubemarine install with kubernetes version fewer than 1.24 (e.g. 1.23.6);
2. Run kubemarine check-paas with cluster_finalyzed.yaml as input, what is the result of previous task.

Results:

| Before | After |
| ------ | ------ |
| Paas-check fails with out-of-index exception | Paas-check works as normal |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


