### PR TITLE
[PSUPCLPL-10584] Ingress nginx controller v1.2

### DIFF
--- a/kubemarine/templates/plugins/nginx-ingress-controller-v1.2.yaml.j2
+++ b/kubemarine/templates/plugins/nginx-ingress-controller-v1.2.yaml.j2
@@ -304,7 +304,6 @@ spec:
       containers:
       - args:
         - /nginx-ingress-controller
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
         - --election-id=ingress-controller-leader
         - --controller-class=k8s.io/ingress-nginx
         - --ingress-class=nginx


### PR DESCRIPTION
### Description
* `Ingress-nginx-controller` templates version 1.2 and version 1.1 are different that cause some unexpected behavior


### Solution
* Delete additional `args` from the template version 1.2  to make it similar to the template version 1.1


### How to apply
Not applicable




### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts



