### PR TITLE
Update check_iaas.py

### DIFF
--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -258,6 +258,12 @@ def system_distributive(cluster):
             else:
                 detected_supported_os.append(detected_os)
                 cluster.log.debug('Host %s running \"%s\"' % (address, detected_os))
+                result = all(versions == detected_os[0] for versions in detected_os)
+                if (result):
+                    print ("Detected versions are similar")
+                else:
+                    raise TestWarn ("Detected OS versions are not similar",
+                    hint="Install similar verions of OS on all nodes")
 
         detected_supported_os = list(set(detected_supported_os))
         detected_unsupported_os = list(set(detected_unsupported_os))


### PR DESCRIPTION
### Description
Check_iaas should provide an warning if different OS versions are installed on nodes


### Solution
Adding a new check in the check_iaas procedure


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:
Initial set-up:
node1: Ubuntu 22.04
node2: Ubuntu 20.04
node3: Ubuntu 20.04

Steps:

1. kubemarine check_iaas

Results:
 k8s-stack.sdntest.testcluster.com DEBUG Host 10.102.0.67 running "ubuntu 22.04"
 System     WARN    008  Distibutive ................................ Detected OS versions are not similar
          HINT:
               Install similar verions of OS on all nodes

![image](https://user-images.githubusercontent.com/100134503/203015932-23f1ec66-e789-4617-8aec-ce7ef44de63a.png)

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts



