### PR TITLE
[MANOPD-80808]Failed CIS compliance checks for Kubernetes v1.23 deployed from Kubemarine 0.7.0

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -343,6 +343,7 @@ def install(group):
                     hostname=node["name"])
                 log.debug("Uploading to '%s'..." % node["connect_to"])
                 node["connection"].put(io.StringIO(template + "\n"), '/etc/systemd/system/kubelet.service', sudo=True)
+                node["connection"].sudo("chmod 644 /etc/systemd/system/kubelet.service")
 
         log.debug("\nReloading systemd daemon...")
         system.reload_systemctl(group)

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -32,8 +32,9 @@ services:
         audit-log-path: /var/log/kubernetes/audit/audit.log
         audit-policy-file: /etc/kubernetes/audit-policy.yaml
         audit-log-maxage: "30"
-        audit-log-maxbackup: "5"
-        audit-log-maxsize: "20"
+        audit-log-maxbackup: "10"
+        audit-log-maxsize: "100"
+        kubelet-certificate-authority: /etc/kubernetes/pki/ca.crt
       extraVolumes:
         - name: audit
           hostPath: '{{ services["kubeadm"]["apiServer"]["extraArgs"]["audit-policy-file"] }}'


### PR DESCRIPTION
### Description

* Failed CIS compliance checks for Kubernetes v1.23 

### Solution

* Change in code to pass test validation

### Test Cases

**TestCase 1**
Run check Kube-Bench

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 22.04
- Inventory: AllInOne

Steps:

1. Starting the cluster verification procedure
Results:

| Before | After |
| ------ | ------ |
| Four failed tests | One failed test |

**Note** This test failed due to the non-support of the checker of this type of cluster. The developer has a ticket for this [problem](https://github.com/aquasecurity/kube-bench/issues/1275)
### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


