### PR TITLE
Apparmor check_paas

### DIFF
--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -58,6 +58,8 @@ This section provides information about the Kubecheck functionality.
     - [224 Calico configuration check](#224-calico-configuration-check)
     - [225 Pod security admission status](#225-pod-security-admission-status)
     - [226 Geo connectivity status](#226-geo-connectivity-status)
+    - [227 Apparmor status](#227-apparmor-status)
+    - [228 Apparmor configuration](#228-apparmor-configuration)
 - [Report File Generation](#report-file-generation)
   - [HTML Report](#html-report)
   - [CSV Report](#csv-report)
@@ -552,6 +554,18 @@ geo-monitor:
 ```
 
 For more information about `paas-geo-monitor` service, refer to DRNavigator repository.
+
+###### 227 AppArmor status
+
+*Task*: `services.security.apparmor.status`
+
+The test checks the status of AppArmor. It should be `enabled` by default.
+
+###### 228 AppArmor configuration
+
+*Task*: `services.security.apparmor.config`
+
+The test checks the AppArmor configuration. It has several modes: `enforce`, `complain`, and `disable`. The profiles (resources) stick to one of the modes. The `cluster.yaml` may incude only part of the profiles.
 
 ### Report File Generation
 

--- a/kubemarine/apparmor.py
+++ b/kubemarine/apparmor.py
@@ -30,9 +30,10 @@ def get_status(group):
     log = group.cluster.log
     result = group.sudo("apparmor_status --json")
     parsed_result = {}
-    for connection, node_result in result.items():
-        log.verbose('Parsing status for %s...' % connection.host)
-        parsed_result[connection] = parse_status(node_result.stdout)
+    if result:
+        for connection, node_result in result.items():
+            log.verbose('Parsing status for %s...' % connection.host)
+            parsed_result[connection] = parse_status(node_result.stdout)
     print_status(log, parsed_result)
     return parsed_result
 

--- a/kubemarine/apparmor.py
+++ b/kubemarine/apparmor.py
@@ -92,13 +92,6 @@ def is_state_valid(group, expected_profiles):
                         valid = False
                         log.verbose('Profile %s is not enabled in %s mode on remote host %s' % (profile, state, connection.host))
                         break
-                # check if some settings on particular node do not match with 'cluster.yaml'
-                for profile in status[state]:
-                    if profile not in profiles:
-                        valid = False
-                        log.verbose("Profile %s is enabled in %s mode on remote host %s but doesn't in 'cluster.yaml'"
-                                 % (profile, state, connection.host))
-                        break
 
     return valid, parsed_result
 

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -24,7 +24,7 @@ import ruamel.yaml
 import ipaddress
 import uuid
 
-from kubemarine import packages as pckgs, system, selinux, etcd, thirdparties
+from kubemarine import packages as pckgs, system, selinux, etcd, thirdparties, apparmor
 from kubemarine.core.action import Action
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.resources import DynamicResources
@@ -1231,6 +1231,59 @@ def geo_check(cluster):
         tc_pod.success("all peer pods available")
 
 
+def verify_apparmor_status(cluster: KubernetesCluster) -> None:
+    """
+    This method is a test, which checks the status of Apparmor.
+    This test is applicable only for systems of the Debian family.
+    :param cluster: KubernetesCluster object
+    :return: None
+    """
+    if system.get_os_family(cluster) in ['rhel', 'rhel8']:
+        return
+
+    with TestCase(cluster.context['testsuite'], '226', "Security", "Apparmor security policy") as tc:
+        group = cluster.nodes['all'].get_accessible_nodes()
+        results = group.sudo("aa-enabled")
+        enabled_nodes = []
+        invalid_nodes = []
+        for connection, item in results.items():
+            apparmor_status = item.stdout
+            cluster.log.warning(f"Apparmor on node: {connection.host} enabled: {apparmor_status}")
+            if apparmor_status ==  "Yes":
+                enabled_nodes.append(connection.host)
+            else:
+                enabled_nodes.append(connection.host)
+        if group.nodes_amount() == len(enabled_nodes):
+            tc.success(results='enabled')
+        else:
+            raise TestFailure(f"Apparmor does not properly configured on the following nodes: {invalid_nodes}")
+
+
+def verify_apparmor_config(cluster: KubernetesCluster) -> None:
+    """
+    This method tests if the Apparmor configuration matches to 'cluster.yaml' spec.
+    This test is applicable only for systems of the Debian family.
+    :param cluster: KubernetesCluster object
+    :return: None
+    """
+    if system.get_os_family(cluster) in ['rhel', 'rhel8']:
+        return
+
+    with TestCase(cluster.context['testsuite'], '227', "Security", "Apparmor security policy") as tc:
+        expected_profiles = cluster.inventory['services']['kernel_security'].get('apparmor', {})
+        group = cluster.nodes['all'].get_accessible_nodes()
+        if expected_profiles:
+            apparmor_configured, result = apparmor.is_state_valid(group, expected_profiles)
+            if apparmor_configured:
+                cluster.log.verbose(f"Apparmor is configured properly on cluster")
+                tc.success(results='valid')
+            else:
+                raise TestFailure('invalid',
+                        hint=f"Some nodes do not have properly configured Apparmor service")
+        else:
+            tc.success(results='skipped')
+
+
 tasks = OrderedDict({
     'services': {
         'security': {
@@ -1238,11 +1291,10 @@ tasks = OrderedDict({
                 'status': verify_selinux_status,
                 'config': verify_selinux_config
             },
-            # TODO: support apparmor validation
-            # 'apparmor': {
-            #     'status': None,
-            #     'config': None
-            # },
+            'apparmor': {
+                'status': verify_apparmor_status,
+                'config': verify_apparmor_config
+            },
             'firewalld': {
                 'status': verify_firewalld_status
             }

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1241,7 +1241,7 @@ def verify_apparmor_status(cluster: KubernetesCluster) -> None:
     if system.get_os_family(cluster) in ['rhel', 'rhel8']:
         return
 
-    with TestCase(cluster.context['testsuite'], '226', "Security", "Apparmor security policy") as tc:
+    with TestCase(cluster.context['testsuite'], '227', "Security", "Apparmor security policy") as tc:
         group = cluster.nodes['all'].get_accessible_nodes()
         results = group.sudo("aa-enabled")
         enabled_nodes = []
@@ -1269,7 +1269,7 @@ def verify_apparmor_config(cluster: KubernetesCluster) -> None:
     if system.get_os_family(cluster) in ['rhel', 'rhel8']:
         return
 
-    with TestCase(cluster.context['testsuite'], '227', "Security", "Apparmor security policy") as tc:
+    with TestCase(cluster.context['testsuite'], '228', "Security", "Apparmor security policy") as tc:
         expected_profiles = cluster.inventory['services']['kernel_security'].get('apparmor', {})
         group = cluster.nodes['all'].get_accessible_nodes()
         if expected_profiles:


### PR DESCRIPTION
### Description
* Apparmor validations and checks are necessary 

Resolves https://github.com/Netcracker/KubeMarine/issues/34


### Solution
* Implement new tasks to `check_paas` for Apparmor status and configuration
* Implement `TODO` part in `system` module
* Fix `is_state_valid` and `parse_status` methods


### How to apply
Not applicable


### Test Cases

**TestCase 1**
Check if the `check_paas` tasks work

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 20.04
- Inventory: Allinone

Steps:

1. Install Kubernetes cluster with Apparmor is enabled.
2. Run `check_paas` with tasks `services.security.apparmor`
3. Change Apparmor configuration on host.
4. Run `check_paas` with tasks `services.security.apparmor`
5. Disable Apparmor on host.
6. Run `check_paas` with tasks `services.security.apparmor`

Results:

| Before | After |
| ------ | ------ |
| Not available | Apparmor is enabled, configuration is valid |
| Not available | Apparmor is enabled, configuration is invalid |
| Not available | Apparmor is disabled, configuration is invalid |

**TestCase 2**
Check if the validation works

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 20.04
- Inventory: Allinone

Steps:

1. Run installation Kubernetes cluster with Apparmor enabled.

Results:

| Before | After |
| ------ | ------ |
| Not available | Success |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


