### PR TITLE
[MANOPD-79810] calico environment variables forwarding support

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3267,6 +3267,9 @@ plugins:
       enabled: true
     node:
       image: calico/node:v3.10.1
+    env:
+      FELIX_USAGEREPORTINGENABLED: true
+
 ```
 
 An example is also available in [Full Inventory Example](../examples/cluster.yaml/full-cluster.yaml).

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -499,6 +499,29 @@ plugins:
       FELIX_LOGSEVERITYSCREEN: info
       FELIX_HEALTHENABLED: true
       FELIX_USAGEREPORTINGENABLED: false
+      FELIX_TYPHAK8SSERVICENAME:
+          configMapKeyRef:
+            name: calico-config
+            key: typha_service_name
+      NODENAME:
+          fieldRef:
+            fieldPath: spec.nodeName
+      CALICO_NETWORKING_BACKEND:
+          configMapKeyRef:
+            name: calico-config
+            key: calico_backend
+      FELIX_IPINIPMTU:
+          configMapKeyRef:
+            name: calico-config
+            key: veth_mtu
+      FELIX_VXLANMTU:
+          configMapKeyRef:
+            name: calico-config
+            key: veth_mtu
+      FELIX_WIREGUARDMTU:
+          configMapKeyRef:
+            name: calico-config
+            key: veth_mtu
     cni:
       image: 'calico/cni:{{ plugins.calico.version }}'
       ipam:

--- a/kubemarine/templates/plugins/calico-v3.21.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.21.yaml.j2
@@ -4318,108 +4318,25 @@ spec:
         # host.
         - name: calico-node
           image: {% if plugins['calico']['installation']['registry'] is defined and plugins['calico']['installation']['registry']|length %}{{ plugins['calico']['installation']['registry'] }}/{% endif %}{{ plugins['calico']['node']['image'] }}
-
-
-
-
-
           env:
-            # Use Kubernetes API as the backing datastore.
-            - name: DATASTORE_TYPE
-              value: "{{ plugins['calico']['env']['DATASTORE_TYPE'] }}"
-{%- if plugins.calico.typha.enabled | default(false) == true %}
-            # Typha support: controlled by the ConfigMap.
+     {%- set ipv6_env = ['CALICO_IPV6POOL_CIDR', 'IP6', 'IP6_AUTODETECTION_METHOD', 'FELIX_IPV6SUPPORT', 'CALICO_IPV6POOL_IPIP', 'CALICO_IPV6POOL_VXLAN'] %}
+     {%- for name_env, env in plugins.calico.env.items() %}
+       {%- if (name_env not in ipv6_env) and (name_env != 'FELIX_TYPHAK8SSERVICENAME') %}
+            - name: {{ name_env }}
+              {% if env is not mapping %}value: "{{ env }}" {% else %}valueFrom: {{ env }}{% endif %}{% else %}
+             {%- if name_env in ipv6_env and not services.kubeadm.networking.podSubnet|isipv4 %}
+            - name: {{ name_env }}
+              {% if env is not mapping %}value: "{{ env }}" {% else %}valueFrom: {{ env }}{% endif %}
+             {%- endif %}
+             {%- if (plugins.calico.typha.enabled | default(false) == true) and (name_env == 'FELIX_TYPHAK8SSERVICENAME') %}
             - name: FELIX_TYPHAK8SSERVICENAME
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: typha_service_name
-{%- endif %}
-            # Wait for the datastore.
-            - name: WAIT_FOR_DATASTORE
-              value: "{{ plugins['calico']['env']['WAIT_FOR_DATASTORE'] }}"
-            # Set based on the k8s node name.
-            - name: NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # Choose the backend to use.
-            - name: CALICO_NETWORKING_BACKEND
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: calico_backend
-            # Cluster type to identify the deployment type
-            - name: CLUSTER_TYPE
-              value: "{{ plugins['calico']['env']['CLUSTER_TYPE'] }}"
-
-
-
-
-
-
-
-
-
-            # Set MTU for tunnel device used if ipip is enabled
-            - name: FELIX_IPINIPMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # Set MTU for the VXLAN tunnel device.
-            - name: FELIX_VXLANMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-
-            - name: CALICO_ROUTER_ID
-              value: "{{ plugins['calico']['env']['CALICO_ROUTER_ID'] }}"
-
-            # IPv4 OPTIONS
-            - name: IP
-              value: "{{ plugins['calico']['env']['IP'] }}"
-            - name: IP_AUTODETECTION_METHOD
-              value: "{{ plugins['calico']['env']['IP_AUTODETECTION_METHOD'] }}"
-            - name: CALICO_IPV4POOL_IPIP
-              value: "{{ plugins['calico']['env']['CALICO_IPV4POOL_IPIP'] }}"
-            - name: CALICO_IPV4POOL_VXLAN
-              value: "{{ plugins['calico']['env']['CALICO_IPV4POOL_VXLAN'] }}"
-            - name: CALICO_IPV4POOL_CIDR
-              value: "{{ plugins['calico']['env']['CALICO_IPV4POOL_CIDR'] }}"
-
-            - name: FELIX_IPV6SUPPORT
-              value: "{{ plugins['calico']['env']['FELIX_IPV6SUPPORT'] }}"
-{%- if not services.kubeadm.networking.podSubnet|isipv4 %}
-            # IPv6 OPTIONS
-            - name: CALICO_IPV6POOL_CIDR
-              value: "{{ plugins['calico']['env']['CALICO_IPV6POOL_CIDR'] }}"
-            - name: IP6
-              value: "{{ plugins['calico']['env']['IP6'] }}"
-            - name: IP6_AUTODETECTION_METHOD
-              value: "{{ plugins['calico']['env']['IP6_AUTODETECTION_METHOD'] }}"
-            - name: FELIX_IPV6SUPPORT
-              value: "{{ plugins['calico']['env']['FELIX_IPV6SUPPORT'] }}"
-            - name: CALICO_IPV6POOL_IPIP
-              value: "{{ plugins['calico']['env']['CALICO_IPV6POOL_IPIP'] }}"
-            - name: CALICO_IPV6POOL_VXLAN
-              value: "{{ plugins['calico']['env']['CALICO_IPV6POOL_VXLAN'] }}"
-{%- endif %}
-
-            # Disable file logging so `kubectl logs` works.
-            - name: CALICO_DISABLE_FILE_LOGGING
-              value: "{{ plugins['calico']['env']['CALICO_DISABLE_FILE_LOGGING'] }}"
-            # Set Felix endpoint to host default action to ACCEPT.
-            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "{{ plugins['calico']['env']['FELIX_DEFAULTENDPOINTTOHOSTACTION'] }}"
-
-
-
-            - name: FELIX_HEALTHENABLED
-              value: "{{ plugins['calico']['env']['FELIX_HEALTHENABLED'] }}"
-            - name: FELIX_USAGEREPORTINGENABLED
-              value: "{{ plugins['calico']['env']['FELIX_USAGEREPORTINGENABLED'] }}"
+             {%- endif %}
+       {%- endif %}
+     {%- endfor %}
           securityContext:
             privileged: true
           resources:

--- a/kubemarine/templates/plugins/calico-v3.22.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.22.yaml.j2
@@ -4326,11 +4326,24 @@ spec:
               name: kubernetes-services-endpoint
               optional: true
           env:
-            # Use Kubernetes API as the backing datastore.
-            {%- for name_env, env in plugins.calico.env.items() %}
+     {%- set ipv6_env = ['CALICO_IPV6POOL_CIDR', 'IP6', 'IP6_AUTODETECTION_METHOD', 'FELIX_IPV6SUPPORT', 'CALICO_IPV6POOL_IPIP', 'CALICO_IPV6POOL_VXLAN'] %}
+     {%- for name_env, env in plugins.calico.env.items() %}
+       {%- if (name_env not in ipv6_env) and (name_env != 'FELIX_TYPHAK8SSERVICENAME') %}
+            - name: {{ name_env }}
+              {% if env is not mapping %}value: "{{ env }}" {% else %}valueFrom: {{ env }}{% endif %}{% else %}
+             {%- if name_env in ipv6_env and not services.kubeadm.networking.podSubnet|isipv4 %}
             - name: {{ name_env }}
               {% if env is not mapping %}value: "{{ env }}" {% else %}valueFrom: {{ env }}{% endif %}
-            {%- endfor %}
+             {%- endif %}
+             {%- if (plugins.calico.typha.enabled | default(false) == true) and (name_env == 'FELIX_TYPHAK8SSERVICENAME') %}
+            - name: FELIX_TYPHAK8SSERVICENAME
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: typha_service_name
+             {%- endif %}
+       {%- endif %}
+     {%- endfor %}
           securityContext:
             privileged: true
           resources:

--- a/kubemarine/templates/plugins/calico-v3.22.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.22.yaml.j2
@@ -4327,99 +4327,10 @@ spec:
               optional: true
           env:
             # Use Kubernetes API as the backing datastore.
-            - name: DATASTORE_TYPE
-              value: "{{ plugins['calico']['env']['DATASTORE_TYPE'] }}"
-{%- if plugins.calico.typha.enabled | default(false) == true %}
-            # Typha support: controlled by the ConfigMap.
-            - name: FELIX_TYPHAK8SSERVICENAME
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: typha_service_name
-{%- endif %}
-            # Wait for the datastore.
-            - name: WAIT_FOR_DATASTORE
-              value: "{{ plugins['calico']['env']['WAIT_FOR_DATASTORE'] }}"
-            # Set based on the k8s node name.
-            - name: NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # Choose the backend to use.
-            - name: CALICO_NETWORKING_BACKEND
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: calico_backend
-            # Cluster type to identify the deployment type
-            - name: CLUSTER_TYPE
-              value: "{{ plugins['calico']['env']['CLUSTER_TYPE'] }}"
-            # Set MTU for tunnel device used if ipip is enabled
-            - name: FELIX_IPINIPMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # Set MTU for the VXLAN tunnel device.
-            - name: FELIX_VXLANMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # Set MTU for the Wireguard tunnel device.
-            - name: FELIX_WIREGUARDMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
-            # chosen from this range. Changing this value after installation will have
-            # no effect. This should fall within `--cluster-cidr`.
-            - name: CALICO_ROUTER_ID
-              value: "{{ plugins['calico']['env']['CALICO_ROUTER_ID'] }}"
-
-            # IPv4 OPTIONS
-            - name: IP
-              value: "{{ plugins['calico']['env']['IP'] }}"
-            - name: IP_AUTODETECTION_METHOD
-              value: "{{ plugins['calico']['env']['IP_AUTODETECTION_METHOD'] }}"
-            - name: CALICO_IPV4POOL_IPIP
-              value: "{{ plugins['calico']['env']['CALICO_IPV4POOL_IPIP'] }}"
-            - name: CALICO_IPV4POOL_VXLAN
-              value: "{{ plugins['calico']['env']['CALICO_IPV4POOL_VXLAN'] }}"
-            - name: CALICO_IPV4POOL_CIDR
-              value: "{{ plugins['calico']['env']['CALICO_IPV4POOL_CIDR'] }}"
-
-            - name: FELIX_IPV6SUPPORT
-              value: "{{ plugins['calico']['env']['FELIX_IPV6SUPPORT'] }}"
-{%- if not services.kubeadm.networking.podSubnet|isipv4 %}
-            # IPv6 OPTIONS
-            - name: CALICO_IPV6POOL_CIDR
-              value: "{{ plugins['calico']['env']['CALICO_IPV6POOL_CIDR'] }}"
-            - name: IP6
-              value: "{{ plugins['calico']['env']['IP6'] }}"
-            - name: IP6_AUTODETECTION_METHOD
-              value: "{{ plugins['calico']['env']['IP6_AUTODETECTION_METHOD'] }}"
-            - name: FELIX_IPV6SUPPORT
-              value: "{{ plugins['calico']['env']['FELIX_IPV6SUPPORT'] }}"
-            - name: CALICO_IPV6POOL_IPIP
-              value: "{{ plugins['calico']['env']['CALICO_IPV6POOL_IPIP'] }}"
-            - name: CALICO_IPV6POOL_VXLAN
-              value: "{{ plugins['calico']['env']['CALICO_IPV6POOL_VXLAN'] }}"
-{%- endif %}
-
-            # - name: CALICO_IPV4POOL_CIDR
-            #   value: "192.168.0.0/16"
-            # Disable file logging so `kubectl logs` works.
-            - name: CALICO_DISABLE_FILE_LOGGING
-              value: "{{ plugins['calico']['env']['CALICO_DISABLE_FILE_LOGGING'] }}"
-            # Set Felix endpoint to host default action to ACCEPT.
-            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "{{ plugins['calico']['env']['FELIX_DEFAULTENDPOINTTOHOSTACTION'] }}"
-            - name: FELIX_HEALTHENABLED
-              value: "{{ plugins['calico']['env']['FELIX_HEALTHENABLED'] }}"
-            - name: FELIX_USAGEREPORTINGENABLED
-              value: "{{ plugins['calico']['env']['FELIX_USAGEREPORTINGENABLED'] }}"
+            {%- for name_env, env in plugins.calico.env.items() %}
+            - name: {{ name_env }}
+              {% if env is not mapping %}value: "{{ env }}" {% else %}valueFrom: {{ env }}{% endif %}
+            {%- endfor %}
           securityContext:
             privileged: true
           resources:

--- a/kubemarine/templates/plugins/calico-v3.24.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.24.yaml.j2
@@ -4652,82 +4652,24 @@ spec:
               name: kubernetes-services-endpoint
               optional: true
           env:
-            # Use Kubernetes API as the backing datastore.
-            - name: DATASTORE_TYPE
-              value: "{{ plugins['calico']['env']['DATASTORE_TYPE'] }}"
-{%- if plugins.calico.typha.enabled | default(false) == true %}
-            # Typha support: controlled by the ConfigMap.
+     {%- set ipv6_env = ['CALICO_IPV6POOL_CIDR', 'IP6', 'IP6_AUTODETECTION_METHOD', 'FELIX_IPV6SUPPORT', 'CALICO_IPV6POOL_IPIP', 'CALICO_IPV6POOL_VXLAN'] %}
+     {%- for name_env, env in plugins.calico.env.items() %}
+       {%- if (name_env not in ipv6_env) and (name_env != 'FELIX_TYPHAK8SSERVICENAME') %}
+            - name: {{ name_env }}
+              {% if env is not mapping %}value: "{{ env }}" {% else %}valueFrom: {{ env }}{% endif %}{% else %}
+             {%- if name_env in ipv6_env and not services.kubeadm.networking.podSubnet|isipv4 %}
+            - name: {{ name_env }}
+              {% if env is not mapping %}value: "{{ env }}" {% else %}valueFrom: {{ env }}{% endif %}
+             {%- endif %}
+             {%- if (plugins.calico.typha.enabled | default(false) == true) and (name_env == 'FELIX_TYPHAK8SSERVICENAME') %}
             - name: FELIX_TYPHAK8SSERVICENAME
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: typha_service_name
-{%- endif %}
-            # Wait for the datastore.
-            - name: WAIT_FOR_DATASTORE
-              value: "{{ plugins['calico']['env']['WAIT_FOR_DATASTORE'] }}"
-            # Set based on the k8s node name.
-            - name: NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # Choose the backend to use.
-            - name: CALICO_NETWORKING_BACKEND
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: calico_backend
-            # Cluster type to identify the deployment type
-            - name: CLUSTER_TYPE
-              value: "{{ plugins['calico']['env']['CLUSTER_TYPE'] }}"
-            # Auto-detect the BGP IP address.
-            - name: IP
-              value: "{{ plugins['calico']['env']['IP'] }}"
-{%- if not services.kubeadm.networking.podSubnet|isipv4 %}
-            # Enable IPIP
-            - name: CALICO_IPV4POOL_IPIP
-              value: "{{ plugins['calico']['env']['CALICO_IPV4POOL_IPIP'] }}"
-            # Enable or Disable VXLAN on the default IP pool.
-            - name: CALICO_IPV4POOL_VXLAN
-              value: "{{ plugins['calico']['env']['CALICO_IPV4POOL_VXLAN'] }}"
-            # Enable or Disable VXLAN on the default IPv6 IP pool.
-            - name: CALICO_IPV6POOL_VXLAN
-              value: "{{ plugins['calico']['env']['CALICO_IPV6POOL_VXLAN'] }}"
-{%- endif %}
-            # Set MTU for tunnel device used if ipip is enabled
-            - name: FELIX_IPINIPMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # Set MTU for the VXLAN tunnel device.
-            - name: FELIX_VXLANMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # Set MTU for the Wireguard tunnel device.
-            - name: FELIX_WIREGUARDMTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
-            # chosen from this range. Changing this value after installation will have
-            # no effect. This should fall within `--cluster-cidr`.
-            # - name: CALICO_IPV4POOL_CIDR
-            #   value: "{{ plugins['calico']['env']['CALICO_IPV4POOL_CIDR'] }}"
-            # Disable file logging so `kubectl logs` works.
-            - name: CALICO_DISABLE_FILE_LOGGING
-              value: "{{ plugins['calico']['env']['CALICO_DISABLE_FILE_LOGGING'] }}"
-            # Set Felix endpoint to host default action to ACCEPT.
-            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-              value: "{{ plugins['calico']['env']['FELIX_DEFAULTENDPOINTTOHOSTACTION'] }}"
-            # Disable IPv6 on Kubernetes.
-            - name: FELIX_IPV6SUPPORT
-              value: "{{ plugins['calico']['env']['FELIX_IPV6SUPPORT'] }}"
-            - name: FELIX_HEALTHENABLED
-              value: "{{ plugins['calico']['env']['FELIX_HEALTHENABLED'] }}"
+             {%- endif %}
+       {%- endif %}
+     {%- endfor %}
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
### Description
* `Calico` environment variables should follow from `cluster.yaml` to `calico.yaml`


### Solution
* Change `Calico` YAML template and `defaults.yaml`


### How to apply
Not applicable


### Test Cases

**TestCase 1**

Check if the solution works

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 20.04
- Inventory: FullHA

Steps:

1. Add to `cluster.yaml` some environment variable in section `plugins.calico.env`
2. Run installation with `--tasks="deploy.plugins"`
3. Check if the variable is set in `Calico` pod description

Results:

| Before | After |
| ------ | ------ |
| absent | is set |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts




