### PR TITLE
Add ability to specify custom Helm release name

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -4373,6 +4373,8 @@ The `values_file` parameter specifies the absolute path on local host to the fil
 
 The `namespace` parameter specifies the cloud namespace where chart should be installed. This parameter is optional.
 
+The `release` parameter specifies target Helm release. The parameter is optional and is equal to chart name by default.
+
 **Note**:
 
 * Helm 3 is only supported.
@@ -4393,6 +4395,7 @@ plugins:
               serviceAccount:
                 create: false
             namespace: elastic-search
+            release: elastic-search-1
             values_file: /tmp/custom_values.yaml
 ```
  

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -776,6 +776,9 @@ def apply_helm(cluster: KubernetesCluster, config, plugin_name=None):
 
     cluster.log.debug("Running helm chart %s" % chart_name)
 
+    release = config.get('release', chart_name)
+    cluster.log.debug("Deploying release %s" % release)
+
     namespace = config.get('namespace')
     if not namespace:
         cluster.log.verbose('Namespace configuration is missing, "default" namespace will be used')
@@ -788,14 +791,14 @@ def apply_helm(cluster: KubernetesCluster, config, plugin_name=None):
     command = prepare_for_helm_command + 'list -q'
     helm_existed_releases = subprocess.check_output(command, shell=True).decode('utf-8')
 
-    if chart_name in helm_existed_releases.splitlines():
-        cluster.log.debug("Deployed release %s is found. Upgrading it..." % chart_name)
+    if release in helm_existed_releases.splitlines():
+        cluster.log.debug("Deployed release %s is found. Upgrading it..." % release)
         deployment_mode = "upgrade"
     else:
-        cluster.log.debug("Deployed release %s is not found. Installing it..." % chart_name)
+        cluster.log.debug("Deployed release %s is not found. Installing it..." % release)
         deployment_mode = "install"
 
-    command = prepare_for_helm_command + f'{deployment_mode} {chart_name} {chart_path} --debug'
+    command = prepare_for_helm_command + f'{deployment_mode} {release} {chart_path} --debug'
     output = subprocess.check_output(command, shell=True)
     cluster.log.debug(output.decode('utf-8'))
 


### PR DESCRIPTION
### Description
* It is not allowed to create few releases from the same Helm chart.

### Solution
* Added option `release` to allow to specify custom release name.

### Test Cases
Install Helm chart with arbitrary release.

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Any

Steps:

1. Configure Kubemarine helm plugin and specify arbitrary `release` option.

Results:

| Before | After |
| ------ | ------ |
| Release is created with Helm chart name | Release is created with supplied custom name |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
