### PR TITLE
MANOPD-76951 Fix "remote_node" procedure for miniHA

### DIFF
--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -309,7 +309,7 @@ class KubernetesCluster(Environment):
             packages_list = []
             final_packages_list = []
             if isinstance(associated_packages, str):
-                packages_list.append(packages.get_package_name(self.nodes['all'].get_nodes_os(), associated_packages))
+                packages_list.append(packages.get_package_name(self.nodes['all'].get_final_nodes().get_nodes_os(), associated_packages))
             elif isinstance(associated_packages, list):
                 associated_packages_clean = []
                 for package in associated_packages:

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -313,7 +313,7 @@ class KubernetesCluster(Environment):
             elif isinstance(associated_packages, list):
                 associated_packages_clean = []
                 for package in associated_packages:
-                     associated_packages_clean.append(packages.get_package_name(self.nodes['all'].get_nodes_os(), package))
+                     associated_packages_clean.append(packages.get_package_name(self.nodes['all'].get_final_nodes().get_nodes_os(), package))
                 packages_list = packages_list + associated_packages_clean
             else:
                 raise Exception('Unsupported associated packages object type')

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -342,7 +342,7 @@ class ClusterStorage:
                 for i, file in enumerate(files):
                     if i >= not_pack_file and i < delete_old:
                         if 'tar.gz' not in file:
-                            control_plane.get_final_nodes().sudo(f'tar -czvf {self.dir_path + file + ".tar.gz"} {self.dir_path + file} &&'
+                            control_plane.sudo(f'tar -czvf {self.dir_path + file + ".tar.gz"} {self.dir_path + file} &&'
                                        f'sudo rm -r {self.dir_path + file}')
                     elif i >= delete_old:
                         control_plane.sudo(f'rm -rf {self.dir_path + file}')
@@ -386,7 +386,7 @@ class ClusterStorage:
         This method is used to transfer backup logs from the main control-plane to the new control-plane.
         """
 
-        node = self.cluster.nodes['control-plane'].get_final_nodes().get_initial_nodes().get_first_member(provide_node_configs=True)
+        node = self.cluster.nodes['control-plane'].get_initial_nodes().get_first_member(provide_node_configs=True)
         control_plane = self.cluster.make_group([node['connect_to']])
         data_copy_res = control_plane.sudo(f'tar -czvf /tmp/kubemarine-backup.tar.gz {self.dir_path}')
         self.cluster.log.debug('Backup created:\n%s' % data_copy_res)


### PR DESCRIPTION
### Description
Job fails if remove **shutdowned** node using maintenance procedure for **miniHA** scheme. When preserving of the information about the procedure the actual number of nodes is not taken into account.


### Solution
Additionally, use the **get_final_nodes()** function to get the actual list of nodes.


### How to apply
none


### Test Cases

**TestCase 1**

Test Configuration:
miniHA cluster of 3 master nodes

Steps:
1. Shutdown master node
2. Remove node from cluster using maintenance procedure
3. The node removal procedure will be fully executed, but the job will fail at the final stage of generating logs about the performed procedure. 

Results:

| Before | After |
| ------ | ------ |
| Job successfully finished | Job failure with python traceback error |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


