### PR TITLE
MANOPD-81038 MANOPD-78302 Refactoring and fixes of OS/package versions

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -1901,7 +1901,11 @@ The following associations are used by default:
 
 **Notes**: 
 * By default, the packages' versions are installed according to the Kubernetes version specified in the [Supported versions](#supported-versions) section.
-* In the procedure for adding nodes, the package versions are taken from the current nodes in order to match the nodes in the cluster. For example, if `containerd.io-1.6.4-1` is installed on the nodes of the cluster, this version is installed on the new node. This behavior can be changed by setting the `cache_versions` option to `false`. The package versions are then used only with the template from the `associations` section.
+* In the procedure for adding nodes, the package versions are taken from the current nodes in order to match the nodes in the cluster.
+  For example, if `containerd.io-1.6.4-1` is installed on the nodes of the cluster, this version is installed on the new node.
+  This behavior can be changed by setting the `cache_versions` option to `false`.
+  The package versions are then used only with the template from the `associations` section.
+  The option can be used both in global `services.packages` and in specific associations sections.
 
 The following is an example of overriding docker associations:
 
@@ -1911,6 +1915,7 @@ services:
     cache_versions: true
     associations:
       docker:
+        cache_versions: false
         executable_name: 'docker'
         package_name:
           - docker-ce-19*
@@ -4880,6 +4885,10 @@ After any procedure is completed, a final inventory with all the missing variabl
 This inventory can be found in the `cluster_finalized.yaml` file in the working directory,
 and can be passed as a source inventory in future runs of KubeMarine procedures.
 
+**Note**: `cluster_finalized.yaml` inventory file is aimed to reflect current cluster state together with the KubeMarine version by which it is created.
+This in particular means that the file cannot be directly used with different KubeMarine version.
+Though, it still can be migrated together with the managed cluster using [Kubemarine Migration Procedure](/documentation/Maintenance.md#kubemarine-migration-procedure).
+
 In the file, you can see not only the compiled inventory, but also some converted values depending on what is installed on the cluster.
 For example, consider the following package's origin configuration:
 
@@ -4904,20 +4913,21 @@ services:
       - policycoreutils-python-utils
 ```
 
-The above configuration is converted to the following finalized configuration:
+The above configuration is converted to the following finalized configuration provided that the cluster is based on RHEL nodes:
 
 ```yaml
 services:
   packages:
     associations:
-      docker:
-        executable_name: 'docker'
-        package_name:
-          - docker-ce-19.03.15-3.el7.x86_64
-          - docker-ce-cli-19.03.15-3.el7.x86_64
-          - containerd.io-1.4.6-3.1.el7.x86_64
-        service_name: 'docker'
-        config_location: '/etc/docker/daemon.json'
+      rhel:
+        docker:
+          executable_name: 'docker'
+          package_name:
+            - docker-ce-19.03.15-3.el7.x86_64
+            - docker-ce-cli-19.03.15-3.el7.x86_64
+            - containerd.io-1.4.6-3.1.el7.x86_64
+          service_name: 'docker'
+          config_location: '/etc/docker/daemon.json'
     install:
       include:
         - conntrack
@@ -4929,6 +4939,11 @@ services:
 ```
 
 **Note**: Some of the packages are impossible to be detected in the system, therefore such packages remain unchanged.
+The same rule is applied if two different package versions are detected on different nodes.
+See also `cache_versions` option in [associations](#associations) section.
+
+**Note**: After some time is passed, the detected packages versions might disappear from the repository.
+Direct using of the `cluster_finalized.yaml` file in procedures like `install` or `add_node` might be impossible due to this reason and would require manual intervention.
 
 The same applies to the VRRP interfaces. For example, the following origin configuration without interfaces:
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -1901,9 +1901,9 @@ The following associations are used by default:
 
 **Notes**: 
 * By default, the packages' versions are installed according to the Kubernetes version specified in the [Supported versions](#supported-versions) section.
-* In the procedure for adding nodes, the package versions are taken from the current nodes in order to match the nodes in the cluster.
+* In the procedure for adding nodes, the package versions are taken from the current nodes to match the nodes in the cluster.
   For example, if `containerd.io-1.6.4-1` is installed on the nodes of the cluster, this version is installed on the new node.
-  This behavior can be changed by setting the `cache_versions` option to `false`.
+  This behavior can be changed by setting the `cache_versions` option to "false".
   The package versions are then used only with the template from the `associations` section.
   The option can be used both in global `services.packages` and in specific associations sections.
 
@@ -4885,9 +4885,9 @@ After any procedure is completed, a final inventory with all the missing variabl
 This inventory can be found in the `cluster_finalized.yaml` file in the working directory,
 and can be passed as a source inventory in future runs of KubeMarine procedures.
 
-**Note**: `cluster_finalized.yaml` inventory file is aimed to reflect current cluster state together with the KubeMarine version by which it is created.
-This in particular means that the file cannot be directly used with different KubeMarine version.
-Though, it still can be migrated together with the managed cluster using [Kubemarine Migration Procedure](/documentation/Maintenance.md#kubemarine-migration-procedure).
+**Note**: The `cluster_finalized.yaml` inventory file is aimed to reflect the current cluster state together with the KubeMarine version using which it is created.
+This in particular means that the file cannot be directly used with a different KubeMarine version.
+Though, it still can be migrated together with the managed cluster using the [Kubemarine Migration Procedure](/documentation/Maintenance.md#kubemarine-migration-procedure).
 
 In the file, you can see not only the compiled inventory, but also some converted values depending on what is installed on the cluster.
 For example, consider the following package's origin configuration:
@@ -4913,7 +4913,7 @@ services:
       - policycoreutils-python-utils
 ```
 
-The above configuration is converted to the following finalized configuration provided that the cluster is based on RHEL nodes:
+The above configuration is converted to the following finalized configuration, provided that the cluster is based on RHEL nodes:
 
 ```yaml
 services:
@@ -4940,10 +4940,10 @@ services:
 
 **Note**: Some of the packages are impossible to be detected in the system, therefore such packages remain unchanged.
 The same rule is applied if two different package versions are detected on different nodes.
-See also `cache_versions` option in [associations](#associations) section.
+Also, see the `cache_versions` option in the [associations](#associations) section.
 
-**Note**: After some time is passed, the detected packages versions might disappear from the repository.
-Direct using of the `cluster_finalized.yaml` file in procedures like `install` or `add_node` might be impossible due to this reason and would require manual intervention.
+**Note**: After some time is passed, the detected package versions might disappear from the repository.
+Direct using of the `cluster_finalized.yaml` file in procedures like `install` or `add_node` might be impossible due to this reason, and would require a manual intervention.
 
 The same applies to the VRRP interfaces. For example, the following origin configuration without interfaces:
 

--- a/kubemarine/apparmor.py
+++ b/kubemarine/apparmor.py
@@ -112,7 +112,7 @@ def configure_apparmor(group, expected_profiles):
 def setup_apparmor(group):
     log = group.cluster.log
 
-    if group.get_nodes_os(suppress_exceptions=True) != 'debian':
+    if group.get_nodes_os() != 'debian':
         log.debug("Skipped - Apparmor is supported only on Ubuntu/Debian")
         return
 

--- a/kubemarine/audit.py
+++ b/kubemarine/audit.py
@@ -54,7 +54,7 @@ def install(group: NodeGroup, enable_service: bool = True, force: bool = False) 
         return
 
     # This method handles cluster with multiple os, exceptions should be suppressed
-    if not force and group.get_nodes_os(suppress_exceptions=True) in ['rhel', 'rhel8']:
+    if not force and group.get_nodes_os() in ['rhel', 'rhel8']:
         log.debug('Auditd installation is not required on RHEL nodes')
         return
 

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -145,9 +145,6 @@ class KubernetesCluster(Environment):
         from kubemarine.core import flow
         return flow.is_task_completed(self, task_path)
 
-    def get_final_inventory(self):
-        return utils.get_final_inventory(self)
-
     def get_facts_enrichment_fns(self):
         return [
             "kubemarine.kubernetes.add_node_enrichment",
@@ -348,7 +345,7 @@ class KubernetesCluster(Environment):
             return results_values[0]
         raise Exception(f'Too many values returned for package associations str "{association_key}" for package "{package}"')
 
-    def dump_finalized_inventory(self):
+    def make_finalized_inventory(self):
         from kubemarine.core import defaults
         from kubemarine.procedures import remove_node
         from kubemarine import controlplane, cri, packages
@@ -367,7 +364,10 @@ class KubernetesCluster(Environment):
         for finalize_fn in cluster_finalized_functions:
             prepared_inventory = finalize_fn(self, prepared_inventory)
 
-        inventory_for_dump = defaults.prepare_for_dump(prepared_inventory, copy=False)
+        return defaults.prepare_for_dump(prepared_inventory, copy=False)
+
+    def dump_finalized_inventory(self):
+        inventory_for_dump = self.make_finalized_inventory()
         data = yaml.dump(inventory_for_dump)
         finalized_filename = "cluster_finalized.yaml"
         utils.dump_file(self, data, finalized_filename)

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -276,6 +276,8 @@ class KubernetesCluster(Environment):
             raise Exception(f'Unsupported association "{association_key}" value type for package "{package}", '
                             f'got: {str(association_value)}')
 
+        return association_value
+
     def get_package_association(self, package: str, association_key: str) -> str or list:
         """
         Returns the specified association for the specified package from inventory for the cluster.

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -90,6 +90,10 @@ class KubernetesCluster(Environment):
         return NodeGroup(connections, self)
 
     def get_access_address_from_node(self, node: dict):
+        """
+        Returns address which should be used to connect to the node via Fabric.
+        The address also can be used as unique identifier of the node.
+        """
         address = node.get('connect_to')
         if address is None:
             address = node.get('address')
@@ -216,6 +220,11 @@ class KubernetesCluster(Environment):
         return node_context['os']['family']
 
     def get_os_family_for_nodes(self, hosts: Iterable[str]) -> str:
+        """
+        Returns the detected operating system family for hosts.
+
+        :return: Detected OS family, possible values: "debian", "rhel", "rhel8", "multiple", "unknown", "unsupported".
+        """
         os_families = {self.get_os_family_for_node(host) for host in hosts}
         if len(os_families) > 1:
             return 'multiple'
@@ -228,6 +237,7 @@ class KubernetesCluster(Environment):
         """
         Returns common OS family name from all final remote hosts.
         The method can be used during enrichment when NodeGroups are not yet calculated.
+
         :return: Detected OS family, possible values: "debian", "rhel", "rhel8", "multiple", "unknown", "unsupported".
         """
         hosts_detect_os_family = []
@@ -239,6 +249,9 @@ class KubernetesCluster(Environment):
         return self.get_os_family_for_nodes(hosts_detect_os_family)
 
     def get_os_identifiers(self) -> Dict[str, Tuple[str, str]]:
+        """
+        For each final node of the cluster, returns a tuple of OS (family, version).
+        """
         nodes_check_os = self.nodes['all'].get_final_nodes()
         os_ids = {}
         for host in nodes_check_os.get_hosts():
@@ -259,7 +272,8 @@ class KubernetesCluster(Environment):
 
     def get_associations_for_node(self, host: str, package: str) -> dict:
         """
-        Returns all packages associations for specific node
+        Returns all packages associations for specific node.
+
         :param host: The address of the node for which required to find the associations
         :param package: The package name to get the associations for
         :return: Dict with packages and their associations
@@ -282,6 +296,7 @@ class KubernetesCluster(Environment):
         """
         Returns the specified association for the specified package from inventory for the cluster.
         The method can be used only if cluster has nodes with the same and supported OS family.
+
         :param package: The package name to get the association for
         :param association_key: Association key to get
         :return: Association string or list value
@@ -291,7 +306,8 @@ class KubernetesCluster(Environment):
 
     def get_package_association_for_node(self, host: str, package: str, association_key: str) -> str or list:
         """
-        Returns the specified association for the specified package from inventory for specific node
+        Returns the specified association for the specified package from inventory for specific node.
+
         :param host: The address of the node for which required to find the association
         :param package: The package name to get the association for
         :param association_key: Association key to get
@@ -302,7 +318,8 @@ class KubernetesCluster(Environment):
 
     def get_package_association_for_group(self, group: NodeGroup, package: str, association_key: str) -> dict:
         """
-        Returns the specified association dict for the specified package from inventory for entire NodeGroup
+        Returns the specified association dict for the specified package from inventory for entire NodeGroup.
+
         :param group: NodeGroup for which required to find the association
         :param package: The package name to get the association for
         :param association_key: Association key to get
@@ -319,6 +336,7 @@ class KubernetesCluster(Environment):
         """
         Returns the specified association string or list for the specified package from inventory for entire NodeGroup.
         If association value is different between some nodes, an exception will be thrown.
+
         :param group: NodeGroup for which required to find the association
         :param package: The package name to get the association for
         :param association_key: Association key to get

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -14,7 +14,7 @@
 
 import re
 from copy import deepcopy
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Iterable, Tuple
 
 import fabric
 import yaml
@@ -89,26 +89,28 @@ class KubernetesCluster(Environment):
                 raise Exception('Unsupported connection object type')
         return NodeGroup(connections, self)
 
-    def get_addresses_from_node_names(self, node_names: List[str]) -> dict:
-        result = {}
+    def get_access_address_from_node(self, node: dict):
+        address = node.get('connect_to')
+        if address is None:
+            address = node.get('address')
+        if address is None:
+            address = node.get('internal_address')
+
+        return address
+
+    def get_addresses_from_node_names(self, node_names: List[str]) -> List[str]:
+        result = []
         for node in self.inventory["nodes"]:
             for requested_node_name in node_names:
                 if requested_node_name == node['name']:
-                    result[node['name']] = {
-                        'address': node.get('address'),
-                        'internal_address': node.get('internal_address'),
-                        'connect_to': node.get('connect_to')
-                    }
+                    result.append(self.get_access_address_from_node(node))
         return result
 
     def get_node(self, host: Union[str, fabric.connection.Connection]) -> dict:
         return self.make_group([host]).get_first_member(provide_node_configs=True)
 
     def make_group_from_nodes(self, node_names: List[str]) -> NodeGroup:
-        addresses = self.get_addresses_from_node_names(node_names)
-        ips = []
-        for item in list(addresses.values()):
-            ips.append(item['connect_to'])
+        ips = self.get_addresses_from_node_names(node_names)
         return self.make_group(ips)
 
     def create_group_from_groups_nodes_names(self, groups_names: List[str], nodes_names: List[str]) -> NodeGroup:
@@ -177,23 +179,7 @@ class KubernetesCluster(Environment):
         self.log.verbose('OS family check finished')
 
         self.log.debug('Detecting nodes context finished!')
-        return {k: deepcopy(self.context[k]) for k in ('nodes', 'os')}
-
-    def _gather_facts_after(self):
-        self.log.debug('Gathering facts after tasks execution started...')
-
-        self.remove_invalid_cri_config(self.inventory)
-        # Method "kubemarine.system.is_multiple_os_detected" is not used because it detects OS family for new nodes
-        # only, while package versions caching performs on all nodes.
-        # Cache packages only if it's set in configuration
-        if self.inventory['services']['packages']['cache_versions']:
-            if self.nodes['all'].get_accessible_nodes().get_nodes_os(suppress_exceptions=True, force_all_nodes=True) != 'multiple':
-                self.cache_package_versions()
-                self.log.verbose('Package versions detection finished')
-            else:
-                self.log.verbose('Package versions detection cancelled - cluster in multiple OS state')
-
-        self.log.debug('Gathering facts after tasks execution finished!')
+        return deepcopy(self.context['nodes'])
 
     def _check_online_nodes(self):
         """
@@ -223,28 +209,76 @@ class KubernetesCluster(Environment):
             raise Exception(f"{not_accessible_online.get_hosts()} are not accessible through ssh. "
                             f"Check ssh credentials.")
 
-    def get_associations_for_os(self, os_family):
-        package_associations = self.inventory['services']['packages']['associations']
-        active_os_family = self.context.get("os")
-        if active_os_family != os_family:
-            package_associations = package_associations[os_family]
-
-        return package_associations
-
     def get_os_family_for_node(self, host: str) -> str:
         node_context = self.context['nodes'].get(host)
         if not node_context or not node_context.get('os', {}).get('family'):
             raise Exception('Node %s do not contain necessary context data' % host)
         return node_context['os']['family']
 
-    def get_associations_for_node(self, host: str) -> dict:
+    def get_os_family_for_nodes(self, hosts: Iterable[str]) -> str:
+        os_families = {self.get_os_family_for_node(host) for host in hosts}
+        if len(os_families) > 1:
+            return 'multiple'
+        elif len(os_families) == 0:
+            raise Exception('Cannot get os family for empty nodes list')
+        else:
+            return list(os_families)[0]
+
+    def get_os_family(self) -> str:
+        """
+        Returns common OS family name from all final remote hosts.
+        :return: Detected OS family, possible values: "debian", "rhel", "rhel8", "multiple", "unknown", "unsupported".
+        """
+        return self.nodes['all'].get_final_nodes().get_nodes_os()
+
+    def get_os_family_from_new_nodes_or_final(self) -> str:
+        """
+        The method can be used during enrichment when NodeGroups are not yet calculated.
+        """
+        procedure = self.context['initial_procedure']
+
+        # For add_node procedure, check only new nodes. Otherwise, use final (except removed) nodes.
+        hosts_detect_os_family = []
+        for node in self.inventory['nodes']:
+            host = self.get_access_address_from_node(node)
+            if 'remove_node' not in node['roles'] and (procedure != 'add_node' or 'add_node' in node['roles']):
+                hosts_detect_os_family.append(host)
+
+        return self.get_os_family_for_nodes(hosts_detect_os_family)
+
+    def get_os_identifiers(self) -> Dict[str, Tuple[str, str]]:
+        nodes_check_os = self.nodes['all'].get_final_nodes()
+        os_ids = {}
+        for host in nodes_check_os.get_hosts():
+            os_details = self.context['nodes'][host]['os']
+            os_ids[host] = (os_details['family'], os_details['version'])
+
+        return os_ids
+
+    def _get_associations_for_os(self, os_family) -> dict:
+        package_associations = self.inventory['services']['packages']['associations']
+        active_os_family = self.get_os_family_from_new_nodes_or_final()
+        if active_os_family != os_family:
+            package_associations = package_associations[os_family]
+
+        return package_associations
+
+    def get_associations_for_node(self, host: str, package: str) -> dict:
         """
         Returns all packages associations for specific node
         :param host: The address of the node for which required to find the associations
+        :param package: The package name to get the associations for
         :return: Dict with packages and their associations
         """
+        if package in ('debian', 'rhel', 'rhel8'):
+            raise Exception(f'Failed to get associations for package "{package}"')
+
         node_os_family = self.get_os_family_for_node(host)
-        return self.get_associations_for_os(node_os_family)
+        associations = self._get_associations_for_os(node_os_family).get(package)
+        if associations is None:
+            raise Exception(f'Failed to get associations for package "{package}"')
+
+        return associations
 
     def get_package_association_for_node(self, host: str, package: str, association_key: str) -> str or list:
         """
@@ -254,8 +288,8 @@ class KubernetesCluster(Environment):
         :param association_key: Association key to get
         :return: Association string or list value
         """
-        associations = self.get_associations_for_node(host)
-        association_value = associations.get(package, {}).get(association_key)
+        associations = self.get_associations_for_node(host, package)
+        association_value = associations.get(association_key)
         if association_value is None:
             raise Exception(f'Failed to get association "{association_key}" for package "{package}"')
         if not isinstance(association_value, str) and not isinstance(association_value, list):
@@ -294,39 +328,61 @@ class KubernetesCluster(Environment):
         raise Exception(f'Too many values returned for package associations str "{association_key}" for package "{package}"')
 
     def cache_package_versions(self):
-        # todo consider nodes not having sudo privileges
-        from kubemarine import packages
-        detected_packages = packages.detect_installed_packages_version_groups(
-            self.nodes['all'].get_unchanged_nodes().get_online_nodes(True))
-        for os_family in ['debian', 'rhel', 'rhel8']:
-            if self.inventory['services']['packages']['associations'].get(os_family):
-                del self.inventory['services']['packages']['associations'][os_family]
-        for association_name, associated_params in self.inventory['services']['packages']['associations'].items():
-            associated_packages = associated_params.get('package_name', [])
-            packages_list = []
-            final_packages_list = []
-            if isinstance(associated_packages, str):
-                packages_list.append(packages.get_package_name(self.nodes['all'].get_final_nodes().get_nodes_os(), associated_packages))
-            elif isinstance(associated_packages, list):
-                associated_packages_clean = []
-                for package in associated_packages:
-                     associated_packages_clean.append(packages.get_package_name(self.nodes['all'].get_final_nodes().get_nodes_os(), package))
-                packages_list = packages_list + associated_packages_clean
-            else:
-                raise Exception('Unsupported associated packages object type')
+        # todo not cache twice for add_node procedure
+        # Cache packages only if it's set in configuration
+        if not self.inventory['services']['packages']['cache_versions']:
+            self.log.debug("Skip caching of package versions as it is manually disabled")
+            return
 
-            for package in packages_list:
+        os_ids = self.get_os_identifiers()
+        different_os = list(set(os_ids.values()))
+        if len(different_os) > 1:
+            self.log.debug(f"Final nodes have different OS families or versions, packages will not be cached. "
+                           f"List of (OS family, version): {different_os}")
+            return
+
+        os_family = different_os[0][0]
+        if os_family in ('unknown', 'unsupported'):
+            # For add_node/install procedures we check that OS is supported in prepare.check.system task.
+            # For check_iaas procedure it is allowed to have unsupported OS, so skip caching.
+            self.log.debug("Skip caching of packages for unsupported OS.")
+            return
+
+        nodes_cache_versions = self.nodes['all'].get_final_nodes().get_sudo_nodes()
+        if nodes_cache_versions.is_empty():
+            # For add_node/install procedures we check that all nodes are sudoers in prepare.check.sudoer task.
+            # For check_iaas procedure the nodes might still be not sudoers, so skip caching.
+            self.log.debug(f"There are no nodes with sudo privileges, packages will not be cached.")
+            return
+
+        self._detect_and_cache_package_versions_by_group(nodes_cache_versions)
+        self.log.debug('Package versions detection finished')
+
+    def _detect_and_cache_package_versions_by_group(self, group: NodeGroup):
+        from kubemarine import packages
+        detected_packages = packages.detect_installed_packages_version_groups(group)
+
+        for association_name, associated_params in self.inventory['services']['packages']['associations'].items():
+            indexed_by_pure_packages = packages.get_indexed_by_pure_packages_for_association(group, association_name)
+            if not indexed_by_pure_packages:
+                continue
+
+            final_packages_list = []
+
+            for package in indexed_by_pure_packages.keys():
                 detected_package_versions = list(detected_packages[package].keys())
+                installed_packages = []
                 for version in detected_package_versions:
                     # add package version to list only if it was found as installed
-                    # skip version, which ended with special symbol = or -
-                    # (it is possible in some cases to receive "containerd=" version)
-                    if "not installed" not in version and version[-1] != '=' and version[-1] != '-':
-                        final_packages_list.append(version)
+                    if "not installed" not in version:
+                        installed_packages.append(version)
 
                 # if there no versions detected, then set package version to default
-                if not final_packages_list:
-                    final_packages_list = [package]
+                if not installed_packages:
+                    final_packages_list.append(indexed_by_pure_packages[package])
+                else:
+                    # todo what if installed with different versions?
+                    final_packages_list.extend(installed_packages)
 
             # if non-multiple value, then convert to simple string
             # packages can contain multiple package values, like docker package
@@ -358,15 +414,26 @@ class KubernetesCluster(Environment):
         return detected_packages
 
     def dump_finalized_inventory(self):
-        self._gather_facts_after()
-        # TODO: rewrite the following lines as deenrichment functions like common enrichment mechanism
+        self.cache_package_versions()
+
         from kubemarine.core import defaults
         from kubemarine.procedures import remove_node
-        from kubemarine import controlplane
-        prepared_inventory = remove_node.remove_node_finalize_inventory(self, self.inventory)
-        prepared_inventory = defaults.prepare_for_dump(prepared_inventory, copy=False)
-        prepared_inventory = self.escape_jinja_characters_for_inventory(prepared_inventory)
-        inventory_for_dump = controlplane.controlplane_finalize_inventory(self, prepared_inventory)
+        from kubemarine import controlplane, cri, packages
+
+        cluster_finalized_functions = {
+            packages.remove_unused_os_family_associations,
+            cri.remove_invalid_cri_config,
+            remove_node.remove_node_finalize_inventory,
+            defaults.escape_jinja_characters_for_inventory,
+            controlplane.controlplane_finalize_inventory,
+        }
+
+        # copying is currently not necessary, but it is possible in general.
+        prepared_inventory = self.inventory
+        for finalize_fn in cluster_finalized_functions:
+            prepared_inventory = finalize_fn(self, prepared_inventory)
+
+        inventory_for_dump = defaults.prepare_for_dump(prepared_inventory, copy=False)
         data = yaml.dump(inventory_for_dump)
         finalized_filename = "cluster_finalized.yaml"
         utils.dump_file(self, data, finalized_filename)
@@ -378,34 +445,7 @@ class KubernetesCluster(Environment):
         cluster_storage = utils.ClusterStorage(self)
         cluster_storage.make_dir()
         if self.context.get('initial_procedure') == 'add_node':
-            cluster_storage.collect_info_all_control_plane()
-            cluster_storage.upload_info_new_node()
+            cluster_storage.upload_info_new_control_planes()
         cluster_storage.collect_procedure_info()
         cluster_storage.compress_and_upload_archive()
         cluster_storage.rotation_file()
-
-    def escape_jinja_characters_for_inventory(self, obj):
-        if isinstance(obj, dict):
-            for key, value in obj.items():
-                obj[key] = self.escape_jinja_characters_for_inventory(value)
-        elif isinstance(obj, list):
-            for key, value in enumerate(obj):
-                obj[key] = self.escape_jinja_characters_for_inventory(value)
-        elif isinstance(obj, str):
-            obj = self.escape_jinja_character(obj)
-        return obj
-
-    def escape_jinja_character(self, value):
-        if '{{' in value and '}}' in value and re.search(jinja_query_regex, value):
-            matches = re.findall(jinja_query_regex, value)
-            for match in matches:
-                # TODO: rewrite to correct way of match replacement: now it can cause "{raw}{raw}xxx.." circular bug
-                value = value.replace(match, '{% raw %}'+match+'{% endraw %}')
-        return value
-
-    def remove_invalid_cri_config(self, inventory):
-        if inventory['services']['cri']['containerRuntime'] == 'docker':
-            if inventory['services']['cri'].get('containerdConfig'):
-                del inventory['services']['cri']['containerdConfig']
-        elif inventory['services']['cri'].get('dockerConfig'):
-            del inventory['services']['cri']['dockerConfig']

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -22,7 +22,7 @@ import yaml
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.errors import KME
 from kubemarine import jinja
-from kubemarine.core import utils
+from kubemarine.core import utils, static
 from kubemarine.core.yaml_merger import default_merger
 from kubemarine import controlplane
 
@@ -447,7 +447,7 @@ def compile_inventory(inventory, cluster):
     # convert references in yaml to normal values
     iterations = 100
     root = deepcopy(inventory)
-    root['globals'] = cluster.globals
+    root['globals'] = static.GLOBALS
 
     while iterations > 0:
 

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -931,6 +931,7 @@ class NodeGroup:
     def get_nodes_os(self) -> str:
         """
         Returns the detected operating system family for group.
+
         :return: Detected OS family, possible values: "debian", "rhel", "rhel8", "multiple", "unknown", "unsupported".
         """
         return self.cluster.get_os_family_for_nodes(self.nodes.keys())

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -881,7 +881,7 @@ class NodeGroup:
 
     def get_host(self):
         if len(self.nodes) != 1:
-            raise Exception("Cannot get the only host from group of few nodes")
+            raise Exception("Cannot get the only host from not a single node")
 
         return list(self.nodes.keys())[0]
 

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -879,6 +879,12 @@ class NodeGroup:
         members = self.get_ordered_members_list(provide_node_configs=True)
         return [node['connect_to'] for node in members]
 
+    def get_host(self):
+        if len(self.nodes) != 1:
+            raise Exception("Cannot get the only host from group of few nodes")
+
+        return list(self.nodes.keys())[0]
+
     def is_empty(self) -> bool:
         return not self.nodes
 
@@ -922,38 +928,19 @@ class NodeGroup:
         """
         return len(self.nodes.keys())
 
-    def get_nodes_os(self, suppress_exceptions: bool = False, force_all_nodes: bool = False) -> str:
+    def get_nodes_os(self) -> str:
         """
-        Returns the detected operating system family for group. If the families are different within the same group, or
-        the family is unknown, the exception will be thrown or a string result will be returned.
-        :param suppress_exceptions: Flag, deactivating exception. A string value "unknown" or "multiple" will be
-        returned instead.
-        :param force_all_nodes: A flag that forces OS detection from all nodes, not just new ones.
-        :return: Detected OS family, possible values: "debian", "rhel", "rhel8", "multiple", "unknown".
+        Returns the detected operating system family for group.
+        :return: Detected OS family, possible values: "debian", "rhel", "rhel8", "multiple", "unknown", "unsupported".
         """
-        detected_os_family = None
-        group = self
-        if not force_all_nodes:
-            group = self.get_new_nodes_or_self()
-        for node in group.get_ordered_members_list(provide_node_configs=True):
-            os_family = self.cluster.context["nodes"][node['connect_to']]["os"]['family']
-            if os_family == 'unknown' and not suppress_exceptions:
-                raise Exception('OS family is unknown')
-            if not detected_os_family:
-                detected_os_family = os_family
-            elif detected_os_family != os_family:
-                detected_os_family = 'multiple'
-                if not suppress_exceptions:
-                    raise Exception('OS families differ: detected "%s" and "%s" in same cluster'
-                                    % (detected_os_family, os_family))
-        return detected_os_family
+        return self.cluster.get_os_family_for_nodes(self.nodes.keys())
 
     def is_multi_os(self) -> bool:
         """
         Returns true if same group contains nodes with multiple OS families
         :return: Boolean
         """
-        return self.get_nodes_os(suppress_exceptions=True) == 'multiple'
+        return self.get_nodes_os() == 'multiple'
 
     def get_subgroup_with_os(self, os_family: str) -> NodeGroup:
         """

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -143,7 +143,7 @@ class DynamicResources:
     def _create_cluster(self, context):
         log = self.logger()
         context = deepcopy(context)
-        default_merger.merge(context, self._get_nodes_context())
+        context['nodes'] = deepcopy(self._get_nodes_context())
         try:
             cluster = self._new_cluster_instance(context)
             cluster.enrich()

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -381,27 +381,25 @@ class ClusterStorage:
         output = yaml.dump(out)
         dump_file(context, output, "procedure_parameters")
 
-    def collect_info_all_control_plane(self):
+    def upload_info_new_control_planes(self):
         """
-        This method is used to transfer backup logs from the main control-plane to the new control-plane.
+        This method is used to transfer backup logs from the initial control-plane to the new control-planes.
         """
+        new_control_planes = self.cluster.nodes['control-plane'].get_new_nodes()
+        if new_control_planes.is_empty():
+            return
 
         node = self.cluster.nodes['control-plane'].get_initial_nodes().get_first_member(provide_node_configs=True)
         control_plane = self.cluster.make_group([node['connect_to']])
         data_copy_res = control_plane.sudo(f'tar -czvf /tmp/kubemarine-backup.tar.gz {self.dir_path}')
-        self.cluster.log.debug('Backup created:\n%s' % data_copy_res)
+        self.cluster.log.verbose('Backup created:\n%s' % data_copy_res)
         control_plane.get('/tmp/kubemarine-backup.tar.gz',
                           get_dump_filepath(self.cluster.context, "dump_log_cluster.tar.gz"), 'dump_log_cluster.tar.gz')
 
         self.cluster.log.debug('Backup downloaded')
 
-    def upload_info_new_node(self):
-
-        new_nodes = self.cluster.nodes['all'].get_new_nodes()
-
-        for new_node in new_nodes.get_ordered_members_list(provide_node_configs=True):
+        for new_node in new_control_planes.get_ordered_members_list(provide_node_configs=True):
             group = self.cluster.make_group([new_node['connect_to']])
-            if 'control-plane' in new_node['roles']:
-                group.put(get_dump_filepath(self.cluster.context, "dump_log_cluster.tar.gz"),
-                    "/tmp/dump_log_cluster.tar.gz", sudo=True)
-                group.sudo(f'tar -C / -xzvf /tmp/dump_log_cluster.tar.gz')
+            group.put(get_dump_filepath(self.cluster.context, "dump_log_cluster.tar.gz"),
+                      "/tmp/dump_log_cluster.tar.gz", sudo=True)
+            group.sudo(f'tar -C / -xzvf /tmp/dump_log_cluster.tar.gz')

--- a/kubemarine/cri/__init__.py
+++ b/kubemarine/cri/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.group import NodeGroupResult
 from kubemarine.cri import docker, containerd
 
@@ -35,6 +35,16 @@ def enrich_inventory(inventory, cluster):
     for key, value in forbidden_cri_sections.items():
         if value in cluster.raw_inventory.get('services', {}).get('cri', {}):
             raise Exception(f"{key} is not used, please remove {value} config from `services.cri` section")
+
+    return inventory
+
+
+def remove_invalid_cri_config(cluster: KubernetesCluster, inventory: dict):
+    if inventory['services']['cri']['containerRuntime'] == 'docker':
+        if inventory['services']['cri'].get('containerdConfig'):
+            del inventory['services']['cri']['containerdConfig']
+    elif inventory['services']['cri'].get('dockerConfig'):
+        del inventory['services']['cri']['dockerConfig']
 
     return inventory
 

--- a/kubemarine/cri/docker.py
+++ b/kubemarine/cri/docker.py
@@ -40,16 +40,15 @@ def uninstall(group):
     return packages.remove(group, include=['docker', 'docker-engine', 'docker.io', 'docker-ce'])
 
 
-def enable(group):
-    system.enable_service(
-        group,
-        name=group.cluster.inventory['services']['packages']['associations']['docker']['service_name'], now=True)
+def enable(group: NodeGroup):
+    # currently it is invoked only for single node
+    service_name = group.cluster.get_package_association_for_node(group.get_host(), 'docker', 'service_name')
+    system.enable_service(group, name=service_name, now=True)
 
 
-def disable(group):
-    system.disable_service(
-        group,
-        name=group.cluster.inventory['services']['packages']['associations']['docker']['service_name'], now=True)
+def disable(group: NodeGroup):
+    service_name = group.cluster.get_package_association_for_node(group.get_host(), 'docker', 'service_name')
+    system.disable_service(group, name=service_name, now=True)
 
 
 def configure(group: NodeGroup):

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -407,8 +407,6 @@ def new_cluster(inventory, procedure=None, fake=True, context: dict = None,
             connect_to = node['address']
         context['nodes'][connect_to] = node_context
 
-    context['os'] = os_family
-
     # It is possible to disable FakeCluster and create real cluster Object for some business case
     if fake:
         cluster = FakeKubernetesCluster(inventory, context)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -848,11 +848,13 @@ def prepare_drain_command(node, version: str, globals, disable_eviction: bool, n
 
 
 def upgrade_cri_if_required(group):
-    log = group.cluster.log
-    cri_impl = group.cluster.inventory['services']['cri']['containerRuntime']
+    # currently it is invoked only for single node
+    cluster = group.cluster
+    log = cluster.log
+    cri_impl = cluster.inventory['services']['cri']['containerRuntime']
 
-    if cri_impl in group.cluster.context["packages"]["upgrade_required"]:
-        cri_packages = group.cluster.inventory['services']['packages']['associations'][cri_impl]['package_name']
+    if cri_impl in cluster.context["packages"]["upgrade_required"]:
+        cri_packages = cluster.get_package_association_for_node(group.get_host(), cri_impl, 'package_name')
 
         log.debug(f"Installing {cri_packages}")
         packages.install(group, include=cri_packages)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -16,7 +16,7 @@ import io
 import math
 import time
 from copy import deepcopy
-from typing import List
+from typing import List, Dict, Union
 
 import ruamel.yaml
 import yaml
@@ -29,6 +29,11 @@ from kubemarine.core.group import NodeGroup
 from kubemarine.core.errors import KME
 
 version_coredns_path_breakage = "v1.21.2"
+
+ERROR_DOWNGRADE='Kubernetes old version \"%s\" is greater than new one \"%s\"'
+ERROR_SAME='Kubernetes old version \"%s\" is the same as new one \"%s\"'
+ERROR_MAJOR_RANGE_EXCEEDED='Major version \"%s\" rises to new \"%s\" more than one'
+ERROR_MINOR_RANGE_EXCEEDED='Minor version \"%s\" rises to new \"%s\" more than one'
 
 
 def add_node_enrichment(inventory, cluster):
@@ -937,7 +942,8 @@ def expect_kubernetes_version(cluster, version, timeout=None, retries=None, node
     raise Exception('In the expected time, the nodes did not receive correct Kubernetes version')
 
 
-def test_version(version):
+def test_version(version: Union[list, str]):
+    version_list: list = version
     # catch version without "v" at the first symbol
     if isinstance(version, str):
         if not version.startswith('v'):
@@ -961,34 +967,30 @@ def test_version(version):
 
 
 def test_version_upgrade_possible(old, new, skip_equal=False):
-    versions = {
+    versions_unchanged = {
         'old': old.strip(),
         'new': new.strip()
     }
-    versions_unchanged = versions.copy()
+    versions: Dict[str, List[int]] = {}
 
-    for v_type, version in versions.items():
+    for v_type, version in versions_unchanged.items():
         versions[v_type] = test_version(version)
 
     # test new is greater than old
     if tuple(versions['old']) > tuple(versions['new']):
-        raise Exception('Kubernetes old version \"%s\" is greater than new one \"%s\"'
-                        % (versions_unchanged['old'], versions_unchanged['new']))
+        raise Exception(ERROR_DOWNGRADE % (versions_unchanged['old'], versions_unchanged['new']))
 
     # test new is the same as old
     if tuple(versions['old']) == tuple(versions['new']) and not skip_equal:
-        raise Exception('Kubernetes old version \"%s\" is the same as new one \"%s\"'
-                        % (versions_unchanged['old'], versions_unchanged['new']))
+        raise Exception(ERROR_SAME % (versions_unchanged['old'], versions_unchanged['new']))
 
     # test major step is not greater than 1
     if versions['new'][0] - versions['old'][0] > 1:
-        raise Exception('Major version \"%s\" rises to new \"%s\" more than one'
-                        % (versions_unchanged['old'], versions_unchanged['new']))
+        raise Exception(ERROR_MAJOR_RANGE_EXCEEDED % (versions_unchanged['old'], versions_unchanged['new']))
 
     # test minor step is not greater than 1
     if versions['new'][1] - versions['old'][1] > 1:
-        raise Exception('Minor version \"%s\" rises to new \"%s\" more than one'
-                        % (versions_unchanged['old'], versions_unchanged['new']))
+        raise Exception(ERROR_MINOR_RANGE_EXCEEDED % (versions_unchanged['old'], versions_unchanged['new']))
 
 
 def recalculate_proper_timeout(nodes, timeout):

--- a/kubemarine/procedures/add_node.py
+++ b/kubemarine/procedures/add_node.py
@@ -98,21 +98,7 @@ def cache_installed_packages(cluster):
     It is called first during "add_node" procedure,
     so that new nodes install exactly the same packages as on other already existing nodes.
     """
-    unique_os = set(((cluster.context['nodes'][node['connect_to']]['os']['family']), (cluster.context['nodes'][node['connect_to']]['os']['version']))
-               for node in cluster.nodes['all'].get_ordered_members_list(provide_node_configs=True))
-    different_os = len(unique_os)
-
-    if different_os > 1:
-        cluster.log.debug(f"New node has different OS"
-                          f" than some other nodes, "
-                          "packages will not be cached.")
-        cluster.log.debug("Count different OS %d ", different_os)
-        cluster.log.debug("Unique OS %s ", unique_os)
-
-        return
-    # Cache packages only if it's set in configuration
-    if cluster.inventory['services']['packages']['cache_versions']:
-        cluster.cache_package_versions()
+    cluster.cache_package_versions()
 
 
 tasks = OrderedDict(copy.deepcopy(install.tasks))

--- a/kubemarine/procedures/add_node.py
+++ b/kubemarine/procedures/add_node.py
@@ -17,9 +17,10 @@
 import copy
 
 from collections import OrderedDict
-from kubemarine import kubernetes, system
+from kubemarine import kubernetes, packages
 from kubemarine.core import flow, utils
 from kubemarine.core.action import Action
+from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.resources import DynamicResources
 from kubemarine.procedures import install
 
@@ -92,13 +93,13 @@ def add_node_finalize_inventory(cluster, inventory_to_finalize):
     return inventory_to_finalize
 
 
-def cache_installed_packages(cluster):
+def cache_installed_packages(cluster: KubernetesCluster):
     """
     Task which is used to collect already installed packages versions on already existing nodes.
     It is called first during "add_node" procedure,
     so that new nodes install exactly the same packages as on other already existing nodes.
     """
-    cluster.cache_package_versions()
+    packages.cache_package_versions(cluster, cluster.inventory, ensured_associations_only=True)
 
 
 tasks = OrderedDict(copy.deepcopy(install.tasks))

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -25,18 +25,16 @@ import time
 from collections import OrderedDict
 import yaml
 
-from kubemarine import system
 from kubemarine.core import utils, flow
 from kubemarine.core.action import Action
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.group import NodeGroup
 from kubemarine.core.resources import DynamicResources
-from kubemarine.procedures import install
 
 
-def get_default_backup_files_list(cluster):
-    haproxy_service = cluster.inventory['services']['packages']['associations']['haproxy']['service_name']
-    keepalived_service = cluster.inventory['services']['packages']['associations']['keepalived']['service_name']
+def get_default_backup_files_list(cluster: KubernetesCluster):
+    haproxy_service = cluster.get_package_association('haproxy', 'service_name')
+    keepalived_service = cluster.get_package_association('keepalived', 'service_name')
 
     backup_files_list = [
         "/etc/resolv.conf",

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -91,9 +91,9 @@ def export_ansible_inventory(cluster):
     cluster.log.verbose('ansible-inventory.ini exported to backup')
 
 
-def export_packages_list(cluster):
+def export_packages_list(cluster: KubernetesCluster):
     cluster.context['backup_descriptor']['nodes']['packages'] = {}
-    if system.get_os_family(cluster) in ['rhel', 'rhel8']:
+    if cluster.get_os_family() in ['rhel', 'rhel8']:
         cmd = r"rpm -qa"
     else:
         cmd = r"dpkg-query -f '${Package}=${Version}\n' -W"

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -110,7 +110,6 @@ def recommended_system_packages_versions(cluster: KubernetesCluster):
         version_key = system.get_compatibility_version_key(cluster)
         if not version_key:
             raise TestFailure("OS is unknown or multiple OS present")
-        version_key = system.get_compatibility_version_key(cluster)
         k8s_version = cluster.inventory['services']['kubeadm']['kubernetesVersion']
         compatibility = cluster.globals["compatibility_map"]["software"]
         if k8s_version not in compatibility["kubeadm"]:

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -41,7 +41,7 @@ def services_status(cluster: KubernetesCluster, service_type: str):
                   default_results='active (running)'):
         service_name = service_type
 
-        if cluster.get_os_family() != 'multiple':
+        if cluster.get_os_family() != 'multiple' and service_type != 'kubelet':
             service_name = cluster.get_package_association(service_type, 'service_name')
 
         group = cluster.nodes['all']

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -96,8 +96,10 @@ def _check_same_os(cluster: KubernetesCluster):
     os_ids = cluster.get_os_identifiers()
     different_os = set(os_ids.values())
     if len(different_os) > 1:
-        raise TestFailure(f"Nodes have different OS families or versions, packages versions cannot be checked. "
-                          f"List of (OS family, version): {list(different_os)}")
+        cluster.log.warning(
+            f"Nodes have different OS families or versions, packages versions cannot be checked. "
+            f"List of (OS family, version): {list(different_os)}")
+        raise TestFailure(f"Nodes have different OS families or versions")
 
 
 def recommended_system_packages_versions(cluster: KubernetesCluster):

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -36,13 +36,13 @@ from kubemarine.coredns import generate_configmap
 from deepdiff import DeepDiff
 
 
-def services_status(cluster, service_type):
+def services_status(cluster: KubernetesCluster, service_type: str):
     with TestCase(cluster.context['testsuite'], '201', "Services", "%s Status" % service_type.capitalize(),
                   default_results='active (running)'):
         service_name = service_type
 
-        if cluster.inventory['services']['packages']['associations'].get(service_type):
-            service_name = cluster.inventory['services']['packages']['associations'][service_type]['service_name']
+        if cluster.get_os_family() != 'multiple':
+            service_name = cluster.get_package_association(service_type, 'service_name')
 
         group = cluster.nodes['all']
         if service_type == 'haproxy':
@@ -147,7 +147,7 @@ def recommended_system_packages_versions(cluster: KubernetesCluster):
         good_results = set()
         bad_results = []
         for package_alias, expected_packages in expected_system_packages.items():
-            actual_packages = cluster.inventory["services"]["packages"]["associations"][package_alias]["package_name"]
+            actual_packages = cluster.get_package_association(package_alias, "package_name")
             if not isinstance(actual_packages, list):
                 actual_packages = [actual_packages]
             for expected_pckg, version in expected_packages.items():
@@ -192,7 +192,7 @@ def system_packages_versions(cluster: KubernetesCluster, pckg_alias: str):
         else:
             raise Exception(f"Unknown system package alias: {pckg_alias}")
 
-        packages = cluster.inventory['services']['packages']['associations'][pckg_alias]['package_name']
+        packages = cluster.get_package_association(pckg_alias, 'package_name')
         if not isinstance(packages, list):
             packages = [packages]
         return check_packages_versions(cluster, tc, group, packages)

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -34,6 +34,17 @@ from kubemarine.core.resources import DynamicResources
 
 
 def _applicable_for_new_nodes_with_roles(*roles):
+    """
+    Decorator to annotate installation methods.
+    If there are no new nodes with the specified roles to be added / installed to the cluster,
+    the decorator skips execution of the method.
+    Otherwise, it runs the annotated method with the calculated group of nodes with the specified roles.
+    Note that the signature of annotated method should be f(NodeGroup),
+    but the resulting wrapping method will be f(KubernetesCluster).
+
+    :param roles: roles of nodes for which the annotated method is applicable.
+    :return: new wrapping method.
+    """
     if not roles:
         raise Exception(f'Roles are not defined')
 

--- a/kubemarine/procedures/migrate_cri.py
+++ b/kubemarine/procedures/migrate_cri.py
@@ -82,12 +82,16 @@ def _prepare_packages(cluster: KubernetesCluster, inventory: dict, finalization=
         return inventory
 
     if finalization:
-        # Merge global associations section as it has priority.
+        # Despite we enrich OS specific section inside system.enrich_upgrade_inventory,
+        # we still merge global associations section because it has priority during enrichment.
         inventory["services"].setdefault("packages", {}).setdefault("associations", {})
         default_merger.merge(inventory["services"]["packages"]["associations"],
                              cluster.procedure_inventory["packages"]["associations"])
     else:
         # Merge OS family specific section. It is already enriched in packages.enrich_inventory_associations
+        # This effectively allows to specify only global section but not for specific OS family.
+        # This restriction is because system.enrich_upgrade_inventory goes after packages.enrich_inventory_associations,
+        # but in future the restriction can be eliminated.
         default_merger.merge(inventory["services"]["packages"]["associations"][cluster.get_os_family()],
                              cluster.procedure_inventory["packages"]["associations"])
 

--- a/kubemarine/procedures/migrate_cri.py
+++ b/kubemarine/procedures/migrate_cri.py
@@ -22,6 +22,7 @@ import uuid
 from kubemarine import kubernetes, etcd, thirdparties, cri, plugins
 from kubemarine.core import flow, utils
 from kubemarine.core.action import Action
+from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.resources import DynamicResources
 from kubemarine.cri import docker
 from kubemarine.procedures import install
@@ -131,7 +132,7 @@ def migrate_cri(cluster):
     _migrate_cri(cluster, cluster.nodes["control-plane"].get_ordered_members_list(provide_node_configs=True))
 
 
-def _migrate_cri(cluster, node_group):
+def _migrate_cri(cluster: KubernetesCluster, node_group: dict):
     """
     Migrate CRI from docker to already installed containerd.
     This method works node-by-node, configuring kubelet to use containerd.
@@ -179,7 +180,7 @@ def _migrate_cri(cluster, node_group):
         node["connection"].sudo("systemctl stop kubelet")
         docker.prune(node["connection"])
 
-        docker_associations = cluster.get_associations_for_node(node['connect_to'])['docker']
+        docker_associations = cluster.get_associations_for_node(node['connect_to'], 'docker')
         node["connection"].sudo(f"systemctl disable {docker_associations['service_name']} --now; "
                                  "sudo sh -c 'rm -rf /var/lib/docker/*'")
 

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -175,9 +175,7 @@ def upgrade_finalize_inventory(cluster, inventory):
         return inventory
     upgrade_version = cluster.context.get("upgrade_version")
 
-    if not inventory['services'].get('kubeadm'):
-        inventory['services']['kubeadm'] = {}
-    inventory['services']['kubeadm']['kubernetesVersion'] = upgrade_version
+    inventory.setdefault("services", {}).setdefault("kubeadm", {})['kubernetesVersion'] = upgrade_version
 
     # if thirdparties was not defined in procedure.yaml,
     # then no need to forcibly place them: user may want to use default
@@ -185,16 +183,14 @@ def upgrade_finalize_inventory(cluster, inventory):
         inventory['services']['thirdparties'] = cluster.procedure_inventory[upgrade_version]['thirdparties']
 
     if cluster.procedure_inventory.get(upgrade_version, {}).get("plugins"):
-        if not inventory.get("plugins"):
-            inventory["plugins"] = {}
+        inventory.setdefault("plugins", {})
         default_merger.merge(inventory["plugins"], cluster.procedure_inventory[upgrade_version]["plugins"])
 
     if cluster.procedure_inventory.get(upgrade_version, {}).get("packages"):
-        if not inventory.get("services"):
-            inventory["services"] = {}
-        if not inventory["services"].get("packages"):
-            inventory["services"]["packages"] = {}
+        inventory['services'].setdefault("packages", {})
         packages = cluster.procedure_inventory[upgrade_version]["packages"]
+        # Despite we enrich OS specific section inside system.enrich_upgrade_inventory,
+        # we still merge global associations section because it has priority during enrichment.
         default_merger.merge(inventory["services"]["packages"], packages)
 
     return inventory

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -22,6 +22,7 @@ import toml
 from distutils.util import strtobool
 
 from kubemarine.core.action import Action
+from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.resources import DynamicResources
 from kubemarine.core.yaml_merger import default_merger
 from kubemarine.core import flow
@@ -106,7 +107,7 @@ def upgrade_plugins(cluster):
     plugins.install(cluster, upgrade_candidates)
 
 
-def upgrade_containerd(cluster):
+def upgrade_containerd(cluster: KubernetesCluster):
     """
         This function fixes the incorrect version of pause during the cluster update procedure
     """
@@ -145,7 +146,7 @@ def upgrade_containerd(cluster):
             with RemoteExecutor(cluster) as exe:
                 for node in cluster.nodes['control-plane'].include_group(cluster.nodes.get('worker')).get_ordered_members_list(
                         provide_node_configs=True):
-                    os_specific_associations = cluster.get_associations_for_node(node['connect_to'])['containerd']
+                    os_specific_associations = cluster.get_associations_for_node(node['connect_to'], 'containerd')
                     node['connection'].put(StringIO(config_string), os_specific_associations['config_location'],
                                            backup=True,
                                            sudo=True, mkdir=True)

--- a/kubemarine/selinux.py
+++ b/kubemarine/selinux.py
@@ -139,7 +139,7 @@ def get_selinux_status(group):
 def is_config_valid(group, state=None, policy=None, permissive=None):
     log = group.cluster.log
 
-    if group.get_nodes_os(suppress_exceptions=True) == 'debian':
+    if group.get_nodes_os() == 'debian':
         log.debug("Skipped - selinux is not supported on Ubuntu/Debian os family")
         return
 
@@ -192,7 +192,7 @@ def setup_selinux(group):
     log = group.cluster.log
 
     # this method handles cluster with multiple os, suppressing should be enabled
-    if group.get_nodes_os(suppress_exceptions=True) not in ['rhel', 'rhel8']:
+    if group.get_nodes_os() not in ['rhel', 'rhel8']:
         log.debug("Skipped - selinux is not supported on Ubuntu/Debian os family")
         return
 

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -136,7 +136,10 @@ def enrich_upgrade_inventory(inventory: dict, cluster: KubernetesCluster):
 
     upgrade_ver = cluster.context["upgrade_version"]
     packages_section = deepcopy(cluster.procedure_inventory.get(upgrade_ver, {}).get("packages", {}))
-    # move associations to the OS family specific section, and then merge with associations from procedure
+    # Move associations to the OS family specific section, and then merge with associations from procedure.
+    # This effectively allows to specify only global section but not for specific OS family.
+    # This restriction is because system.enrich_upgrade_inventory goes after packages.enrich_inventory_associations,
+    # but in future the restriction can be eliminated.
     associations = packages_section.pop("associations", {})
     default_merger.merge(inventory["services"]["packages"]["associations"][os_family], associations)
 

--- a/test/unit/core/test_flow.py
+++ b/test/unit/core/test_flow.py
@@ -193,8 +193,8 @@ class FlowTest(unittest.TestCase):
          deploy.loadbalancer.haproxy, deploy.loadbalancer.keepalived, deploy.accounts, overview.")
 
     def test_run_tasks(self):
-        context = demo.create_silent_context(flow.new_tasks_flow_parser("Help text"),
-                                             ['--tasks', 'deploy.loadbalancer.haproxy'])
+        context = demo.create_silent_context(['--tasks', 'deploy.loadbalancer.haproxy'],
+                                             parser=flow.new_tasks_flow_parser("Help text"))
         inventory = demo.generate_inventory(**demo.FULLHA)
         cluster = demo.new_cluster(inventory, context=context)
         flow.run_tasks(demo.FakeResources(context, inventory, cluster=cluster), tasks)
@@ -205,7 +205,7 @@ class FlowTest(unittest.TestCase):
         inventory = demo.generate_inventory(**demo.FULLHA)
         hosts = [node["address"] for node in inventory["nodes"]]
         self._stub_detect_nodes_context(inventory, hosts, hosts)
-        context = demo.create_silent_context(flow.new_tasks_flow_parser("Help text"), [])
+        context = demo.create_silent_context([], parser=flow.new_tasks_flow_parser("Help text"))
         res = demo.FakeResources(context, inventory, fake_shell=self.light_fake_shell)
         # not throws any exception during cluster initialization
         flow.run_tasks(res, tasks)
@@ -223,7 +223,7 @@ class FlowTest(unittest.TestCase):
         inventory = demo.generate_inventory(**demo.FULLHA)
         hosts = [node["address"] for node in inventory["nodes"]]
         self._stub_detect_nodes_context(inventory, hosts, [])
-        context = demo.create_silent_context(flow.new_tasks_flow_parser("Help text"), [])
+        context = demo.create_silent_context([], parser=flow.new_tasks_flow_parser("Help text"))
         res = demo.FakeResources(context, inventory, fake_shell=self.light_fake_shell)
         flow.run_tasks(res, tasks)
         cluster = res.cluster()
@@ -242,7 +242,7 @@ class FlowTest(unittest.TestCase):
         online_hosts = [node["address"] for node in inventory["nodes"]]
         offline = online_hosts.pop(random.randrange(len(online_hosts)))
         self._stub_detect_nodes_context(inventory, online_hosts, [])
-        context = demo.create_silent_context(flow.new_tasks_flow_parser("Help text"), [])
+        context = demo.create_silent_context([], parser=flow.new_tasks_flow_parser("Help text"))
         res = demo.FakeResources(context, inventory, fake_shell=self.light_fake_shell)
 
         exc = None
@@ -265,8 +265,8 @@ class FlowTest(unittest.TestCase):
         procedure_inventory = {"nodes": [{"name": inventory["nodes"][masters[i]]["name"]}]}
 
         self._stub_detect_nodes_context(inventory, online_hosts, [])
-        context = demo.create_silent_context(flow.new_procedure_parser("Help text"), ['fake_path.yaml'],
-                                             procedure='remove_node')
+        context = demo.create_silent_context(['fake_path.yaml'], procedure='remove_node',
+                                             parser=flow.new_procedure_parser("Help text"))
         res = demo.FakeResources(context, inventory, procedure_inventory=procedure_inventory,
                                  fake_shell=self.light_fake_shell)
 

--- a/test/unit/core/test_flow.py
+++ b/test/unit/core/test_flow.py
@@ -213,7 +213,7 @@ class FlowTest(unittest.TestCase):
         self.assertEqual(4, cluster.context["test_info"],
                          "Here should be all 4 calls of test_func")
 
-        self.assertEqual("rhel", cluster.context["os"])
+        self.assertEqual("rhel", cluster.get_os_family())
         for host, node_context in cluster.context["nodes"].items():
             self.assertEqual({'online': True, 'accessible': True, 'sudo': 'Root'}, node_context["access"])
             self.assertEqual({'name': 'centos', 'version': '7.6', 'family': 'rhel'}, node_context["os"])
@@ -230,7 +230,7 @@ class FlowTest(unittest.TestCase):
         self.assertEqual(4, cluster.context["test_info"],
                          "Here should be all 4 calls of test_func")
 
-        self.assertEqual("rhel", cluster.context["os"])
+        self.assertEqual("rhel", cluster.get_os_family())
         for host, node_context in cluster.context["nodes"].items():
             self.assertEqual({'online': True, 'accessible': True, 'sudo': 'No'}, node_context["access"])
             # continue to collect info

--- a/test/unit/core/test_run_actions.py
+++ b/test/unit/core/test_run_actions.py
@@ -31,7 +31,7 @@ class FakeResources(demo.FakeResources):
 
 class RunActionsTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.context = demo.create_silent_context(flow.new_common_parser("Help text"), [])
+        self.context = demo.create_silent_context()
         self.context['preserve_inventory'] = True
         self.inventory = demo.generate_inventory(**demo.FULLHA)
         self.cluster: demo.FakeKubernetesCluster = demo.new_cluster(self.inventory, context=self.context)

--- a/test/unit/test_audit.py
+++ b/test/unit/test_audit.py
@@ -34,7 +34,7 @@ class NodeGroupResultsTest(unittest.TestCase):
 
     def test_audit_installation_for_debian(self):
         cluster = demo.new_cluster(self.inventory, os_name='ubuntu', os_version='20.04')
-        package_associations = cluster.inventory['services']['packages']['associations']['audit']
+        package_associations = cluster.inventory['services']['packages']['associations']['debian']['audit']
 
         package_name = package_associations['package_name']
         service_name = package_associations['service_name']
@@ -61,7 +61,7 @@ class NodeGroupResultsTest(unittest.TestCase):
 
     def test_audit_installation_when_already_installed_for_debian(self):
         cluster = demo.new_cluster(self.inventory, os_name='ubuntu', os_version='20.04')
-        package_associations = cluster.inventory['services']['packages']['associations']['audit']
+        package_associations = cluster.inventory['services']['packages']['associations']['debian']['audit']
 
         package_name = package_associations['package_name']
 
@@ -76,7 +76,7 @@ class NodeGroupResultsTest(unittest.TestCase):
     def test_audit_installation_when_partly_installed_for_debian(self):
         cluster = demo.new_cluster(self.inventory, os_name='ubuntu', os_version='20.04')
         all_nodes_group = cluster.nodes['all'].nodes
-        package_associations = cluster.inventory['services']['packages']['associations']['audit']
+        package_associations = cluster.inventory['services']['packages']['associations']['debian']['audit']
 
         package_name = package_associations['package_name']
         service_name = package_associations['service_name']
@@ -119,7 +119,7 @@ class NodeGroupResultsTest(unittest.TestCase):
 
     def test_audit_configuring(self):
         cluster = demo.new_cluster(self.inventory, os_name='ubuntu', os_version='20.04')
-        package_associations = cluster.inventory['services']['packages']['associations']['audit']
+        package_associations = cluster.inventory['services']['packages']['associations']['debian']['audit']
         package_name = package_associations['package_name']
         config_location = package_associations['config_location']
 

--- a/test/unit/test_audit.py
+++ b/test/unit/test_audit.py
@@ -20,6 +20,7 @@ import fabric
 
 from kubemarine import demo, audit
 from kubemarine.core.group import NodeGroupResult
+from kubemarine.demo import FakeKubernetesCluster
 
 
 class NodeGroupResultsTest(unittest.TestCase):
@@ -28,12 +29,19 @@ class NodeGroupResultsTest(unittest.TestCase):
         super().__init__(*args, **kwargs)
         self.inventory = demo.generate_inventory(**demo.FULLHA)
 
+    def new_debian_cluster(self) -> FakeKubernetesCluster:
+        context = demo.create_silent_context()
+        context['nodes'] = demo.generate_nodes_context(self.inventory, os_name='ubuntu', os_version='20.04')
+        return demo.new_cluster(self.inventory, context=context)
+
     def test_audit_installation_for_centos(self):
-        cluster = demo.new_cluster(self.inventory, os_name='centos', os_version='7.9')
+        context = demo.create_silent_context()
+        context['nodes'] = demo.generate_nodes_context(self.inventory, os_name='centos', os_version='7.9')
+        cluster = demo.new_cluster(self.inventory, context=context)
         audit.install(cluster.nodes['master'])
 
     def test_audit_installation_for_debian(self):
-        cluster = demo.new_cluster(self.inventory, os_name='ubuntu', os_version='20.04')
+        cluster = self.new_debian_cluster()
         package_associations = cluster.inventory['services']['packages']['associations']['debian']['audit']
 
         package_name = package_associations['package_name']
@@ -60,7 +68,7 @@ class NodeGroupResultsTest(unittest.TestCase):
         audit.install(cluster.nodes['master'])
 
     def test_audit_installation_when_already_installed_for_debian(self):
-        cluster = demo.new_cluster(self.inventory, os_name='ubuntu', os_version='20.04')
+        cluster = self.new_debian_cluster()
         package_associations = cluster.inventory['services']['packages']['associations']['debian']['audit']
 
         package_name = package_associations['package_name']
@@ -74,7 +82,7 @@ class NodeGroupResultsTest(unittest.TestCase):
         audit.install(cluster.nodes['master'])
 
     def test_audit_installation_when_partly_installed_for_debian(self):
-        cluster = demo.new_cluster(self.inventory, os_name='ubuntu', os_version='20.04')
+        cluster = self.new_debian_cluster()
         all_nodes_group = cluster.nodes['all'].nodes
         package_associations = cluster.inventory['services']['packages']['associations']['debian']['audit']
 
@@ -118,7 +126,7 @@ class NodeGroupResultsTest(unittest.TestCase):
                               msg="Installation task did not finished with audit enable command")
 
     def test_audit_configuring(self):
-        cluster = demo.new_cluster(self.inventory, os_name='ubuntu', os_version='20.04')
+        cluster = self.new_debian_cluster()
         package_associations = cluster.inventory['services']['packages']['associations']['debian']['audit']
         package_name = package_associations['package_name']
         config_location = package_associations['config_location']

--- a/test/unit/test_haproxy.py
+++ b/test/unit/test_haproxy.py
@@ -68,7 +68,7 @@ class TestHaproxyInstallation(unittest.TestCase):
         inventory = demo.generate_inventory(**demo.FULLHA)
         cluster = demo.new_cluster(inventory)
 
-        package_associations = cluster.inventory['services']['packages']['associations']['haproxy']
+        package_associations = cluster.inventory['services']['packages']['associations']['rhel']['haproxy']
 
         # simulate already installed haproxy package
         expected_results_1 = demo.create_nodegroup_result(cluster.nodes['balancer'], stdout='Haproxy v1.2.3')
@@ -98,7 +98,7 @@ class TestHaproxyInstallation(unittest.TestCase):
         inventory = demo.generate_inventory(**demo.FULLHA)
         cluster = demo.new_cluster(inventory)
 
-        package_associations = cluster.inventory['services']['packages']['associations']['haproxy']
+        package_associations = cluster.inventory['services']['packages']['associations']['rhel']['haproxy']
 
         # simulate haproxy package missing
         missing_package_command = ['%s -v' % package_associations['executable_name']]

--- a/test/unit/test_keepalived.py
+++ b/test/unit/test_keepalived.py
@@ -140,7 +140,7 @@ class TestKeepalivedInstallation(unittest.TestCase):
         inventory = demo.generate_inventory(**demo.FULLHA_KEEPALIVED)
         cluster = demo.new_cluster(inventory)
 
-        package_associations = cluster.inventory['services']['packages']['associations']['keepalived']
+        package_associations = cluster.inventory['services']['packages']['associations']['rhel']['keepalived']
 
         # simulate already installed keepalived package
         expected_results_1 = demo.create_nodegroup_result(cluster.nodes['keepalived'], stdout='Keepalived v1.2.3')
@@ -174,7 +174,7 @@ class TestKeepalivedInstallation(unittest.TestCase):
         inventory = demo.generate_inventory(**demo.FULLHA_KEEPALIVED)
         cluster = demo.new_cluster(inventory)
 
-        package_associations = cluster.inventory['services']['packages']['associations']['keepalived']
+        package_associations = cluster.inventory['services']['packages']['associations']['rhel']['keepalived']
 
         # simulate keepalived package missing
         missing_package_command = ['%s -v' % package_associations['executable_name']]
@@ -239,7 +239,7 @@ class TestKeepalivedConfigApply(unittest.TestCase):
         node = cluster.nodes['keepalived'].get_first_member(provide_node_configs=True)
         expected_config = keepalived.generate_config(cluster.inventory, node)
 
-        package_associations = cluster.inventory['services']['packages']['associations']['keepalived']
+        package_associations = cluster.inventory['services']['packages']['associations']['rhel']['keepalived']
         configs_directory = '/'.join(package_associations['config_location'].split('/')[:-1])
 
         # simulate mkdir for configs

--- a/test/unit/test_migrate_cri.py
+++ b/test/unit/test_migrate_cri.py
@@ -1,0 +1,45 @@
+import unittest
+from copy import deepcopy
+
+from kubemarine import demo
+from kubemarine.core import utils
+
+
+def generate_migrate_cri_environment() -> (dict, dict):
+    inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+    inventory['services']['cri'] = {
+        'containerRuntime': 'docker'
+    }
+    context = demo.create_silent_context(procedure='migrate_cri')
+    return inventory, context
+
+
+class MigrateCriPackagesEnrichment(unittest.TestCase):
+    def prepare_procedure_inventory(self):
+        return {
+            'cri': {
+                'containerRuntime': 'containerd'
+            },
+            'packages': {
+                'associations': {
+                    'containerd': {
+                        'package_name': 'containerd'
+                    }
+                }
+            }
+        }
+
+    def test_enrich_packages_propagate_associations(self):
+        inventory, context = generate_migrate_cri_environment()
+        migrate_cri = self.prepare_procedure_inventory()
+        cluster = demo.new_cluster(inventory, procedure_inventory=migrate_cri, context=context)
+        self.assertEqual('containerd', cluster.inventory['services']['packages']['associations']['rhel']['containerd']['package_name'],
+                         "Associations packages are enriched incorrectly")
+
+    def test_final_inventory_enrich_global(self):
+        inventory, context = generate_migrate_cri_environment()
+        migrate_cri = self.prepare_procedure_inventory()
+        cluster = demo.new_cluster(deepcopy(inventory), procedure_inventory=deepcopy(migrate_cri), context=context)
+        final_inventory = utils.get_final_inventory(cluster, inventory)
+        self.assertEqual(migrate_cri['packages'], final_inventory['services']['packages'],
+                         "Final inventory is recreated incorrectly")

--- a/test/unit/test_migrate_cri.py
+++ b/test/unit/test_migrate_cri.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 from copy import deepcopy
 

--- a/test/unit/test_packages.py
+++ b/test/unit/test_packages.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 from copy import deepcopy
 from typing import Optional, Dict

--- a/test/unit/test_packages.py
+++ b/test/unit/test_packages.py
@@ -1,0 +1,438 @@
+import unittest
+from copy import deepcopy
+from typing import Optional, Dict
+
+from kubemarine import demo, packages
+from kubemarine.core import static, defaults, log
+from kubemarine.demo import FakeKubernetesCluster
+from kubemarine.procedures import add_node
+
+
+def new_debian_cluster(inventory: dict) -> FakeKubernetesCluster:
+    context = demo.create_silent_context()
+    context['nodes'] = demo.generate_nodes_context(inventory, os_name='ubuntu', os_version='20.04')
+    return demo.new_cluster(inventory, context=context)
+
+
+def prepare_compiled_associations_defaults() -> dict:
+    defs = deepcopy(static.DEFAULTS)
+    defs['cluster_name'] = 'k8s.fake.local'
+    context = demo.create_silent_context()
+    logger = log.init_log_from_context_args(static.GLOBALS, context, defs).logger
+
+    root = deepcopy(defs)
+    root['globals'] = static.GLOBALS
+    return defaults.compile_object(logger, defs['services']['packages']['associations'], root)
+
+
+COMPILED_ASSOCIATIONS_DEFAULTS = prepare_compiled_associations_defaults()
+
+
+def get_compiled_defaults():
+    return deepcopy(COMPILED_ASSOCIATIONS_DEFAULTS)
+
+
+def global_associations(inventory: dict) -> dict:
+    return inventory.setdefault('services', {}).setdefault('packages', {}).setdefault('associations', {})
+
+
+def os_family_associations(inventory: dict, os_family: str) -> dict:
+    return global_associations(inventory).setdefault(os_family, {})
+
+
+def package_associations(inventory: dict, os_family: Optional[str], package: str) -> dict:
+    return (os_family_associations(inventory, os_family) if os_family else global_associations(inventory))\
+        .setdefault(package, {})
+
+
+def set_cache_versions_false(inventory: dict, os_family: Optional[str], package: Optional[str]):
+    section = inventory.setdefault('services', {}).setdefault('packages', {})
+    if os_family or package:
+        section = section.setdefault('associations', {})
+    if os_family:
+        section = section.setdefault(os_family, {})
+    if package:
+        section = section.setdefault(package, {})
+    section['cache_versions'] = False
+
+
+def get_package_name(os_family, package) -> str:
+    return packages.get_package_name(os_family, package)
+
+
+def make_finalized_inventory(cluster: FakeKubernetesCluster):
+    return cluster.make_finalized_inventory()
+
+
+def cache_installed_packages(cluster: FakeKubernetesCluster):
+    add_node.cache_installed_packages(cluster)
+
+
+class AssociationsEnrichment(unittest.TestCase):
+    def test_simple_enrich_defaults(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        cluster = new_debian_cluster(inventory)
+        associations = global_associations(cluster.inventory)
+        self.assertEqual(packages.get_associations_os_family_keys(), associations.keys(),
+                         "Associations should have only OS family specific sections")
+        self.assertEqual(get_compiled_defaults(), associations,
+                         "Enriched associations of the cluster does not equal to enriched defaults")
+
+    def test_redefine_os_specific_section(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        expected_pkgs = 'docker-ce'
+        package_associations(inventory, 'debian', 'docker')['package_name'] = expected_pkgs
+        cluster = new_debian_cluster(inventory)
+        associations = global_associations(cluster.inventory)
+
+        defs = get_compiled_defaults()
+        self.assertNotEqual(expected_pkgs, defs['debian']['docker']['package_name'])
+        defs['debian']['docker']['package_name'] = expected_pkgs
+        self.assertEqual(defs, associations,
+                         "Debian associations section was not enriched")
+
+    def test_propagate_global_section_to_os_specific(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        expected_pkgs_1 = 'docker-ce'
+        expected_pkgs_2 = ['podman', 'containerd=1.5.*']
+        package_associations(inventory, None, 'docker')['package_name'] = expected_pkgs_1
+        package_associations(inventory, None, 'containerd')['package_name'] = expected_pkgs_2
+        cluster = new_debian_cluster(inventory)
+        associations = global_associations(cluster.inventory)
+        self.assertEqual(packages.get_associations_os_family_keys(), associations.keys(),
+                         "Associations should have only OS family specific sections")
+
+        defs = get_compiled_defaults()
+        self.assertNotEqual(expected_pkgs_1, defs['debian']['docker']['package_name'])
+        self.assertNotEqual(expected_pkgs_2, defs['debian']['containerd']['package_name'])
+        defs['debian']['docker']['package_name'] = expected_pkgs_1
+        defs['debian']['containerd']['package_name'] = expected_pkgs_2
+        self.assertEqual(defs, associations,
+                         "Debian associations section was not enriched")
+
+    def test_error_if_global_section_redefined_for_multiple_os(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        expected_pkgs = 'docker-ce'
+        package_associations(inventory, None, 'docker')['package_name'] = expected_pkgs
+        context = demo.create_silent_context()
+        host_different_os = inventory['nodes'][0]['address']
+        context['nodes'] = self._nodes_context_one_different_os(inventory, host_different_os)
+        with self.assertRaisesRegex(Exception, packages.ERROR_GLOBAL_ASSOCIATIONS_REDEFINED_MULTIPLE_OS):
+            demo.new_cluster(inventory, context=context)
+
+    def test_error_if_global_section_redefined_for_add_node_different_os(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        expected_pkgs = 'docker-ce'
+        package_associations(inventory, None, 'docker')['package_name'] = expected_pkgs
+        context = demo.create_silent_context(procedure='add_node')
+        host_different_os = inventory['nodes'][0]['address']
+        context['nodes'] = self._nodes_context_one_different_os(inventory, host_different_os)
+        add_node = {'nodes': [inventory['nodes'].pop(0)]}
+        with self.assertRaisesRegex(Exception, packages.ERROR_GLOBAL_ASSOCIATIONS_REDEFINED_MULTIPLE_OS):
+            demo.new_cluster(inventory, procedure_inventory=add_node, context=context)
+
+    def test_success_if_os_specific_section_redefined_for_add_node_different_os(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        expected_pkgs = 'docker-ce'
+        package_associations(inventory, 'rhel', 'docker')['package_name'] = expected_pkgs
+        context = demo.create_silent_context(procedure='add_node')
+        host_different_os = inventory['nodes'][0]['address']
+        context['nodes'] = self._nodes_context_one_different_os(inventory, host_different_os)
+        add_node = {'nodes': [inventory['nodes'].pop(0)]}
+        # no error
+        demo.new_cluster(inventory, procedure_inventory=add_node, context=context)
+
+    def test_cache_versions_false_use_recommended_versions(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        set_cache_versions_false(inventory, None, None)
+        cluster = new_debian_cluster(inventory)
+        associations = global_associations(cluster.inventory)
+        self.assertEqual(get_compiled_defaults(), associations,
+                         "Even if cache_versions == false, we still need to use recommended versions")
+
+    def test_remove_unused_os_family_associations(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        cluster = new_debian_cluster(inventory)
+        finalized_inventory = packages.remove_unused_os_family_associations(cluster, cluster.inventory)
+        self.assertEqual({'debian'}, global_associations(finalized_inventory).keys())
+
+    def _nodes_context_one_different_os(self, inventory, host_different_os):
+        nodes_context = demo.generate_nodes_context(inventory, os_name='ubuntu', os_version='20.04')
+        nodes_context[host_different_os]['os'] = {
+            'name': 'centos',
+            'family': 'rhel',
+            'version': '7.9'
+        }
+        return nodes_context
+
+
+class PackagesUtilities(unittest.TestCase):
+    def test_get_package_name_rhel(self):
+        self.assertEqual('docker-ce', get_package_name('rhel', 'docker-ce-19.03.15-3.el7.x86_64'))
+        self.assertEqual('docker-ce', get_package_name('rhel', 'docker-ce-19.03*'))
+        self.assertEqual('docker-ce', get_package_name('rhel', 'docker-ce-*'))
+        self.assertEqual('docker-ce', get_package_name('rhel', 'docker-ce'))
+
+    def test_get_package_name_debian(self):
+        self.assertEqual('containerd', get_package_name('debian', 'containerd=1.5.9-0ubuntu1~20.04.4'))
+        self.assertEqual('containerd', get_package_name('debian', 'containerd=1.5.*'))
+        self.assertEqual('containerd', get_package_name('debian', 'containerd=*'))
+        self.assertEqual('containerd', get_package_name('debian', 'containerd'))
+
+    def test_detect_versions_debian(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        context = demo.create_silent_context()
+        context['nodes'] = demo.generate_nodes_context(inventory, os_name='ubuntu', os_version='20.04')
+        cluster = demo.new_cluster(inventory, context=context)
+
+        expected_pkg = 'containerd=1.5.9-0ubuntu1~20.04.4'
+        queried_pkg = 'containerd=1.5.*'
+        group = cluster.nodes['all']
+        results = demo.create_nodegroup_result(group, stdout=expected_pkg)
+        cluster.fake_shell.add(results, 'sudo', [packages.get_detect_package_version_cmd('debian', 'containerd')])
+
+        detected_packages = packages.detect_installed_packages_version_groups(group, queried_pkg)
+        self.assertEqual({queried_pkg}, detected_packages.keys(),
+                         "Incorrect initially queries package")
+
+        package_versions = detected_packages[queried_pkg]
+        self.assertEqual({expected_pkg}, package_versions.keys(),
+                         "Incorrect detected package versions")
+        self.assertEqual(set(group.get_hosts()), set(package_versions[expected_pkg]),
+                         "Incorrect set of hosts with detected package version")
+
+    def test_detect_versions_rhel(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        context = demo.create_silent_context()
+        context['nodes'] = demo.generate_nodes_context(inventory, os_name='centos', os_version='7.9')
+        cluster = demo.new_cluster(inventory, context=context)
+
+        expected_pkg = 'docker-ce-19.03.15-3.el7.x86_64'
+        queried_pkg = 'docker-ce-19.03*'
+        group = cluster.nodes['all']
+        results = demo.create_nodegroup_result(group, stdout=expected_pkg)
+        cluster.fake_shell.add(results, 'sudo', [packages.get_detect_package_version_cmd('rhel', 'docker-ce')])
+
+        detected_packages = packages.detect_installed_packages_version_groups(group, [queried_pkg])
+        self.assertEqual({queried_pkg}, detected_packages.keys(),
+                         "Incorrect initially queries package")
+
+        package_versions = detected_packages[queried_pkg]
+        self.assertEqual({expected_pkg}, package_versions.keys(),
+                         "Incorrect detected package versions")
+        self.assertEqual(set(group.get_hosts()), set(package_versions[expected_pkg]),
+                         "Incorrect set of hosts with detected package version")
+
+
+class CacheVersions(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fake_shell = demo.FakeShell()
+        self.inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        self.context = demo.create_silent_context(procedure='add_node')
+        self.context['nodes'] = demo.generate_nodes_context(self.inventory, os_name='ubuntu', os_version='20.04')
+        self.hosts = [node['address'] for node in self.inventory['nodes']]
+        self.new_host = self.inventory['nodes'][0]['address']
+        self.procedure_inventory = {'nodes': [self.inventory['nodes'].pop(0)]}
+        self.initial_hosts = [node['address'] for node in self.inventory['nodes']]
+
+    def _new_cluster(self):
+        cluster = FakeKubernetesCluster(self.inventory, self.context, procedure_inventory=self.procedure_inventory,
+                                        fake_shell=self.fake_shell)
+        cluster.enrich()
+        return cluster
+
+    def _stub_detect_package_result(self, package, hosts_stub: Dict[str, str]):
+        results = {}
+        for host in self.hosts:
+            if host in hosts_stub:
+                results[host] = demo.create_result(stdout=hosts_stub[host])
+            else:
+                results[host] = demo.create_result(stdout='not installed')
+
+        cmd = packages.get_detect_package_version_cmd('debian', package)
+        self.fake_shell.add(results, 'sudo', [cmd])
+
+    def _stub_associations_packages(self, packages_hosts_stub: Dict[str, Dict[str, str]]):
+        packages_list = []
+        for association_params in get_compiled_defaults()['debian'].values():
+            pkgs = association_params['package_name']
+            if isinstance(pkgs, str):
+                pkgs = [pkgs]
+
+            packages_list.extend(pkgs)
+
+        packages_list = list(set(packages_list))
+        for package in packages_list:
+            package = get_package_name('debian', package)
+            self._stub_detect_package_result(package, packages_hosts_stub.get(package, {}))
+
+    def _packages_install(self, inventory: dict):
+        return inventory.setdefault('services', {}).setdefault('packages', {}).setdefault('install', [])
+
+    def _packages_include(self, inventory: dict):
+        return inventory.setdefault('services', {}).setdefault('packages', {}).setdefault('install', {})\
+            .setdefault('include', [])
+
+    def _stub_custom_packages(self, packages_hosts_stub: Dict[str, Dict[str, str]]):
+        for package, hosts_stub in packages_hosts_stub.items():
+            self._packages_install(self.inventory).append(package)
+            package = get_package_name('debian', package)
+            self._stub_detect_package_result(package, hosts_stub)
+
+    def test_cache_versions_and_finalize_inventory(self):
+        self._stub_associations_packages({
+            'containerd': {host: 'containerd=1.5.9-0ubuntu1~20.04.4' for host in self.initial_hosts},
+            'auditd': {host: 'auditd=1:2.8.5-2ubuntu6' for host in self.initial_hosts},
+        })
+        self._stub_custom_packages({
+            'curl': {host: 'curl=7.68.0-1ubuntu2.14' for host in self.hosts},
+            'unzip': {host: 'unzip=6.0-25ubuntu1.1' for host in self.hosts},
+        })
+
+        cluster = self._new_cluster()
+        cache_installed_packages(cluster)
+
+        self.assertEqual('containerd=1.5.9-0ubuntu1~20.04.4',
+                         package_associations(cluster.inventory, 'debian', 'containerd')['package_name'][0],
+                         "containerd was not detected")
+        self.assertEqual('auditd=1:2.8.5-2ubuntu6',
+                         package_associations(cluster.inventory, 'debian', 'audit')['package_name'],
+                         "auditd was not detected")
+        self.assertEqual({'curl', 'unzip'}, set(self._packages_include(cluster.inventory)),
+                         "Custom packages versions should be not detected when adding node")
+
+        finalized_inventory = make_finalized_inventory(cluster)
+        self.assertEqual('containerd=1.5.9-0ubuntu1~20.04.4',
+                         package_associations(finalized_inventory, 'debian', 'containerd')['package_name'][0],
+                         "containerd was not detected")
+        self.assertEqual('auditd=1:2.8.5-2ubuntu6',
+                         package_associations(finalized_inventory, 'debian', 'audit')['package_name'],
+                         "auditd was not detected")
+        self.assertEqual({'curl=7.68.0-1ubuntu2.14', 'unzip=6.0-25ubuntu1.1'}, set(self._packages_include(finalized_inventory)),
+                         "Custom packages versions should be detected in finalized inventory")
+
+    def test_cache_versions_global_off(self):
+        expected_containerd = 'containerd=1.5.9-0ubuntu1~20.04.4'
+        default_containerd = get_compiled_defaults()['debian']['containerd']['package_name'][0]
+        self.assertNotEqual(expected_containerd, default_containerd)
+
+        self._stub_associations_packages({
+            'containerd': {host: expected_containerd for host in self.initial_hosts},
+        })
+
+        set_cache_versions_false(self.inventory, None, None)
+        cluster = self._new_cluster()
+        cache_installed_packages(cluster)
+
+        self.assertEqual(default_containerd,
+                         package_associations(cluster.inventory, 'debian', 'containerd')['package_name'][0],
+                         "containerd should be default because caching versions is off")
+
+        finalized_inventory = make_finalized_inventory(cluster)
+        self.assertEqual(expected_containerd,
+                         package_associations(finalized_inventory, 'debian', 'containerd')['package_name'][0],
+                         "containerd was not detected")
+
+    def test_cache_versions_specific_off(self):
+        default_containerd = get_compiled_defaults()['debian']['containerd']['package_name'][0]
+        default_haproxy = get_compiled_defaults()['debian']['haproxy']['package_name']
+
+        self._stub_associations_packages({
+            'containerd': {host: 'containerd=1.5.9-0ubuntu1~20.04.4' for host in self.initial_hosts},
+            'auditd': {host: 'auditd=1:2.8.5-2ubuntu6' for host in self.initial_hosts},
+            'haproxy': {host: 'haproxy=2.0.29-0ubuntu1' for host in self.initial_hosts},
+        })
+
+        set_cache_versions_false(self.inventory, None, 'containerd')
+        set_cache_versions_false(self.inventory, 'debian', 'haproxy')
+        cluster = self._new_cluster()
+        cache_installed_packages(cluster)
+
+        self.assertEqual(default_containerd,
+                         package_associations(cluster.inventory, 'debian', 'containerd')['package_name'][0],
+                         "containerd should be default because caching versions is off")
+        self.assertEqual('auditd=1:2.8.5-2ubuntu6',
+                         package_associations(cluster.inventory, 'debian', 'audit')['package_name'],
+                         "auditd was not detected")
+        self.assertEqual(default_haproxy,
+                         package_associations(cluster.inventory, 'debian', 'haproxy')['package_name'],
+                         "haproxy should be default because caching versions is off")
+
+        finalized_inventory = make_finalized_inventory(cluster)
+        self.assertEqual('containerd=1.5.9-0ubuntu1~20.04.4',
+                         package_associations(finalized_inventory, 'debian', 'containerd')['package_name'][0],
+                         "containerd was not detected")
+        self.assertEqual('auditd=1:2.8.5-2ubuntu6',
+                         package_associations(finalized_inventory, 'debian', 'audit')['package_name'],
+                         "auditd was not detected")
+        self.assertEqual('haproxy=2.0.29-0ubuntu1',
+                         package_associations(finalized_inventory, 'debian', 'haproxy')['package_name'],
+                         "haproxy was not detected")
+
+    def test_add_node_fails_different_package_versions(self):
+        self._stub_associations_packages({
+            'containerd': {
+                self.initial_hosts[0]: 'containerd=1.5.9-0ubuntu1~20.04.4',
+                self.initial_hosts[1]: 'containerd=2',
+            },
+        })
+
+        cluster = self._new_cluster()
+        expected_error_regex = packages.ERROR_MULTIPLE_PACKAGE_VERSIONS_DETECTED.replace('%s', '.*')
+        with self.assertRaisesRegex(Exception, expected_error_regex):
+            cache_installed_packages(cluster)
+
+    def test_finalize_inventory_different_package_versions(self):
+        default_containerd = get_compiled_defaults()['debian']['containerd']['package_name'][0]
+
+        self._stub_associations_packages({
+            'containerd': {
+                self.initial_hosts[0]: 'containerd=1.5.9-0ubuntu1~20.04.4',
+                self.initial_hosts[1]: 'containerd=2',
+            },
+            'auditd': {host: 'auditd=1:2.8.5-2ubuntu6' for host in self.initial_hosts},
+        })
+        self._stub_custom_packages({
+            'curl=7.*': {
+                self.initial_hosts[0]: 'curl=7.68.0-1ubuntu2.14',
+                self.initial_hosts[1]: 'curl=2',
+            },
+            'unzip=6.*': {host: 'unzip=6.0-25ubuntu1.1' for host in self.hosts},
+        })
+
+        cluster = self._new_cluster()
+
+        finalized_inventory = make_finalized_inventory(cluster)
+        self.assertEqual(default_containerd,
+                         package_associations(finalized_inventory, 'debian', 'containerd')['package_name'][0],
+                         "containerd should be default because multiple versions are installed")
+        self.assertEqual('auditd=1:2.8.5-2ubuntu6',
+                         package_associations(finalized_inventory, 'debian', 'audit')['package_name'],
+                         "auditd was not detected")
+        self.assertEqual({'curl=7.*', 'unzip=6.0-25ubuntu1.1'}, set(self._packages_include(finalized_inventory)),
+                         "Custom packages versions should be partially detected in finalized inventory")
+
+    def test_not_cache_versions_if_multiple_os_family_versions(self):
+        default_containerd = get_compiled_defaults()['debian']['containerd']['package_name'][0]
+
+        self._stub_associations_packages({
+            'containerd': {host: 'containerd=1.5.9-0ubuntu1~20.04.4' for host in self.initial_hosts},
+        })
+        self._stub_custom_packages({
+            'curl=7.*': {host: 'curl=7.68.0-1ubuntu2.14' for host in self.hosts},
+        })
+
+        self.context['nodes'][self.new_host]['os']['version'] = '22.04'
+        cluster = self._new_cluster()
+        cache_installed_packages(cluster)
+
+        self.assertEqual(default_containerd,
+                         package_associations(cluster.inventory, 'debian', 'containerd')['package_name'][0],
+                         "containerd should be default because multiple OS versions are detected")
+
+        finalized_inventory = make_finalized_inventory(cluster)
+        self.assertEqual(default_containerd,
+                         package_associations(finalized_inventory, 'debian', 'containerd')['package_name'][0],
+                         "containerd should be default because multiple OS versions are detected")
+        self.assertEqual({'curl=7.*'}, set(self._packages_include(finalized_inventory)),
+                         "Custom packages should be default because multiple OS versions are detected")


### PR DESCRIPTION
### Description
1. `cluster_finalized.yaml` no longer caches versions of custom packages from `services.packages.install` section after #168
1. Changes in enrichment procedure in #181 related to `cache_versions` property are doubtful and should be reverted/reworked.
    * If the user customizes an association, its caching is skipped during add_node.
      Instead, turning the caching off should be done intentionally via the same `cache_versions=false` property for each necessary association.
    * If the user uses `cache_versions=false` for all associations, we do not use our recommended package versions.
      We should do use recommended versions.
      The user will still be able to not follow our recommendations by explicitly redefining of `package_name` section of each necessary association.
1. Detection and work with OS versions are weird and should be reworked.

Fixes #262

### Solution
* Enrichment procedure is changed as per the p. 2 of the Description.
* `cluster_finalized.yaml` now caches package versions independently on `cache_versions` property.
  If any package is installed with different versions on different nodes, warning is printed and the package is taken as-is from the inventory.
  If multiple OS families or versions detected on nodes, packages detection is skipped.
* Major refactoring of OS and package versions detection, enrichment and usage.
    * Enrichment of packages now happens independently on whether it is `add_node` or any other procedure.
      Customized packages are moved to OS family specific section and later used from there.
    * It is **no longer possible** to customize associations in global section for clusters in multiple OS.
      The customization should be moved to the corresponding OS specific section before OS migration.
    * `cluster.context['os']` variable is removed. Now cluster global OS is detected using `cluster.get_os_family()`.
      It does not depend on the procedure with the only exception that global OS family is calculated based on final nodes only.
    * `NodeGroup.get_nodes_os()` no longer accepts any flag.
      It returns OS family of really those group on which it is called and does not throw exceptions for unsupported or multiple OS families.
* Fixed unnecessary audit installation if balancer is added.
* Resolving of `cluster_finalized.yaml` is rewritten to enrichment-like style.
* Other fixes of `cluster_finalized.yaml` resolving if multiple OS families or versions detected on nodes or if some nodes are not sudoers.
* Fixes in `check_paas` procedure for clusters on multiple OS.
* Other refactoring and fixes.

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: All nodes have the same OS
- Inventory: Any with non-empty `services.packages.install` section. Some of packages have equal version on all nodes and some of them do not.

Steps:

1. Run any procedure

Results:

| Before | After |
| ------ | ------ |
| `cluster_finalized.yaml` does not contain versions for `services.packages.install` section | Packages that have equal version on all nodes are cached. For other packages there are warnings in logs. |

### Regression Tests
* `upgrade` and `migrate_cri` procedures with custom `packages` sections.
* Audit installation on cluster with debian nodes.
* OS migration
* `add_node` when initial nodes having different associations packages versions and if `cache_versions` option is specified.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation.
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description.
- [x] There is no merge conflicts


#### Unit tests
* test_cluster.py: added tests for cluster.get_os_family()
* test_audit.py, test_haproxy.py, test_keepalived.py: fixes according to new enrichment approach
* test_migrate_cri.py, test_upgrade.py: added tests for packages enrichment and finalization
* test_packages.py: added many tests for packages enrichment, detection and caching.
