### PR TITLE
[MANOPD-79453] Upgrade kubernetes 1.21.2 -> 1.21.12 failed

### DIFF
--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -105,6 +105,10 @@ workaround:
 compatibility_map:
   software:
     docker:
+      v1.21.2:
+        version_rhel: 19.03*
+        version_rhel8: 19.03*
+        version_debian: 5:19.03.*
       v1.21.5:
         version_rhel: 19.03*
         version_rhel8: 19.03*
@@ -138,6 +142,9 @@ compatibility_map:
         version_rhel8: 19.03*
         version_debian: 5:19.03.*
     containerd:
+      v1.21.2:
+        version_rhel: 1.4*
+        version_debian: 1.5.*
       v1.21.5:
         version_rhel8: 1.4*
         version_debian: 1.5.*
@@ -163,6 +170,10 @@ compatibility_map:
         version_rhel8: 1.4*
         version_debian: 1.5.*
     containerdio:
+      v1.21.2:
+        version_rhel: 1.6*
+        version_rhel8: 1.6*
+        version_debian: 1.4.*
       v1.21.5:
         version_rhel: 1.6*
         version_rhel8: 1.6*
@@ -196,6 +207,10 @@ compatibility_map:
         version_rhel8: 1.6*
         version_debian: 1.4.*
     podman:
+      v1.21.2:
+        version_rhel: 1.6.4*
+        version_rhel8: "*"
+        version_debian: "*"
       v1.21.5:
         version_rhel: 1.6.4*
         version_rhel8: "*"
@@ -229,6 +244,10 @@ compatibility_map:
         version_rhel8: "*"
         version_debian: "*"
     haproxy:
+      v1.21.2:
+        version_rhel: 1.8*
+        version_rhel8: 1.8*
+        version_debian: 2.0.*
       v1.21.5:
         version_rhel: 1.8*
         version_rhel8: 1.8*
@@ -262,6 +281,10 @@ compatibility_map:
         version_rhel8: 1.8*
         version_debian: 2.0.*
     keepalived:
+      v1.21.2:
+        version_rhel: 1.3*
+        version_rhel8: 2.1*
+        version_debian: 1:2.0.*
       v1.21.5:
         version_rhel: 1.3*
         version_rhel8: 2.1*
@@ -295,6 +318,9 @@ compatibility_map:
         version_rhel8: 2.1*
         version_debian: 1:2.0.*
     crictl:
+      v1.21.2:
+        version: v1.23.0
+        sha1: 332001091d2e4523cbe8d97ab0f7bfbf4dfebda2
       v1.21.5:
         version: v1.23.0
         sha1: 332001091d2e4523cbe8d97ab0f7bfbf4dfebda2
@@ -320,6 +346,8 @@ compatibility_map:
         version: v1.23.0
         sha1: 332001091d2e4523cbe8d97ab0f7bfbf4dfebda2
     kubeadm:
+      v1.21.2:
+        sha1: cbb07d380de4ef73d43d594a1055839fa9753138
       v1.21.5:
         sha1: 2ee056ac1d0b9c2289bdb03cb7bb0cd21ee29a8b
       v1.21.12:
@@ -337,6 +365,8 @@ compatibility_map:
       v1.24.2:
         sha1: 65c3e96dc54e7f703bf1ea9c6e5573dca067f726
     kubelet:
+      v1.21.2:
+        sha1: 024e458aa0f74cba6b773401b779590437812fc6
       v1.21.5:
         sha1: 61da22475b977cb678cca8cf7249bf727d72ee89
       v1.21.12:
@@ -354,6 +384,8 @@ compatibility_map:
       v1.24.2:
         sha1: 35c3d20f92c8159b4f65aaafe6e9fc57c9f9e308
     kubectl:
+      v1.21.2:
+        sha1: 2c7a7de9fff41ac49f7c2546a9b1aff2c1d9c468
       v1.21.5:
         sha1: c4648e31ca16fb00e3826f8ab7c653da81eff367
       v1.21.12:


### PR DESCRIPTION
### Description
* Inability to upgrade to a new version of kubernetes without specifying it in global.yaml

### Solution

* Add minor version kubernetes in globals.yaml


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts



