### PR TITLE
[MANOPD-77802] - Check default thirdparties sha despite of source

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -341,8 +341,9 @@ def thirdparties_hashes(cluster):
                             broken.append(f'failed to get sha for temporary file {random_path} on {host.host}: {result.stderr}')
                             cluster.log.verbose(f'failed to get sha for temporary file {random_path} on {host.host}: {result.stderr}')
                         else:
-                            expected_sha = result.stdout.strip()
-                            cluster.log.verbose(f"Expected sha was got for {path}")
+                            result_str = result.stdout.strip()
+                            expected_sha = result_str if len(result_str) > 0 else expected_sha
+                            cluster.log.verbose(f"Expected sha was got for {path}: {expected_sha}")
                 # Remove temporary dir in any case
                 cluster.log.verbose(f"Remove temporary dir {random_dir}...")
                 first_control_plane.sudo(final_commands, hide=True, warn=True)
@@ -352,7 +353,7 @@ def thirdparties_hashes(cluster):
                 warnings.append(f"{path} source contains not recommended thirdparty version for used kubernetes version")
 
             if config.get("sha1", expected_sha) != expected_sha:
-                warnings.append("Given sha is not equal with actual sha from source for %s" % path)
+                broken .append("Given sha is not equal with actual sha from source for %s" % path)
 
             expected_sha = config.get("sha1", expected_sha)
 

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -297,7 +297,7 @@ def thirdparties_hashes(cluster):
     If there is no thirdparties with hashes, then warning is shown.
     """
     with TestCase(cluster.context['testsuite'], '212', "Thirdparties", "Hashes") as tc:
-        successful = []
+        warning = []
         broken = []
 
         for path, config in cluster.inventory['services']['thirdparties'].items():
@@ -336,10 +336,9 @@ def thirdparties_hashes(cluster):
                 # was not able to find single actual SHA, errors already collected, nothing to do
                 continue
             if actual_sha != expected_sha:
-                broken.append(f'expected sha {expected_sha} is not equal to actual sha {actual_sha} for {path}')
+                warning.append(f'expected sha {expected_sha} is not equal to actual sha {actual_sha} for {path}')
                 continue
 
-            successful.append(path)
             # SHA is correct, now check if it is an archive and if it does, then also check SHA for archive content
             if 'unpack' in config:
                 unpack_dir = config['unpack']
@@ -368,8 +367,8 @@ def thirdparties_hashes(cluster):
 
         if broken:
             raise TestFailure('Found inconsistent hashes', hint=yaml.safe_dump(broken))
-        if not successful:
-            raise TestWarn('Did not found any hashes')
+        if warning:
+            raise TestWarn('Found warnings', hint=yaml.safe_dump(warning))
         tc.success('All found hashes are correct')
 
 

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -25,7 +25,7 @@ import ruamel.yaml
 import ipaddress
 import uuid
 
-from kubemarine import packages as pckgs, system, selinux, etcd
+from kubemarine import packages as pckgs, system, selinux, etcd, thirdparties
 from kubemarine.core.action import Action
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.resources import DynamicResources
@@ -346,6 +346,10 @@ def thirdparties_hashes(cluster):
                 # Remove temporary dir in any case
                 cluster.log.verbose(f"Remove temporary dir {random_dir}...")
                 first_control_plane.sudo(final_commands, hide=True, warn=True)
+
+            recommended_sha = thirdparties.get_thirdparty_recommended_sha(path, cluster)
+            if recommended_sha is not None and recommended_sha != expected_sha:
+                warnings.append(f"{path} source contains not recommended thirdparty version for used kubernetes version")
 
             if config.get("sha1", expected_sha) != expected_sha:
                 warnings.append("Given sha is not equal with actual sha from source for %s" % path)

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -79,22 +79,17 @@ services:
       binary: false
     /usr/bin/kubeadm:
       source: 'https://storage.googleapis.com/kubernetes-release/release/{{ services.kubeadm.kubernetesVersion }}/bin/linux/amd64/kubeadm'
-      sha1: '{{ globals.compatibility_map.software.kubeadm[services.kubeadm.kubernetesVersion].sha1 }}'
     /usr/bin/kubelet:
       source: 'https://storage.googleapis.com/kubernetes-release/release/{{ services.kubeadm.kubernetesVersion }}/bin/linux/amd64/kubelet'
-      sha1: '{{ globals.compatibility_map.software.kubelet[services.kubeadm.kubernetesVersion].sha1 }}'
     /usr/bin/kubectl:
       source: 'https://storage.googleapis.com/kubernetes-release/release/{{ services.kubeadm.kubernetesVersion }}/bin/linux/amd64/kubectl'
-      sha1: '{{ globals.compatibility_map.software.kubectl[services.kubeadm.kubernetesVersion].sha1 }}'
       group: control-plane
     /usr/bin/calicoctl:
       source: 'https://github.com/projectcalico/calico/releases/download/{{ plugins.calico.version }}/calicoctl-linux-amd64'
-      sha1: '{{ globals.compatibility_map.software.calico[services.kubeadm.kubernetesVersion|minorversion].sha1 }}'
       group: control-plane
     # "crictl" is installed by default ONLY if "containerRuntime != docker", otherwise it is removed programmatically
     /usr/bin/crictl.tar.gz:
       source: 'https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ globals.compatibility_map.software.crictl[services.kubeadm.kubernetesVersion].version }}/crictl-{{ globals.compatibility_map.software.crictl[services.kubeadm.kubernetesVersion].version }}-linux-amd64.tar.gz'
-      sha1: '{{ globals.compatibility_map.software.crictl[services.kubeadm.kubernetesVersion].sha1 }}'
       unpack: /usr/bin/
 
   cri:

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -102,6 +102,18 @@ workaround:
   retries: 10
   delay_period: 5
 
+thirdparties:
+  /usr/bin/kubeadm:
+    software_name: kubeadm
+  /usr/bin/kubelet:
+    software_name: kubelet
+  /usr/bin/kubectl:
+    software_name: kubectl
+  /usr/bin/calicoctl:
+    software_name: calico
+  /usr/bin/crictl.tar.gz:
+    software_name: crictl
+
 compatibility_map:
   software:
     docker:

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -102,11 +102,10 @@ def enrich_inventory_apply_defaults(inventory, cluster):
                                     'Expected any of %s, but \'%s\' found.'
                                     % (destination, all_nodes_names, node_name))
 
-        # if source is re-defined by user, but "sha1" is not provided,
-        # then remove default "sha1", because it may be wrong
         raw_config = raw_inventory.get('services', {}).get('thirdparties', {}).get(destination, {})
-        if 'source' in raw_config and 'sha1' not in raw_config and 'sha1' in config:
-            del config['sha1']
+        recommended_sha = get_thirdparty_recommended_sha(destination, cluster)
+        if 'source' not in raw_config and 'sha1' not in raw_config and recommended_sha is not None:
+            config['sha1'] = get_thirdparty_recommended_sha(destination, cluster)
 
         inventory['services']['thirdparties'][destination] = config
 

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -79,6 +79,12 @@ def enrich_inventory_apply_defaults(inventory, cluster):
                                     'Expected any of %s, but \'%s\' found.'
                                     % (destination, all_nodes_names, node_name))
 
+        # if source is re-defined by user, but "sha1" is not provided,
+        # then remove default "sha1", because it may be wrong
+        raw_config = raw_inventory.get('services', {}).get('thirdparties', {}).get(destination, {})
+        if 'source' in raw_config and 'sha1' not in raw_config and 'sha1' in config:
+            del config['sha1']
+
         inventory['services']['thirdparties'][destination] = config
 
     # remove "crictl" from thirdparties when docker is used, but ONLY IF it is NOT explicitly specified in cluster.yaml

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -38,6 +38,29 @@ def enrich_inventory_apply_upgrade_defaults(inventory, cluster):
     return inventory
 
 
+def get_thirdparty_recommended_sha(destination, cluster):
+    cluster.log.verbose("Calculate recommended sha for thirdparty %s..." % destination)
+    # Get kubeadm version
+    kubernetes_version = cluster.inventory['services']['kubeadm']['kubernetesVersion']
+    effective_kubernetes_version = ".".join(kubernetes_version.split('.')[0:2])
+
+    # Get software versions map
+    software_name = cluster.globals['thirdparties'].get(destination, {}).get('software_name', None)
+    software_versions = cluster.globals['compatibility_map']['software'].get(software_name, {})
+
+    # Return sha1 related to used kubernetes version
+    recommended_sha = software_versions[kubernetes_version].get('sha1', None) \
+        if kubernetes_version in software_versions else \
+        software_versions.get(effective_kubernetes_version, {}).get('sha1', None)
+
+    if recommended_sha is not None:
+        cluster.log.verbose(f"Recommended sha for thirdparty {destination} was calculated: {recommended_sha}")
+    else:
+        cluster.log.verbose(f"Recommended sha for thirdparty {destination} doesn't exist")
+
+    return recommended_sha
+
+
 def enrich_inventory_apply_defaults(inventory, cluster):
     # if thirdparties is empty, then nothing to do
     if not inventory['services'].get('thirdparties', {}):

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -79,12 +79,6 @@ def enrich_inventory_apply_defaults(inventory, cluster):
                                     'Expected any of %s, but \'%s\' found.'
                                     % (destination, all_nodes_names, node_name))
 
-        # if source is re-defined by user, but "sha1" is not provided,
-        # then remove default "sha1", because it may be wrong
-        raw_config = raw_inventory.get('services', {}).get('thirdparties', {}).get(destination, {})
-        if 'source' in raw_config and 'sha1' not in raw_config and 'sha1' in config:
-            del config['sha1']
-
         inventory['services']['thirdparties'][destination] = config
 
     # remove "crictl" from thirdparties when docker is used, but ONLY IF it is NOT explicitly specified in cluster.yaml

--- a/test/unit/test_thirdparties.py
+++ b/test/unit/test_thirdparties.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+from kubemarine import demo, thirdparties
+
+
+class K8sCertTest(unittest.TestCase):
+
+    customized_services = {
+        'kubeadm': {
+            'kubernetesVersion': "v1.24.0"
+        },
+        'thirdparties': {
+            '/usr/bin/kubelet': {
+                'source': 'overriden_source'
+            },
+            '/usr/bin/kubectl': {
+                'source': 'overriden_source',
+                'sha1': 'overriden_sha'
+            },
+            'custom/thirdparty/without/sha': {
+                'source': 'some-source'
+            },
+            'custom/thirdparty/with/sha': {
+                'source': 'some-source',
+                'sha1': 'some-sha'
+            }
+        }
+    }
+
+    def test_recommended_sha_calculation(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+
+        # Add custom parameters with version and override thirdparties info
+        inventory['services'] = self.customized_services
+
+        cluster = demo.new_cluster(inventory, fake=False)
+
+        self.assertIsNone(thirdparties.get_thirdparty_recommended_sha("/usr/bin/etcdctl", cluster))
+        self.assertEqual(cluster.globals['compatibility_map']['software']['kubeadm']['v1.24.0']['sha1'],
+                         thirdparties.get_thirdparty_recommended_sha("/usr/bin/kubeadm", cluster))
+        self.assertEqual(cluster.globals['compatibility_map']['software']['kubelet']['v1.24.0']['sha1'],
+                         thirdparties.get_thirdparty_recommended_sha("/usr/bin/kubelet", cluster))
+        self.assertEqual(cluster.globals['compatibility_map']['software']['kubectl']['v1.24.0']['sha1'],
+                         thirdparties.get_thirdparty_recommended_sha("/usr/bin/kubectl", cluster))
+        self.assertEqual(cluster.globals['compatibility_map']['software']['calico']['v1.24']['sha1'],
+                         thirdparties.get_thirdparty_recommended_sha("/usr/bin/calicoctl", cluster))
+        self.assertIsNone(thirdparties.get_thirdparty_recommended_sha("custom/thirdparty/without/sha", cluster))
+        self.assertIsNone(thirdparties.get_thirdparty_recommended_sha("custom/thirdparty/with/sha", cluster))
+
+    def test_default_sha_calculation(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+
+        # Add custom parameters with version and override thirdparties info
+        inventory['services'] = self.customized_services
+
+        cluster = demo.new_cluster(inventory, fake=False)
+
+        self.assertNotIn('sha1', cluster.inventory['services']['thirdparties']["/usr/bin/etcdctl"])
+        self.assertEqual(cluster.globals['compatibility_map']['software']['kubeadm']['v1.24.0']['sha1'],
+                         cluster.inventory['services']['thirdparties']["/usr/bin/kubeadm"]['sha1'])
+        self.assertNotIn('sha1', cluster.inventory['services']['thirdparties']["/usr/bin/kubelet"])
+        self.assertEqual(self.customized_services['thirdparties']['/usr/bin/kubectl']['sha1'],
+                         cluster.inventory['services']['thirdparties']["/usr/bin/kubectl"]['sha1'])
+        self.assertEqual(cluster.globals['compatibility_map']['software']['calico']['v1.24']['sha1'],
+                         cluster.inventory['services']['thirdparties']["/usr/bin/calicoctl"]['sha1'])
+        self.assertNotIn('sha1', cluster.inventory['services']['thirdparties']["custom/thirdparty/without/sha"])
+        self.assertEqual(self.customized_services['thirdparties']['custom/thirdparty/with/sha']['sha1'],
+                         cluster.inventory['services']['thirdparties']["custom/thirdparty/with/sha"]['sha1'])
+
+


### PR DESCRIPTION
### Description
We've already had default sha for thirdparties, but we specially delete them. And then we skip sha check, if it's not defined in cluster.

Fixes # (issue)
* If default sha is not defined, for check caches thirdparty will be loaded to one of control-plane node and expexted sha will be got from this file.

### How to apply
Provide steps how to apply on top previous Kubemarine version to execute on existing clusters
* [Install task/s](documentation/Installation.md#installation-tasks-description)
* [Check Paas](documentation/Kubecheck.md#paas-procedure)


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


