### PR TITLE
MiniHA Upgrade from v1.23.6 to v1.24.2 failed

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -182,7 +182,8 @@ def enrich_inventory(inventory, cluster):
                         node["taints"].append("node-role.kubernetes.io/control-plane:NoSchedule-")
                         node["taints"].append("node-role.kubernetes.io/master:NoSchedule-")
                     else:
-                        node["taints"].append("node-role.kubernetes.io/control-plane:NoSchedule-")
+                        if inventory["services"]["kubeadm"]["kubernetesVersion"] == "v1.24.0":
+                            node["taints"].append("node-role.kubernetes.io/control-plane:NoSchedule-")
 
     # use first control plane internal address as a default bind-address
     # for other control-planes we override it during initialization


### PR DESCRIPTION
### Description
*  Upgrade miniHA cluster from v1.23.6 to v1.24.2 failed with error
```
taint "node-role.kubernetes.io/control-plane:NoSchedule" not found
```
* Upgrade miniHA cluster from v1.23.6 to v1.24.0 succeeded

Fixes # (issue)


### Solution
* Change conditions for `taints` applying


### How to apply
Not applicable


### Test Cases

**TestCase 1**
Upgrade from v1.23.6 to v1.24.2 works properly

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 20.04
- Inventory: miniHA

Steps:

1. Install Kubernetes v1.23.6
2. Upgrade Kubernetes to v1.24.2

Results:

| Before | After |
| ------ | ------ |
| Fail | Success |


**TestCase 2**
Upgrade from v1.23.6 to v1.24.0 works properly

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 20.04
- Inventory: miniHA

Steps:

1. Install Kubernetes v1.23.6
2. Upgrade Kubernetes to v1.24.0

Results:

| Before | After |
| ------ | ------ |
| Success | Success |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
