### PR TITLE
Relative-path-to-ssh-in-cluster.yaml-key-is-not-supported-#130   -  Update connections.py

### DIFF
--- a/kubemarine/core/connections.py
+++ b/kubemarine/core/connections.py
@@ -14,7 +14,7 @@
 
 from typing import Dict
 
-import fabric
+import fabric, os
 
 from kubemarine.core.environment import Environment
 


### PR DESCRIPTION
### Description
* When we run Kubemarine command the "tilde(~)" expression specified in the keypath in cluster.yaml file was not getting recognized as the home path for the keyfile path.

### Solution
In order  to overcome this, in the connections.py script expand the keyfile path while reading it.

### How to apply
Not applicable


### Test Cases

1. Kubemarine install - Successfully read the id_rsa file from the path "~/.ssh/id_rsa" and installation was successful.
2.  Kubemarine backup - Successfully established the connection and created a backup file. 

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


