### PR TITLE
[MANOPD-80122] check_paas DR clusters connectivity checks

### DIFF
--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -543,7 +543,7 @@ The test checks status of Pod Security Admissions, default PSS(Pod Security Stan
 *Task*: `geo_monitor`
 
 The task checks status of DNS resolving, pod-to-service and pod-to-pod connectivity between cluster in geographically
-distributed schemas. This task works only if `procedure_config` is provided with information about `paas-geo-monitor`,
+distributed schemas. This task works only if procedure config file is provided with information about `paas-geo-monitor`,
 at least service name and namespace. For example:
 ```yaml
 geo-monitor:

--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -57,6 +57,7 @@ This section provides information about the Kubecheck functionality.
     - [223 Default services health status](#223-default-services-health-status)
     - [224 Calico configuration check](#224-calico-configuration-check)
     - [225 Pod security admission status](#225-pod-security-admission-status)
+    - [226 Geo connectivity status](#226-geo-connectivity-status)
 - [Report File Generation](#report-file-generation)
   - [HTML Report](#html-report)
   - [CSV Report](#csv-report)
@@ -105,12 +106,18 @@ The final report is generated in a file. For more information, see [Report File 
 Check procedure execution form CLI can be started with the following command:
 
 ```bash
-kubemarine check %{CHECK_TYPE}
-kubemarine check iaas
-kubemarine check paas
+kubemarine check_iaas
+kubemarine check_paas
 ```
 
 It begins the execution of all tasks available in the procedure in accordance with the procedure type. For more information about how a tasks list can be redefined, see [Tasks List Redefinition](Installation.md#tasks-list-redefinition) in _Kubemarine Installation Procedure_.
+
+**Note:** some `paas` checks work only if additional configuration is provided through `--procedure_config` yaml file.
+Without additional configuration, such checks will be skipped without warning. 
+See particular check documentation for configuration format. Following is an example of passing procedure config:
+```bash
+kubemarine check_paas --procedure_config=procedure.yaml
+```
 
 ### Check Procedures
 
@@ -530,6 +537,21 @@ This test checks the configuration of the `calico-node` envs, Calico's ConfigMap
 *Task*: `kubernetes.admission`
 
 The test checks status of Pod Security Admissions, default PSS(Pod Security Standards) profile and match consistance between 'cluster.yaml' and current Kubernetes configuration. Also it check consistancy between 'kube-apiserver.yaml' and 'kubeadm-config'.
+
+###### 226 Geo connectivity status
+
+*Task*: `geo_monitor`
+
+The task checks status of DNS resolving, pod-to-service and pod-to-pod connectivity between cluster in geographically
+distributed schemas. This task works only if `procedure_config` is provided with information about `paas-geo-monitor`,
+at least service name and namespace. For example:
+```yaml
+geo-monitor:
+  namespace: site-manager
+  service: paas-geo-monitor
+```
+
+For more information about `paas-geo-monitor` service, refer to DRNavigator repository.
 
 ### Report File Generation
 

--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -112,11 +112,11 @@ kubemarine check_paas
 
 It begins the execution of all tasks available in the procedure in accordance with the procedure type. For more information about how a tasks list can be redefined, see [Tasks List Redefinition](Installation.md#tasks-list-redefinition) in _Kubemarine Installation Procedure_.
 
-**Note:** some `paas` checks work only if additional configuration is provided through `--procedure_config` yaml file.
+**Note:** some `paas` checks work only if additional configuration file is provided.
 Without additional configuration, such checks will be skipped without warning. 
-See particular check documentation for configuration format. Following is an example of passing procedure config:
+See particular check documentation for configuration format. Following is an example of passing procedure config file:
 ```bash
-kubemarine check_paas --procedure_config=procedure.yaml
+kubemarine check_paas procedure.yaml
 ```
 
 ### Check Procedures

--- a/kubemarine/core/flow.py
+++ b/kubemarine/core/flow.py
@@ -316,7 +316,7 @@ def new_procedure_parser(cli_help, optional_config=False):
 
     help_msg = 'config file for the procedure'
     if optional_config:
-        parser.add_argument('--procedure_config', type=str, help=help_msg)
+        parser.add_argument('procedure_config', metavar='procedure_config', type=str, help=help_msg, nargs='?')
     else:
         parser.add_argument('procedure_config', metavar='procedure_config', type=str, help=help_msg)
 

--- a/kubemarine/core/flow.py
+++ b/kubemarine/core/flow.py
@@ -311,11 +311,14 @@ def new_tasks_flow_parser(cli_help):
     return parser
 
 
-def new_procedure_parser(cli_help):
+def new_procedure_parser(cli_help, optional_config=False):
     parser = new_tasks_flow_parser(cli_help)
 
-    parser.add_argument('procedure_config', metavar='procedure_config', type=str,
-                        help='config file for the procedure')
+    help_msg = 'config file for the procedure'
+    if optional_config:
+        parser.add_argument('--procedure_config', type=str, help=help_msg)
+    else:
+        parser.add_argument('procedure_config', metavar='procedure_config', type=str, help=help_msg)
 
     return parser
 

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1183,7 +1183,7 @@ def geo_monitor(cluster):
             status = neighbor["clusterIpStatus"]
             if not status["dnsStatus"]["resolved"]:
                 failed.append(f'Unable to resolve neighbor ({neighbor["name"]}) service '
-                              f'name: {status["clusterIp"]["name"]}')
+                              f'name: {status["name"]}')
                 continue
             if not status["svcStatus"]["available"]:
                 failed.append(f'Neighbor ({neighbor["name"]}) service address '

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1183,15 +1183,17 @@ def geo_monitor(cluster):
             status = neighbor["clusterIpStatus"]
             if not status["dnsStatus"]["resolved"]:
                 failed.append(f'Unable to resolve neighbor ({neighbor["name"]}) service '
-                              f'name: {status["name"]}')
+                              f'name: {status["name"]}, error: {status["dnsStatus"]["error"]}')
                 continue
             if not status["svcStatus"]["available"]:
                 failed.append(f'Neighbor ({neighbor["name"]}) service address '
-                              f'is not reachable: {status["svcStatus"]["address"]}')
+                              f'ping failed: {status["svcStatus"]["address"]}, '
+                              f'error: {status["svcStatus"]["error"]}')
                 continue
             if not status["podStatus"]["available"]:
                 failed.append(f'Neighbor ({neighbor["name"]}) pod address '
-                              f'is not reachable: {status["podStatus"]["address"]}')
+                              f'ping failed: {status["podStatus"]["address"]}, '
+                              f'error: {status["podStatus"]["error"]}')
                 continue
 
         if failed:

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1149,7 +1149,7 @@ def geo_monitor(cluster):
     This test only work if "procedure.yaml" has "geo-monitor" section filled.
     """
     if not cluster.procedure_inventory or not cluster.procedure_inventory.get("geo-monitor"):
-        # skip this check silently if configuration is not provided
+        cluster.log.debug("Geo connectivity check is skipped, no configuration provided")
         return
 
     with TestCase(cluster.context['testsuite'], '226', "Geo Monitor", "Geo connectivity") as tc:

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1148,10 +1148,11 @@ def geo_monitor(cluster):
     This test checks connectivity between clusters in geo schemas using paas-geo-monitor service.
     This test only work if "procedure.yaml" has "geo-monitor" section filled.
     """
-    with TestCase(cluster.context['testsuite'], '226', "Geo Monitor", "Geo connectivity") as tc:
-        if not cluster.procedure_inventory or not cluster.procedure_inventory.get("geo-monitor"):
-            raise TestWarn("Skipped", hint="no geo-monitor information is provided in procedure inventory")
+    if not cluster.procedure_inventory or not cluster.procedure_inventory.get("geo-monitor"):
+        # skip this check silently if configuration is not provided
+        return
 
+    with TestCase(cluster.context['testsuite'], '226', "Geo Monitor", "Geo connectivity") as tc:
         geo_monitor_inventory = cluster.procedure_inventory["geo-monitor"]
         if geo_monitor_inventory.get("namespace") is None or geo_monitor_inventory.get("service") is None:
             raise TestFailure("Configuration error",

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1152,10 +1152,16 @@ def geo_check(cluster):
         cluster.log.debug("Geo connectivity check is skipped, no configuration provided")
         return
 
-    with TestCase(cluster.context['testsuite'], '226', "Geo Monitor", "Geo connectivity") as tc:
+    collected_results = {
+        "statusCollected": False,
+        "dnsStatus": {"failed": []},
+        "svcStatus": {"failed": [], "skipped": []},
+        "podStatus": {"failed": [], "skipped": []}
+    }
+    with TestCase(cluster.context['testsuite'], '226', "Geo Monitor", "Collect status") as tc_collect:
         geo_monitor_inventory = cluster.procedure_inventory["geo-monitor"]
         if geo_monitor_inventory.get("namespace") is None or geo_monitor_inventory.get("service") is None:
-            raise TestFailure("Configuration error",
+            raise TestFailure("configuration error",
                               hint="geo-monitor namespace and/or service name is not provided in procedure inventory")
 
         namespace = geo_monitor_inventory["namespace"]
@@ -1176,29 +1182,55 @@ def geo_check(cluster):
 
         peers = yaml.safe_load(io.StringIO(peers_result))
         if len(peers) == 0:
-            raise TestFailure("Configuration error", hint="geo-monitor instance has no peers")
+            raise TestFailure("configuration error", hint="geo-monitor instance has no peers")
 
-        failed = []
         for peer in peers:
             status = peer["clusterIpStatus"]
             if not status["dnsStatus"]["resolved"]:
-                failed.append(f'Unable to resolve peer ({peer["name"]}) service '
-                              f'name: {status["name"]}, error: {status["dnsStatus"]["error"]}')
+                error = f'FAILED DNS resolving for peer ({peer["name"]}) service ' \
+                        f'name: {status["name"]}, error: {status["dnsStatus"]["error"]}'
+                collected_results["dnsStatus"]["failed"].append(error)
+                collected_results["svcStatus"]["skipped"].append(error)
+                collected_results["podStatus"]["skipped"].append(error)
                 continue
             if not status["svcStatus"]["available"]:
-                failed.append(f'peer ({peer["name"]}) service address '
-                              f'ping failed: {status["svcStatus"]["address"]}, '
-                              f'error: {status["svcStatus"]["error"]}')
+                error = f'FAILED ping service for peer ({peer["name"]}), ' \
+                        f'address: {status["svcStatus"]["address"]}, error: {status["svcStatus"]["error"]}'
+                collected_results["svcStatus"]["failed"].append(error)
+                collected_results["podStatus"]["skipped"].append(error)
                 continue
             if not status["podStatus"]["available"]:
-                failed.append(f'peer ({peer["name"]}) pod address '
-                              f'ping failed: {status["podStatus"]["address"]}, '
-                              f'error: {status["podStatus"]["error"]}')
+                error = f'FAILED ping pod for peer ({peer["name"]}), ' \
+                        f'address: {status["podStatus"]["address"]}, error: {status["podStatus"]["error"]}'
+                collected_results["podStatus"]["failed"].append(error)
                 continue
 
-        if failed:
-            raise TestFailure("found failed statuses", hint=failed)
-        tc.success(results="all checks passed")
+        collected_results["statusCollected"] = True
+        tc_collect.success(results="peers data collected")
+
+    if not collected_results["statusCollected"]:
+        return
+
+    with TestCase(cluster.context['testsuite'], '226.1', "Geo Monitor", "DNS resolving") as tc_dns:
+        if collected_results["dnsStatus"]["failed"]:
+            raise TestFailure("found failed DNS statuses", hint=collected_results["dnsStatus"]["failed"])
+        tc_dns.success("all peer names resolved")
+
+    with TestCase(cluster.context['testsuite'], '226.2', "Geo Monitor", "Pod-to-service") as tc_svc:
+        if collected_results["svcStatus"]["failed"]:
+            raise TestFailure("found unavailable peer services",
+                              hint=collected_results["svcStatus"]["failed"]+collected_results["svcStatus"]["skipped"])
+        if collected_results["svcStatus"]["skipped"]:
+            raise TestWarn("found skipped peer services", hint=collected_results["svcStatus"]["skipped"])
+        tc_svc.success("all peer services available")
+
+    with TestCase(cluster.context['testsuite'], '226.3', "Geo Monitor", "Pod-to-pod") as tc_pod:
+        if collected_results["podStatus"]["failed"]:
+            raise TestFailure("found unavailable peer pod",
+                              hint=collected_results["podStatus"]["failed"]+collected_results["podStatus"]["skipped"])
+        if collected_results["podStatus"]["skipped"]:
+            raise TestWarn("found skipped peer pods", hint=collected_results["podStatus"]["skipped"])
+        tc_pod.success("all peer pods available")
 
 
 tasks = OrderedDict({


### PR DESCRIPTION
### Description
Added `check_paas` check which tests cross-clusters connectivity in DR schemas. This check uses `paas-geo-monitor` service from DRNavigator.


### Solution
* `check_paas` now supports optional procedure.yaml
* new optional check `geo_monitor` is added
* documentation is updated accordingly


### Test Cases

**TestCase 1**

Test Configuration:

- Two clusters in DR schema

Steps:

1. Run `check_paas` procedure with procedure.yaml for the new `geo_monitor` check

Results:

| Before | After |
| ------ | ------ |
| -  | cross-cluster dns/connectivity check is performed |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts