### PR TITLE
[MANOPD-80329] Do not remove default sections from finalized inventory

### DIFF
--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -365,8 +365,6 @@ def recursive_apply_defaults(defaults, section):
                     default_value = deepcopy(section[key])
                     section[value][custom_key] = default_merger.merge(default_value, custom_value)
 
-            del section[key]
-
 
 def calculate_node_names(inventory, cluster):
     roles_iterators = {}


### PR DESCRIPTION
### Description
If use cluster_finalized.yaml as a source inventory file and run `add_node` procedure, then it is always necessary to specify `keyfile` in new node inventory because `node_defaults` section is absent.

### Solution
Do not remove [node_defaults](https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#node_defaults), [account_defaults](https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#rbac-account_defaults), [plugin_defaults](https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#plugin_defaults) defaults sections from finalized inventory. This is safe because applying of defaults is an idempotent operation: once applied, the corresponding section in inventory will always redefine the defaults.

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Contains `node_defaults` section with `keyfile`

Steps:

1. Run `install` procedure
2. Take cluster_finalized.yaml from previous step and use it as a source inventory.
3. Run `add_node` procedure not specifying `keyfile` in the inventory of new node.

Results:

| Before | After |
| ------ | ------ |
| There is no keyfile specified in configfile for node | Node successfully added |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
