### PR TITLE
fix etcdctl.sh for treating nodenames with dots

### DIFF
--- a/kubemarine/resources/scripts/etcdctl.sh
+++ b/kubemarine/resources/scripts/etcdctl.sh
@@ -39,7 +39,7 @@ if [ -n "${ETCD_POD_CONFIG}" ]; then
   ETCD_CERT=$(echo "${ETCD_POD_CONFIG}" | grep '\- --cert-file' | sed s/=/\\n/g | sed -n 2p)
   ETCD_KEY=$(echo "${ETCD_POD_CONFIG}" | grep '\- --key-file' | sed s/=/\\n/g | sed -n 2p)
   ETCD_CA=$(echo "${ETCD_POD_CONFIG}" | grep '\- --trusted-ca-file' | sed s/=/\\n/g | sed -n 2p)
-  ETCD_ENDPOINTS=$(echo "${ETCD_POD_CONFIG}" | grep '\- --initial-cluster=' | sed -e 's/\s*- --initial-cluster=//g' -e "s/[a-zA-Z0-9-]*=//g" -e "s/2380/2379/g")
+  ETCD_ENDPOINTS=$(echo "${ETCD_POD_CONFIG}" | grep '\- --initial-cluster=' | sed -e 's/\s*- --initial-cluster=//g' -e "s/[a-zA-Z0-9\.-]*=//g" -e "s/2380/2379/g")
   while IFS= read -r line; do
       volume=$(echo "${line}" | awk '{print $3; exit}')
       ETCD_MOUNTS="${ETCD_MOUNTS} -v ${volume}:${volume}"


### PR DESCRIPTION
### Description
According to the documentation (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names) nodes can have names with dots.
Currently etcdctl script works properly only with names without dots.

Fixes # (issue)
none

### Solution
Dot is added to the sed pattern used in ETCD_ENDPOINTS variable in etcdcl.sh

### How to apply
none


### Test Cases
1. Deploy cluster with at least master nodenames containing dots. It should be deployed successfully.
2. Try to run etcdctl against at any master node (for example, `etcdctl member list`). It should work without errors.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


