### PR TITLE
[MANOPD-00000] Fix for Kubernetes 1.25 adoption

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2867,7 +2867,7 @@ services:
 
 *Installation task*: `deploy.admission`
 
-There are two options for admissions: `psp` and `pss`. PodSecurityPolicy (PSP) is being deprecated in Kubernetes 1.21 and will be removed in Kubernetes 1.25. Kubernetes 1.23 supports Pod Security Standards (PSS) that are implemented as a feature gate of `kube-apiserver`.
+There are two options for admissions: `psp` and `pss`. PodSecurityPolicy (PSP) is being deprecated in Kubernetes 1.21 and will be removed in Kubernetes 1.25. Kubernetes 1.23 supports Pod Security Standards (PSS) that are implemented as a feature gate of `kube-apiserver`. Since Kubernetes v1.25 doesn't support PSP, installation and other maintenance procedure assume the `cluster.yaml` includes `admission: pss` explicitly.
 
 ```yaml
 rbac:

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2867,7 +2867,7 @@ services:
 
 *Installation task*: `deploy.admission`
 
-There are two options for admissions: `psp` and `pss`. PodSecurityPolicy (PSP) is being deprecated in Kubernetes 1.21 and will be removed in Kubernetes 1.25. Kubernetes 1.23 supports Pod Security Standards (PSS) that are implemented as a feature gate of `kube-apiserver`. Since Kubernetes v1.25 doesn't support PSP, installation and other maintenance procedure assume the `cluster.yaml` includes `admission: pss` explicitly.
+There are two options for admissions: `psp` and `pss`. PodSecurityPolicy (PSP) is being deprecated in Kubernetes 1.21 and will be removed in Kubernetes 1.25. Kubernetes 1.23 supports Pod Security Standards (PSS) that are implemented as a feature gate of `kube-apiserver`. Since Kubernetes v1.25 doesn't support PSP, installation and maintenance procedures assume the `cluster.yaml` includes `admission: pss` explicitly.
 
 ```yaml
 rbac:

--- a/kubemarine/admission.py
+++ b/kubemarine/admission.py
@@ -655,12 +655,6 @@ def manage_pss_enrichment(inventory, cluster):
 
 
 def manage_enrichment(inventory, cluster):
-    # workaround for easy install Kubernetes v1.25 that doesn't have PSP at all:
-    # if the 'admission' parameter is empty in 'cluster.yaml', then set it to 'pss' instead of 'psp'
-    minor_version = int(inventory["services"]["kubeadm"]["kubernetesVersion"].split('.')[1])
-    if minor_version >= 25:
-        if cluster.context.get('initial_procedure') == 'install' and not cluster.raw_inventory['rbac'].get('admission', ''):
-            inventory['rbac']['admission'] = "pss"
     admission_impl = inventory['rbac']['admission']
     if admission_impl == "psp":
         return manage_psp_enrichment(inventory, cluster)

--- a/kubemarine/procedures/migrate_cri.py
+++ b/kubemarine/procedures/migrate_cri.py
@@ -216,7 +216,7 @@ def _migrate_cri(cluster, node_group):
                 node['connection'].sudo("sleep 30 && "
                                         "sudo kubectl -n kube-system  delete pod "
                                         "$(sudo kubectl -n kube-system get pod --field-selector='status.phase=Pending' | "
-                                        "grep 'kube-proxy' | awk '{ print $1 }')")
+                                        "grep 'kube-proxy' | awk '{ print $1 }') || true")
             kubernetes.wait_for_any_pods(cluster, node["connection"], apply_filter=node["name"])
             # check ETCD health
             etcd.wait_for_health(cluster, node["connection"])


### PR DESCRIPTION
### Description
* Workaround for `admission` makes changes implicitly
* `migrate_cri` procedure doesn't work for CentOS


### Solution
* Delete workaround for `admission`
* Update documentation in Admission article
* Fix `migrate_cri`


### How to apply
The `cluster.yaml` must include `admission: pss` for successful running any procedure if Kubernetes has version 1.25


### Test Cases

**TestCase 1**
The `migrate_cri` procedure works for CentOS

Test Configuration:

- Hardware: 2CPU/4GB
- OS: CentOS7
- Inventory: FullHA

Steps:

1. Install Kubernetes cluster with `containerRuntime: docker`
2. Run `migrate_cri` pricedure

Results:

| Before | After |
| ------ | ------ |
| Fail | Success |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


