### PR TITLE
[MANOPD-80822] adjust typha toleration settings and add toleration configuration option

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3283,6 +3283,8 @@ plugins:
     mtu: 1400
     typha:
       enabled: true
+      nodeSelector:
+        region: infra
     node:
       image: calico/node:v3.10.1
     env:
@@ -3341,7 +3343,7 @@ If necessary, remove `route-reflector` label from the cluster.yaml as well.
 
 **Warning**: For correct network communication, it is important to set the correct MTU value (For example in case `ipip` mode it should be 20 bytes less than MTU NIC size), see more details in [Troubleshooting Guide](Troubleshooting.md#packets-between-nodes-in-different-networks-are-lost).
 
-**Note**: If the cluster size is more than 50 nodes, it is recommended to enable the Calico Typha daemon and adjust the size of its replicas.
+**Note**: If the cluster size is more than 3 nodes, Calico Typha daemon is enabled by default and number of its replicas is incremented with every 50 nodes. This behavior can be overridden with cluster.yaml.
 
 The plugin configuration supports the following parameters:
 
@@ -3354,9 +3356,10 @@ The plugin configuration supports the following parameters:
 | announceServices       | boolean | false                               | true/false                                       | Enable announces of ClusterIP services CIDR through BGP            |
 | defaultAsNumber        | int     | 64512                               |                                                  | AS Number to be used by default for this cluster                   |
 | globalBgpPeers         | list    | []                                  | list of (IP,AS) pairs                            | List of global BGP Peer (IP,AS) values                             |
-| typha.enabled          | boolean | `false`                             | Enable if you have more than 50 nodes in cluster | Enables the [Typha Daemon](https://github.com/projectcalico/typha) |
-| typha.replicas         | int     | `{{ (((nodes\                       | length)/50) + 1) \                               | round(1) }}`                                                       |1 replica for every 50 cluster nodes|Number of Typha running replicas|
+| typha.enabled          | boolean | `true` or `false`                   | if nodes < 4 then `true` else `false`            | Enables the [Typha Daemon](https://github.com/projectcalico/typha) |
+| typha.replicas         | int     | `{{ (((nodes\                       | length)/50) + 2) \                               | round(1) }}`                                                       |Starts from 2 replicas amd increments for every 50  nodes|Number of Typha running replicas|
 | typha.image            | string  | `calico/typha:v3.10.1`              | Should contain both image name and version       | Calico Typha image                                                 |
+| typha.tolerations      | list    |                                     |                                                  | Custom toleration for calico-typha pods                            |
 | cni.image              | string  | `calico/cni:v3.10.1`                | Should contain both image name and version       | Calico CNI image                                                   |
 | node.image             | string  | `calico/node:v3.10.1`               | Should contain both image name and version       | Calico Node image                                                  |
 | kube-controllers.image | string  | `calico/kube-controllers:v3.10.1`   | Should contain both image name and version       | Calico Kube Controllers image                                      |

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3356,7 +3356,7 @@ The plugin configuration supports the following parameters:
 | announceServices       | boolean | false                               | true/false                                       | Enable announces of ClusterIP services CIDR through BGP            |
 | defaultAsNumber        | int     | 64512                               |                                                  | AS Number to be used by default for this cluster                   |
 | globalBgpPeers         | list    | []                                  | list of (IP,AS) pairs                            | List of global BGP Peer (IP,AS) values                             |
-| typha.enabled          | boolean | `true` or `false`                   | if nodes < 4 then `true` else `false`            | Enables the [Typha Daemon](https://github.com/projectcalico/typha) |
+| typha.enabled          | boolean | `true` or `false`                   | If nodes < 4 then `false` else `true`            | Enables the [Typha Daemon](https://github.com/projectcalico/typha) |
 | typha.replicas         | int     | `{{ (((nodes\                       | length)/50) + 2) \                               | round(1) }}`                                                       |Starts from 2 replicas amd increments for every 50  nodes|Number of Typha running replicas|
 | typha.image            | string  | `calico/typha:v3.10.1`              | Should contain both image name and version       | Calico Typha image                                                 |
 | typha.tolerations      | list    |                                     |                                                  | Custom toleration for calico-typha pods                            |

--- a/kubemarine/templates/plugins/calico-v3.21.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.21.yaml.j2
@@ -4109,6 +4109,10 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/kubemarine/templates/plugins/calico-v3.21.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.21.yaml.j2
@@ -4109,10 +4109,13 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node.kubernetes.io/network-unavailable
           effect: NoSchedule
-        - key: node-role.kubernetes.io/control-plane
-          effect: NoSchedule
+        - key: node.kubernetes.io/network-unavailable
+          effect: NoExecute
+        {% if plugins['calico']['typha']['tolerations'] is defined -%}
+          {{ plugins['calico']['typha']['tolerations'] | toyaml | indent(width=8, indentfirst=False) -}}
+        {%- endif %}
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/kubemarine/templates/plugins/calico-v3.21.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.21.yaml.j2
@@ -4109,7 +4109,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-<<<<<<< HEAD
         - key: node.kubernetes.io/network-unavailable
           effect: NoSchedule
         - key: node.kubernetes.io/network-unavailable
@@ -4117,12 +4116,6 @@ spec:
         {% if plugins['calico']['typha']['tolerations'] is defined -%}
           {{ plugins['calico']['typha']['tolerations'] | toyaml | indent(width=8, indentfirst=False) -}}
         {%- endif %}
-=======
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/control-plane
-          effect: NoSchedule
->>>>>>> 23aed5d2be4ae2c0319ae2aab45c78a93abc977e
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/kubemarine/templates/plugins/calico-v3.22.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.22.yaml.j2
@@ -4110,7 +4110,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-<<<<<<< HEAD
         - key: node.kubernetes.io/network-unavailable
           effect: NoSchedule
         - key: node.kubernetes.io/network-unavailable
@@ -4118,12 +4117,6 @@ spec:
         {% if plugins['calico']['typha']['tolerations'] is defined -%}
           {{ plugins['calico']['typha']['tolerations'] | toyaml | indent(width=8, indentfirst=False) -}}
         {%- endif %}
-=======
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/control-plane
-          effect: NoSchedule
->>>>>>> 23aed5d2be4ae2c0319ae2aab45c78a93abc977e
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/kubemarine/templates/plugins/calico-v3.22.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.22.yaml.j2
@@ -4110,10 +4110,13 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node.kubernetes.io/network-unavailable
           effect: NoSchedule
-        - key: node-role.kubernetes.io/control-plane
-          effect: NoSchedule
+        - key: node.kubernetes.io/network-unavailable
+          effect: NoExecute
+        {% if plugins['calico']['typha']['tolerations'] is defined -%}
+          {{ plugins['calico']['typha']['tolerations'] | toyaml | indent(width=8, indentfirst=False) -}}
+        {%- endif %}
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/kubemarine/templates/plugins/calico-v3.22.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.22.yaml.j2
@@ -4111,8 +4111,8 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
         - key: node-role.kubernetes.io/master
-          operator: Equal
-          value: true
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.

--- a/kubemarine/templates/plugins/calico-v3.22.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.22.yaml.j2
@@ -4110,6 +4110,10 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Equal
+          value: true
+          effect: NoSchedule
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/kubemarine/templates/plugins/calico-v3.24.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.24.yaml.j2
@@ -4424,7 +4424,9 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
         - key: node-role.kubernetes.io/master
-          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/kubemarine/templates/plugins/calico-v3.24.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.24.yaml.j2
@@ -4423,10 +4423,13 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node.kubernetes.io/network-unavailable
           effect: NoSchedule
-        - key: node-role.kubernetes.io/control-plane
-          effect: NoSchedule
+        - key: node.kubernetes.io/network-unavailable
+          effect: NoExecute
+        {% if plugins['calico']['typha']['tolerations'] is defined -%}
+          {{ plugins['calico']['typha']['tolerations'] | toyaml | indent(width=8, indentfirst=False) -}}
+        {%- endif %}
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/kubemarine/templates/plugins/calico-v3.24.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.24.yaml.j2
@@ -4423,6 +4423,8 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/kubemarine/templates/plugins/calico-v3.24.yaml.j2
+++ b/kubemarine/templates/plugins/calico-v3.24.yaml.j2
@@ -4423,7 +4423,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-<<<<<<< HEAD
         - key: node.kubernetes.io/network-unavailable
           effect: NoSchedule
         - key: node.kubernetes.io/network-unavailable
@@ -4431,12 +4430,6 @@ spec:
         {% if plugins['calico']['typha']['tolerations'] is defined -%}
           {{ plugins['calico']['typha']['tolerations'] | toyaml | indent(width=8, indentfirst=False) -}}
         {%- endif %}
-=======
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/control-plane
-          effect: NoSchedule
->>>>>>> 23aed5d2be4ae2c0319ae2aab45c78a93abc977e
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node


### PR DESCRIPTION
### Description
By default typha pods cannot be scheduled to master nodes. In some cases it's necessary to allow typha pods to master nodes. So possibility to configure toleration for calico-typha pods is added.
Also added toleration to node.kubernetes.io/network-unavailable: NoSchedule|NoExecute. 

Fixes # (issue)
MANOPD-80822

### Solution
Toleration is added for typha pods:

        - key: node.kubernetes.io/network-unavailable
          effect: NoSchedule
        - key: node.kubernetes.io/network-unavailable
          effect: NoExecute

Also added possibility to set additional tolerations in cluster.yaml

### How to apply
Deploy calico plugin.

### Test Cases
1. Deploy calico at 4+ nodes cluster.
 ER: Typha pods are scheduled and running and have toleration to node-role.kubernetes.io/network-unreachable (NoSchedule, NoExecute).

2. Add to cluster.yaml additional toleration settings, for example:
```
plugins:
  calico:
    install: true
    typha:
      enabled: true
      tolerations:
      - key: node-role.kubernetes.io/control-plane
        effect: NoSchedule
      - key: someotherkey
        operator: Exists
        effect: NoExecute
```
and deploy calico plugin in a cluster with 4+ nodes.

ER: Typha pods are scheduled and running and have toleration to node-role.kubernetes.io/network-unreachable and those from cluster.yaml.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
