### PR TITLE
[MANOPD-80822] change default typha settings

### DIFF
--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -473,7 +473,9 @@ plugins:
     defaultAsNumber: 64512
     globalBgpPeers: []
     typha:
+      # enabled by default for envs with nodes > 3
       enabled: '{% if (nodes|length) < 4 %}false{% else %}true{% endif %}'
+      # let's start from 2 replicas and increment it every 50 nodes
       replicas: '{{ (((nodes|length)/50) + 2) | round(1) | int }}'
       image: 'calico/typha:{{ plugins.calico.version }}'
       nodeSelector:

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -473,8 +473,8 @@ plugins:
     defaultAsNumber: 64512
     globalBgpPeers: []
     typha:
-      enabled: false
-      replicas: '{{ (((nodes|length)/50) + 1) | round(1) | int }}'
+      enabled: '{% if (nodes|length) < 4 %}false{% else %}true{% endif %}'
+      replicas: '{{ (((nodes|length)/50) + 2) | round(1) | int }}'
       image: 'calico/typha:{{ plugins.calico.version }}'
       nodeSelector:
         kubernetes.io/os: linux


### PR DESCRIPTION
### Description
For medium and large clusters it's recommended to use `typha` in `calico` deployments to decrease number of calls to kubernetes api-server.
This PR is to change default `calico` settings.

Fixes # (issue)
MANOPD-80822

### Solution
Default `calico` settings are changed. `typha` is enabled by default for clusters with more than 3 nodes and at least 2 replicas of `typha` are created for clusters with 4 nodes and more. With every 50 nodes number of `typha` replicas is incremented.

### How to apply

### Test Cases
1. Deploy `calico` with default settings to the cluster with <= 3 nodes. Check that deployment finishes successfully, no `typha` installed, pods at different nodes can see each other.
2. Deploy `calico` with default settings to the cluster with more than 3 nodes. Check that deployment finishes successfully, `typha` pods are running and ready, pods at different nodes can see each other.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests


