### PR TITLE
Rework procedure check status firewallD

### DIFF
--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -401,7 +401,7 @@ def disable_firewalld(group, check_post=None):
 
     if disabled_status and restart_node != True:
         log.debug("Skipped - FirewallD already disabled or not installed")
-        return result
+        return result, disabled_status
     if restart_node == True:
         group.cluster.schedule_cumulative_point(reboot_nodes)
         group.cluster.schedule_cumulative_point(verify_system)

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -659,11 +659,12 @@ def verify_system(group):
         firewalld_disabled, firewalld_result = is_firewalld_disabled(group)
         log.debug(firewalld_result)
         if not firewalld_disabled:
-            raise Exception("FirewallD is still enabled")
+            log.debug("FirewallD is still enabled")
+            disable_service(group, name='firewalld', now=True)
+            reboot_nodes(group)
+            verify_system(group)
         else:
             log.debug("FirewallD disabled")
-    else:
-        log.debug('FirewallD verification skipped - origin disable task was not completed')
 
     if group.cluster.is_task_completed('prepare.system.disable_swap'):
         log.debug("Verifying swap...")

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -380,12 +380,12 @@ def fetch_firewalld_status(group: NodeGroup) -> NodeGroupResult:
 
 def is_firewalld_disabled(group):
     result = fetch_firewalld_status(group)
-    disabled_status = True
+    disabled_status = False
 
     for node_result in list(result.values()):
-        if node_result.return_code != 4 and "disabled" not in node_result.stdout:
-            disabled_status = False
-
+        if node_result.return_code == 4 and "inactive" not in node_result.stdout or \
+                node_result.return_code == 3 and "inactive" in node_result.stdout:
+            disabled_status = True
     return disabled_status, result
 
 
@@ -660,6 +660,8 @@ def verify_system(group):
         log.debug(firewalld_result)
         if not firewalld_disabled:
             raise Exception("FirewallD is still enabled")
+        else:
+            log.debug("FirewallD disabled")
     else:
         log.debug('FirewallD verification skipped - origin disable task was not completed')
 

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -385,12 +385,11 @@ def is_firewalld_disabled(group):
     for node_result in list(result.values()):
         if node_result.return_code == 4:
             disabled_status = True
-        elif node_result.return_code == 3 and "disabled" not in node_result.stdout:
-            return disabled_status, result
         elif node_result.return_code == 3 and "disabled" in node_result.stdout:
             disabled_status = True
         else:
-            disabled_status = False
+            disable_service(node_result.connection, name='firewalld', now=True)
+            disabled_status = True
     return disabled_status, result
 
 
@@ -402,16 +401,6 @@ def disable_firewalld(group):
     if already_disabled:
         log.debug("Skipped - FirewallD already disabled or not installed")
         return result
-
-    log.verbose("Trying to stop and disable FirewallD...")
-
-    result = disable_service(group, name='firewalld', now=True)
-
-    group.cluster.schedule_cumulative_point(reboot_nodes)
-    group.cluster.schedule_cumulative_point(verify_system)
-
-    return result
-
 
 def is_swap_disabled(group):
     result = group.sudo("cat /proc/swaps", warn=True)


### PR DESCRIPTION
### Description

* Incorrect operation of checking the status of firewalld in the scenarios of a installation and adding a new node. When the firewall status is inactive on the nodes

### Solution

* Adding a new check in the firewallD Status check procedure

### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

    Hardware: 4CPU/4GB
    OS: Ubuntu 22.04
    Inventory: AllInOne

Steps:

1. install(firewallD disabled) 

Results:

| Before | After |
| ------ | ------ |
| Procedure fail | Procedure OK |

2. add node(firewallD disabled)

Results:

| Before | After |
| ------ | ------ |
| Procedure fail | Procedure OK |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


