### PR TITLE
[MANOPD-80822] change default typha settings

### DIFF
--- a/kubemarine/jinja.py
+++ b/kubemarine/jinja.py
@@ -28,8 +28,8 @@ def new(log, root=None):
     env.filters['majorversion'] = lambda version: precompile(log, version, root).split('.')[0]
     # we need these filters because rendered cluster.yaml can contain variables like 
     # enable: 'true'
-    env.filters['is_true'] = lambda v: True if (v in ['true','True','TRUE'] or v == True) else False
-    env.filters['is_false'] = lambda v: True if (v in ['false','False','FALSE'] or v == False) else False
+    env.filters['is_true'] = lambda v: v in ['true', 'True', 'TRUE', True]
+    env.filters['is_false'] = lambda v: v in ['false', 'False', 'FALSE', False]
     return env
 
 

--- a/kubemarine/jinja.py
+++ b/kubemarine/jinja.py
@@ -26,7 +26,10 @@ def new(log, root=None):
     env.filters['isipv4'] = lambda ip: ":" not in precompile(log, ip, root)
     env.filters['minorversion'] = lambda version: ".".join(precompile(log, version, root).split('.')[0:2])
     env.filters['majorversion'] = lambda version: precompile(log, version, root).split('.')[0]
-
+    # we need these filters because rendered cluster.yaml can contain variables like 
+    # enable: 'true'
+    env.filters['is_true'] = lambda v: True if (v in ['true','True','TRUE'] or v == True) else False
+    env.filters['is_false'] = lambda v: True if (v in ['false','False','FALSE'] or v == False) else False
     return env
 
 

--- a/kubemarine/templates/plugins/calico-v3.21.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.21.yaml.j2
@@ -7,7 +7,7 @@ metadata:
   name: calico-config
   namespace: kube-system
 data:
-  typha_service_name: "{% if plugins.calico.typha.enabled | default(false) == true %}calico-typha{% else %}none{% endif %}"
+  typha_service_name: "{% if plugins.calico.typha.enabled | default(false) | is_true == true %}calico-typha{% else %}none{% endif %}"
 
   # Configure the backend to use.
   calico_backend: "bird"
@@ -4050,7 +4050,7 @@ subjects:
   name: calico-node
   namespace: kube-system
 
-{% if plugins.calico.typha.enabled | default(false) == true -%}
+{% if plugins.calico.typha.enabled | default(false) | is_true == true -%}
 ---
 # Source: calico/templates/calico-typha.yaml
 # This manifest creates a Service, which will be backed by Calico's Typha daemon.
@@ -4328,7 +4328,7 @@ spec:
             - name: {{ name_env }}
               {% if env is not mapping %}value: "{{ env }}" {% else %}valueFrom: {{ env }}{% endif %}
              {%- endif %}
-             {%- if (plugins.calico.typha.enabled | default(false) == true) and (name_env == 'FELIX_TYPHAK8SSERVICENAME') %}
+             {%- if (plugins.calico.typha.enabled | default(false) | is_true == true) and (name_env == 'FELIX_TYPHAK8SSERVICENAME') %}
             - name: FELIX_TYPHAK8SSERVICENAME
               valueFrom:
                 configMapKeyRef:

--- a/kubemarine/templates/plugins/calico-v3.22.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.22.yaml.j2
@@ -8,7 +8,7 @@ metadata:
   namespace: kube-system
 data:
   # Typha is disabled.
-  typha_service_name: "{% if plugins.calico.typha.enabled | default(false) == true %}calico-typha{% else %}none{% endif %}"
+  typha_service_name: "{% if plugins.calico.typha.enabled | default(false) | is_true == true %}calico-typha{% else %}none{% endif %}"
 
   # Configure the backend to use.
   calico_backend: "bird"
@@ -4051,7 +4051,7 @@ subjects:
   name: calico-node
   namespace: kube-system
 
-{% if plugins.calico.typha.enabled | default(false) == true -%}
+{% if plugins.calico.typha.enabled | default(false) | is_true == true -%}
 ---
 # Source: calico/templates/calico-typha.yaml
 # This manifest creates a Service, which will be backed by Calico's Typha daemon.
@@ -4335,7 +4335,7 @@ spec:
             - name: {{ name_env }}
               {% if env is not mapping %}value: "{{ env }}" {% else %}valueFrom: {{ env }}{% endif %}
              {%- endif %}
-             {%- if (plugins.calico.typha.enabled | default(false) == true) and (name_env == 'FELIX_TYPHAK8SSERVICENAME') %}
+             {%- if (plugins.calico.typha.enabled | default(false) | is_true == true) and (name_env == 'FELIX_TYPHAK8SSERVICENAME') %}
             - name: FELIX_TYPHAK8SSERVICENAME
               valueFrom:
                 configMapKeyRef:

--- a/kubemarine/templates/plugins/calico-v3.24.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.24.yaml.j2
@@ -54,7 +54,7 @@ metadata:
   namespace: kube-system
 data:
   # You must set a non-zero value for Typha replicas below.
-  typha_service_name: "{% if plugins.calico.typha.enabled | default(false) == true %}calico-typha{% else %}none{% endif %}"
+  typha_service_name: "{% if plugins.calico.typha.enabled | default(false) | is_true == true %}calico-typha{% else %}none{% endif %}"
   # Configure the backend to use.
   calico_backend: "bird"
 
@@ -4365,7 +4365,7 @@ subjects:
   name: calico-node
   namespace: kube-system
 
-{% if plugins.calico.typha.enabled | default(false) == true -%}
+{% if plugins.calico.typha.enabled | default(false) | is_true == true -%}
 ---
 # Source: calico/templates/calico-typha.yaml
 # This manifest creates a Service, which will be backed by Calico's Typha daemon.
@@ -4661,7 +4661,7 @@ spec:
             - name: {{ name_env }}
               {% if env is not mapping %}value: "{{ env }}" {% else %}valueFrom: {{ env }}{% endif %}
              {%- endif %}
-             {%- if (plugins.calico.typha.enabled | default(false) == true) and (name_env == 'FELIX_TYPHAK8SSERVICENAME') %}
+             {%- if (plugins.calico.typha.enabled | default(false) | is_true == true) and (name_env == 'FELIX_TYPHAK8SSERVICENAME') %}
             - name: FELIX_TYPHAK8SSERVICENAME
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
### Description
For medium and large clusters it's recommended to use `typha` in `calico` deployments to decrease number of calls to kubernetes api-server.
This PR is to change default `calico` settings.

Fixes # (issue)
MANOPD-80822

### Solution
Default `calico` settings are changed. `typha` is enabled by default for clusters with more than 3 nodes and at least 2 replicas of `typha` are created for clusters with 4 nodes and more. With every 50 nodes number of `typha` replicas is incremented.

2 additional jinja filters were created: `is_true` and `is_false`. They are added to the calico templates in the conditions which test `calico.typha.enabled` value. It's necessary because yaml parser considers `'true'` value as a string, not as a boolean variable.

### How to apply

### Test Cases
1. Deploy `calico` with default settings to the cluster with <= 3 nodes. Check that deployment finishes successfully, no `typha` installed, pods at different nodes can see each other.
2. Deploy `calico` with default settings to the cluster with more than 3 nodes. Check that deployment finishes successfully, `typha` pods are running and ready, pods at different nodes can see each other.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests


