### PR TITLE
MANOPD-78236 Fixed patch autodeletion workflow

### DIFF
--- a/.github/workflows/patch.yaml
+++ b/.github/workflows/patch.yaml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          token: ${{ secrets.NCCLPLCI_PAT }}
           # By default, tag is checked out. It needs to check out branch to commit to.
           ref: ${{ github.event.release.target_commitish }}
       - run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,8 @@ jobs:
      steps:
        - uses: actions/checkout@v2
        - run: docker run -v "${PWD}:/src" -i ghcr.io/google/addlicense -v -c "${{ env.COPYRIGHT_COMPANY }}" -y "${{ env.COPYRIGHT_YEAR }}" $(find . -type f -name "*.py" | xargs echo)
+       # This currently not works for protected branches,
+       # but all pushes to them should be done through PRs that already contain inserted license.
        - uses: stefanzweifel/git-auto-commit-action@v4
          with:
            commit_message: Auto-update license header


### PR DESCRIPTION
### Description
* `.github/workflows/patch.yaml` workflow fails to push to protected branches.

Fixes #202 

### Solution
* The job now checkouts the branch using PAT of NetcrackerCLPLCI user which has grants to push to protected branches

### Test Cases

**TestCase 1**

Steps:

1. Publish release that has one or more [patches](https://github.com/Netcracker/KubeMarine/blob/main/documentation/Maintenance.md#patch-identifiers).

Results:

| Before | After |
| ------ | ------ |
| `Manage Patches` workflow fails | `Manage Patches` workflow deletes all patches  |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts