### PR TITLE
[PSUPCLPL-10537] fix verify_upgrade_versions for nested nodenames

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -867,10 +867,10 @@ def verify_upgrade_versions(cluster):
     k8s_nodes_group = cluster.nodes["worker"].include_group(cluster.nodes['control-plane'])
     for node in k8s_nodes_group.get_ordered_members_list(provide_node_configs=True):
         cluster.log.debug(f"Verifying current k8s version for node {node['name']}")
-        result = first_control_plane['connection'].sudo("kubectl get nodes -o custom-columns="
-                                                 "'VERSION:.status.nodeInfo.kubeletVersion,NAME:.metadata.name' "
-                                                 f"| grep -w {node['name']} "
-                                                 "| awk '{ print $1 }'")
+        result = first_control_plane['connection'].sudo("kubectl get nodes "
+                                                 f"{node['name']}"
+                                                 " -o custom-columns='VERSION:.status.nodeInfo.kubeletVersion' "
+                                                 "| grep -vw ^VERSION ")
         curr_version = list(result.values())[0].stdout
         test_version_upgrade_possible(curr_version, upgrade_version, skip_equal=True)
 


### PR DESCRIPTION
### Description
If cluster nodes have `.` in their names or some node name is a substring of another node name (for example, 
`worker-db-01` and `svt-worker-db-01`) there is an error in verify_upgrade_versions() which appears during upgrade.

Fixes # (issue)
PSUPCLPL-10537

### Solution
Command to get kubelet version of a node is adjusted.

### How to apply
-

### Test Cases
1. Deploy cluster with node names like
```
node-12
node-12-1
node-12.test
svt-node-12
no.e-112
```
ER: Deployment is successful.

2. Upgrade the cluster from step 1 to the next kubernetes version.
ER: Upgrade is successful.
### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
