### PR TITLE
[MANOPD-000] - add upgrade calico patch

### DIFF
--- a/documentation/internal/Patches.md
+++ b/documentation/internal/Patches.md
@@ -1,0 +1,20 @@
+# Kubemarine patches
+
+Patch is automatic action, what is needed to migrate cluster, that is managed via kubemarine, from one kubemarine release to another.  
+Patches are needed when weupdate kubetools 3rd parties, specific kubernetes parameters, kubetools procudures/features and etc.  
+Patches are installed during specific kubemarine migration procedure. Information about it can be found in [migration procedure guide](/documentation/Maintenance.md#kubemarine-migration-procedure).
+
+## How to write your own patch
+
+Patches are described in special [folder](/kubemarine/patches).  
+
+Every patch is an inheritor of [abstract Patch class](/kubemarine/core/patch.py) that has one field and two methods to implement:
+* **identifier** is unique name of patch, that is used to reqognize it and call if needed;
+* **description** is method that returns text description of patch. This method is used in `migrate_kubemarine --describe patch` operation;
+* **action** is method that returns special implementation of [abstract Action](/kubemarine/core/action.py) class there code of patch is placed.
+
+To enable patch you should add this patch to [special list](/kubemarine/patches/__init__.py#L26). The order of patches there are correspond with the patch  execution order.
+
+## Example
+
+Example of patch you can find in [kubemarine release 0.4.0](https://github.com/Netcracker/KubeMarine/tree/0.4.0/kubemarine/patches).

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -22,7 +22,9 @@ The whole directory is automatically cleared and reset after new version of Kube
 from typing import List
 
 from kubemarine.core.patch import Patch
+from kubemarine.patches.p1_upgrade_calico_version import UpgrateCalicoVersion
 
 patches: List[Patch] = [
+    UpgrateCalicoVersion()
 ]
 """List of patches which can be executed strictly in the declared order"""

--- a/kubemarine/patches/p1_upgrade_calico_version.py
+++ b/kubemarine/patches/p1_upgrade_calico_version.py
@@ -1,0 +1,54 @@
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kubemarine.core import flow
+from kubemarine.core.action import Action
+from kubemarine.core.patch import Patch
+from kubemarine.core.resources import DynamicResources
+from kubemarine import plugins 
+
+
+class TheAction(Action):
+    def __init__(self):
+        super().__init__("Upgrade calico version")
+
+    def run(self, res: DynamicResources):
+        cluster = res.cluster()
+
+        version = cluster.inventory['services']['kubeadm']['kubernetesVersion']
+        if '.'.join(version.split('.')[:-1]) in ['v1.22', 'v1.23', 'v1.24']:
+            calico_plugin = cluster.inventory['plugins']['calico']
+            if not calico_plugin.get('install', False) or calico_plugin.get('installation', {}).get('procedures') is None:
+                cluster.log.debug("Calico plugin is disabled or its procedures aren't defined")
+            else:
+                cluster.log.debug(f"The following plugins will be installed: calico")
+                plugins.install_plugin(cluster, 'calico', calico_plugin['installation']['procedures'])
+        else:
+            cluster.log.debug(f"Skip opgrate for kubernetes version {version}")
+
+
+class UpgrateCalicoVersion(Patch):
+    def __init__(self):
+        super().__init__("upgrade_calico_version")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return """\
+Upgrade calico plugin to v3.24.1 for kubernetes clusters on v1.22.X or v1.23.X or v1.24.X.
+Note that you may probably need to update plugins.calico section preliminarily.
+Equivalent to 'kubemarine install --tasks=deploy_plugins' for that clusters."""

--- a/kubemarine/patches/p1_upgrade_calico_version.py
+++ b/kubemarine/patches/p1_upgrade_calico_version.py
@@ -51,4 +51,4 @@ class UpgrateCalicoVersion(Patch):
         return """\
 Upgrade calico plugin to v3.24.1 for kubernetes clusters on v1.22.X or v1.23.X or v1.24.X.
 Note that you may probably need to update plugins.calico section preliminarily.
-Equivalent to 'kubemarine install --tasks=deploy_plugins' for that clusters."""
+Equivalent to 'kubemarine install --tasks=deploy.plugins' for that clusters."""


### PR DESCRIPTION
### Description
During release 0.7.0 we upgrade recommended calico version for kubernetes clusters 1.22.X, 1.23.X and 1.24.X.
For this reason we should add special migration action for automatic update from kubemarine 0.6.0 to 0.7.0.

### Solution
Special patch was added. This patch upgrade calico version to 3.24.1 for clusters with version 1.22.X, 1.23.X and 1.24.X.

### How to apply
* [Install task/s with calico version 3.22](documentation/Installation.md#installation-tasks-description)
* [Migrate kubemarine](documentation/Maintenance.md#kubemarine-migration-procedure)

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


