### PR TITLE
Fix calico paas check

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1054,7 +1054,7 @@ def calico_config_check(cluster):
         result = result.get_simple_out()
         result = yaml.safe_load(result)
         for env in result["spec"]["template"]["spec"]["containers"][0]["env"]:
-            if cluster.inventory["plugins"]["calico"]["env"].get(env["name"]):
+            if cluster.inventory["plugins"]["calico"]["env"].get(env["name"]) and ("value" in env.keys()):
                 if not str(cluster.inventory["plugins"]["calico"]["env"].get(env["name"])) == env["value"]:
                     correct_config = False
         if not correct_config:

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1054,8 +1054,10 @@ def calico_config_check(cluster):
         result = result.get_simple_out()
         result = yaml.safe_load(result)
         for env in result["spec"]["template"]["spec"]["containers"][0]["env"]:
-            if cluster.inventory["plugins"]["calico"]["env"].get(env["name"]) and ("value" in env.keys()):
-                if not str(cluster.inventory["plugins"]["calico"]["env"].get(env["name"])) == env["value"]:
+            if cluster.inventory["plugins"]["calico"]["env"].get(env["name"]):
+                if "value" in env.keys() and not str(cluster.inventory["plugins"]["calico"]["env"].get(env["name"])) == env["value"]:
+                    correct_config = False
+                if "valueFrom" in env.keys() and len(DeepDiff(cluster.inventory["plugins"]["calico"]["env"].get(env["name"]), env["valueFrom"], ignore_order=True)) != 0:
                     correct_config = False
         if not correct_config:
             message += "calico-node env configuration is outdated\n"

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -482,7 +482,7 @@ plugins:
       DATASTORE_TYPE: kubernetes
       WAIT_FOR_DATASTORE: true
       CLUSTER_TYPE: k8s,bgp
-      CALICO_ROUTER_ID: '{% if not services.kubeadm.networking.podSubnet|isipv4 %}hash{% endif %}'
+      CALICO_ROUTER_ID: '{% if not services.kubeadm.networking.podSubnet|isipv4 %}hash{% else %}{% endif %}'
       IP: '{% if services.kubeadm.networking.podSubnet|isipv4 %}autodetect{% else %}none{% endif %}'
       IP_AUTODETECTION_METHOD: first-found
       CALICO_IPV4POOL_IPIP: '{% if plugins.calico.mode | default("vxlan") == "ipip" and services.kubeadm.networking.podSubnet|isipv4 %}Always{% else %}Never{% endif %}'

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -482,7 +482,7 @@ plugins:
       DATASTORE_TYPE: kubernetes
       WAIT_FOR_DATASTORE: true
       CLUSTER_TYPE: k8s,bgp
-      CALICO_ROUTER_ID: '{% if not services.kubeadm.networking.podSubnet|isipv4 %}hash{% else %}{% endif %}'
+      CALICO_ROUTER_ID: '{% if not services.kubeadm.networking.podSubnet|isipv4 %}hash{% endif %}'
       IP: '{% if services.kubeadm.networking.podSubnet|isipv4 %}autodetect{% else %}none{% endif %}'
       IP_AUTODETECTION_METHOD: first-found
       CALICO_IPV4POOL_IPIP: '{% if plugins.calico.mode | default("vxlan") == "ipip" and services.kubeadm.networking.podSubnet|isipv4 %}Always{% else %}Never{% endif %}'

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -505,6 +505,7 @@ plugins:
             key: typha_service_name
       NODENAME:
           fieldRef:
+            apiVersion: v1
             fieldPath: spec.nodeName
       CALICO_NETWORKING_BACKEND:
           configMapKeyRef:


### PR DESCRIPTION
### Description
In 0.7.1 check_paas procedure starts failing on the 224 check (Calico configfuration check).

Fixes # (issue)


### Solution
New approach to calico envs definition is introduced in v0.7.1. According to that an env can look like
```
      NODENAME:
          fieldRef:
            fieldPath: spec.nodeName
```
which doesn't fit to the condition https://github.com/Netcracker/KubeMarine/blob/dcc7040664fad54cbfcf2e8dacbb8abe996f3bf1/kubemarine/procedures/check_paas.py#L1058
```
                if not str(cluster.inventory["plugins"]["calico"]["env"].get(env["name"])) == env["value"]:
```

### How to apply

### Test Cases
Run check_paas procedure. The check 224 should run with "valid" result.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


