### PR TITLE
Update Installation.md

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -5652,9 +5652,6 @@ The tables below shows the correspondence of versions that are supported and is 
   </tr>
   <tr>
     <td rowspan="5">rpms</td>
-    <td>docker-ce</td>
-    <td colspan="4">19.03</td>
-    <td></td>
   </tr>
   <tr>
     <td>containerd.io</td>


### PR DESCRIPTION
### Description
Deletion information from documentation table about support docker ce in Kubernetes v.1.24 according https://kubernetes.io/blog/2022/01/07/kubernetes-is-moving-on-from-dockershim/.
* 


### Checklist

- [x] I have made corresponding changes to the documentation





