### PR TITLE
[MANOPD-77444] Fix check_iaas for ipv6 environment

### DIFF
--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -451,14 +451,14 @@ def tcp_connect(cluster, node_from, node_to, tcp_ports, host_to_ip, mtu):
     node_from['connection'].sudo(cmd, timeout=cluster.globals['connection']['defaults']['timeout'])
 
 
-def get_start_tcp_listener_cmd(python_executable, tcp_listener):
+def get_start_tcp_listener_cmd(python_executable, tcp_listener, ip_version):
     # 1. Create anonymous pipe
     # 2. Create python tcp listener process in background and redirect output to pipe
     # 3. Wait till the listener successfully binds the port, or till it fails and exits.
     #    Read one line from pipe to check that.
     # 4. Exit with success or fail correspondingly.
     return "PORT=%s; PIPE=$(mktemp -u); mkfifo $PIPE; exec 3<>$PIPE; rm $PIPE; " \
-           f"sudo nohup {python_executable} {tcp_listener} $PORT >&3 2>&1 & " \
+           f"sudo nohup {python_executable} {tcp_listener} $PORT {ip_version} >&3 2>&1 & " \
            "PID=$(echo $!); " \
            "while read -t 0.1 -u 3 || sudo kill -0 $PID 2>/dev/null && [[ -z $REPLY ]]; do " \
                ":; " \
@@ -476,7 +476,7 @@ def get_start_tcp_listener_cmd(python_executable, tcp_listener):
 
 
 def get_stop_tcp_listener_cmd(tcp_listener):
-    identify_pid = "ps aux | grep \" %s ${port}$\" | grep -v grep | grep -v nohup | awk '{print $2}'" % tcp_listener
+    identify_pid = "ps aux | grep \" %s ${port} \" | grep -v grep | grep -v nohup | awk '{print $2}'" % tcp_listener
     return f"port=%s;pid=$({identify_pid}) " \
            "&& if [ ! -z $pid ]; then sudo kill -9 $pid; echo \"killed pid $pid for port $port\"; fi"
 
@@ -540,8 +540,10 @@ def install_tcp_listener(cluster: KubernetesCluster, nodes: dict, tcp_ports):
         with RemoteExecutor(cluster) as exe:
             # Run process that LISTEN TCP port
             for host, node in nodes.items():
+                internal_ip = node.get('internal_address')
+                ip_version = ipaddress.ip_address(internal_ip).version 
                 python_executable = cluster.context['nodes'][host]['python']['executable']
-                tcp_listener_cmd = cmd_for_ports(tcp_ports, get_start_tcp_listener_cmd(python_executable, tcp_listener))
+                tcp_listener_cmd = cmd_for_ports(tcp_ports, get_start_tcp_listener_cmd(python_executable, tcp_listener, ip_version))
                 node['connection'].sudo(tcp_listener_cmd, warn=True)
 
             exe.flush()

--- a/kubemarine/resources/scripts/simple_tcp_listener.py
+++ b/kubemarine/resources/scripts/simple_tcp_listener.py
@@ -15,12 +15,15 @@
 # Simple TCP socket listener that can be run on both python 2 and 3,
 # The listener accepts connections sequentially, and suppresses the received data.
 # The script is for testing purpose only.
-# The only argv parameter is a TCP port to listen.
+# The first argv parameter is the TCP port to listen. The second argv parameter is the ip protocol version.
 
 import socket
 import sys
 
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+if sys.argv[2] == '6' :
+  s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+else:
+  s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
 try:
     s.bind(('', int(sys.argv[1])))


### PR DESCRIPTION
### Description
Check_iaas procedure fails on network.pod_subnet_connectivity/network.service_subnet_connectivity in the ipv6 environment.

Fixes # (issue)
MANOPD-77444

### Solution
1. The number of possible addresses in the ipv6 network exceeds the maximum allowed value for the list in python. Added a limit for the list of 1 million addresses.
2. For the 'ip' command, the format of the entry "ip a add \<ip\>/\<net_mask\>" is not applicable for ipv6 addresses. Fixed to "ip a add \<ip\>/\<prefixlength\>".
3. [simple_tcp_listener.py](https://github.com/Netcracker/KubeMarine/blob/main/kubemarine/resources/scripts/simple_tcp_listener.py) script did not work for ipv6 addresses. Added an argument that allows to select the ip protocol version.

### How to apply
none


### Test Cases
Run check_iaas procedure against ipv4 and ipv6 clusters.
In both cases the result should contain
![image](https://user-images.githubusercontent.com/110163750/186124168-c0baf0ed-656e-4a78-a194-8c26c01aa1bc.png)


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests


