### PR TITLE
[MANOPD-81799] Fix images

### DIFF
--- a/kubemarine/plugins/calico.py
+++ b/kubemarine/plugins/calico.py
@@ -159,7 +159,7 @@ def enrich_deployment_calico_kube_controllers(cluster, obj_list):
     for container in obj_list[key]['spec']['template']['spec']['containers']:
         if container['name'] == "calico-kube-controllers":
             num = obj_list[key]['spec']['template']['spec']['containers'].index(container)
-            val = f"{cluster.inventory['plugins']['calico']['kube-controllers']['image']}"
+            val = enrich_image(cluster, cluster.inventory['plugins']['calico']['kube-controllers']['image'])
             obj_list[key]['spec']['template']['spec']['containers'][num]['image'] = val
             cluster.log.verbose(f"The {key} has been patched in "
                                 f"'spec.template.spec.containers.[{num}].image with '{val}'")
@@ -177,26 +177,26 @@ def enrich_daemonset_calico_node(cluster, obj_list):
     for container in obj_list[key]['spec']['template']['spec']['initContainers']:
         if container['name'] in ['upgrade-ipam', 'install-cni']: 
             num = obj_list[key]['spec']['template']['spec']['initContainers'].index(container)
-            val = f"{cluster.inventory['plugins']['calico']['cni']['image']}"
+            val = enrich_image(cluster, cluster.inventory['plugins']['calico']['cni']['image'])
             obj_list[key]['spec']['template']['spec']['initContainers'][num]['image'] = val
             cluster.log.verbose(f"The {key} has been patched in "
                                 f"'spec.template.spec.initContainers.[{num}].image' with '{val}'")
         if container['name'] == "mount-bpffs":
             num = obj_list[key]['spec']['template']['spec']['initContainers'].index(container)
-            val = f"{cluster.inventory['plugins']['calico']['node']['image']}"
+            val = enrich_image(cluster, cluster.inventory['plugins']['calico']['node']['image'])
             obj_list[key]['spec']['template']['spec']['initContainers'][num]['image'] = val
             cluster.log.verbose(f"The {key} has been patched in "
                                 f"'spec.template.spec.initContainers.[{num}].image' with '{val}'")
         if container['name'] == "flexvol-driver":
             num = obj_list[key]['spec']['template']['spec']['initContainers'].index(container)
-            val = f"{cluster.inventory['plugins']['calico']['flexvol']['image']}"
+            val = enrich_image(cluster, cluster.inventory['plugins']['calico']['flexvol']['image'])
             obj_list[key]['spec']['template']['spec']['initContainers'][num]['image'] = val
             cluster.log.verbose(f"The {key} has been patched in "
                                 f"'spec.template.spec.initContainers.[{num}].image' with '{val}'")
     for container in obj_list[key]['spec']['template']['spec']['containers']:
         if container['name'] == "calico-node":
             num = obj_list[key]['spec']['template']['spec']['containers'].index(container)
-            val = f"{cluster.inventory['plugins']['calico']['node']['image']}"
+            val = enrich_image(cluster, cluster.inventory['plugins']['calico']['node']['image'])
             obj_list[key]['spec']['template']['spec']['containers'][num]['image'] = val 
             cluster.log.verbose(f"The {key} has been patched in "
                                 f"'spec.template.spec.containers.[{num}].image' with '{val}'")
@@ -251,7 +251,7 @@ def enrich_deployment_calico_typha(cluster, obj_list):
     for container in obj_list[key]['spec']['template']['spec']['containers']:
         if container['name'] == "calico-typha":
             num = obj_list[key]['spec']['template']['spec']['containers'].index(container)
-            val = f"{cluster.inventory['plugins']['calico']['typha']['image']}"
+            val = enrich_image(cluster, cluster.inventory['plugins']['calico']['typha']['image'])
             obj_list[key]['spec']['template']['spec']['containers'][num]['image'] = val
             cluster.log.verbose(f"The {key} has been patched in "
                                 f"'spec.template.spec.containers.[{num}].image with '{val}'")
@@ -405,6 +405,19 @@ def true_or_false(input_string):
         result = "undefined"
 
     return result
+
+def enrich_image(cluster, image):
+    """
+    The method implements some validations for Calico objects
+    :param cluster: Cluster object
+    :param image: particular image
+    """
+    if cluster.inventory['plugins']['calico']['installation'].get('registry', ''):
+        if len(cluster.inventory['plugins']['calico']['installation']['registry']):
+            return f"{cluster.inventory['plugins']['calico']['installation']['registry']}/{image}"
+
+    return image
+
 
 # name of objects and enrichment methods mapping
 enrich_objects_fns = {

--- a/kubemarine/plugins/calico.py
+++ b/kubemarine/plugins/calico.py
@@ -406,9 +406,10 @@ def true_or_false(input_string):
 
     return result
 
+
 def enrich_image(cluster, image):
     """
-    The method implements some validations for Calico objects
+    The method add registry to image if it's necessary
     :param cluster: Cluster object
     :param image: particular image
     """

--- a/kubemarine/plugins/calico.py
+++ b/kubemarine/plugins/calico.py
@@ -409,7 +409,7 @@ def true_or_false(input_string):
 
 def enrich_image(cluster, image):
     """
-    The method add registry to image if it's necessary
+    The method adds registry to image if it's necessary
     :param cluster: Cluster object
     :param image: particular image
     """

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -19,7 +19,7 @@ services:
   kubeadm:
     apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
-    kubernetesVersion: v1.25.2
+    kubernetesVersion: v1.24.0
     controlPlaneEndpoint: '{{ cluster_name }}:6443'
     networking:
       podSubnet: '{% if nodes[0]["internal_address"]|isipv4 %}10.128.0.0/14{% else %}fd02::/48{% endif %}'

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -532,7 +532,7 @@ plugins:
             name: calico-config
             key: veth_mtu
     cni:
-      image: '{% if plugins.calico.installation.registry is defined and plugins.calico.installation.registry|length %}{{ plugins.calico.installation.registry }}/{% endif %}calico/cni:{{ plugins.calico.version }}'
+      image: 'calico/cni:{{ plugins.calico.version }}'
       ipam:
         ipv4:
           assign_ipv4: 'true'
@@ -548,13 +548,13 @@ plugins:
             - default-ipv6-ippool
           type: calico-ipam
     node:
-      image: '{% if plugins.calico.installation.registry is defined and plugins.calico.installation.registry|length %}{{ plugins.calico.installation.registry }}/{% endif %}calico/node:{{ plugins.calico.version }}'
+      image: 'calico/node:{{ plugins.calico.version }}'
     kube-controllers:
-      image: '{% if plugins.calico.installation.registry is defined and plugins.calico.installation.registry|length %}{{ plugins.calico.installation.registry }}/{% endif %}calico/kube-controllers:{{ plugins.calico.version }}'
+      image: 'calico/kube-controllers:{{ plugins.calico.version }}'
       nodeSelector:
         kubernetes.io/os: linux
     flexvol:
-      image: '{% if plugins.calico.installation.registry is defined and plugins.calico.installation.registry|length %}{{ plugins.calico.installation.registry }}/{% endif %}calico/pod2daemon-flexvol:{{ plugins.calico.version }}'
+      image: 'calico/pod2daemon-flexvol:{{ plugins.calico.version }}'
 
   flannel:
     installation:

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -488,7 +488,7 @@ plugins:
         kubernetes.io/os: linux
     env:
       DATASTORE_TYPE: kubernetes
-      WAIT_FOR_DATASTORE: true
+      WAIT_FOR_DATASTORE: 'true'
       CLUSTER_TYPE: k8s,bgp
       CALICO_ROUTER_ID: '{% if not services.kubeadm.networking.podSubnet|isipv4 %}hash{% endif %}'
       IP: '{% if services.kubeadm.networking.podSubnet|isipv4 %}autodetect{% else %}none{% endif %}'
@@ -502,11 +502,11 @@ plugins:
       FELIX_IPV6SUPPORT: '{% if not services.kubeadm.networking.podSubnet|isipv4 %}true{% else %}false{% endif %}'
       CALICO_IPV6POOL_IPIP: '{% if plugins.calico.mode | default("vxlan") == "ipip" and not services.kubeadm.networking.podSubnet|isipv4 %}Always{% else %}Never{% endif %}'
       CALICO_IPV6POOL_VXLAN: '{% if plugins.calico.mode | default("vxlan") == "vxlan" and not services.kubeadm.networking.podSubnet|isipv4 %}Always{% else %}Never{% endif %}'
-      CALICO_DISABLE_FILE_LOGGING: true
+      CALICO_DISABLE_FILE_LOGGING: 'true'
       FELIX_DEFAULTENDPOINTTOHOSTACTION: ACCEPT
       FELIX_LOGSEVERITYSCREEN: info
-      FELIX_HEALTHENABLED: true
-      FELIX_USAGEREPORTINGENABLED: false
+      FELIX_HEALTHENABLED: 'true'
+      FELIX_USAGEREPORTINGENABLED: 'false'
       FELIX_TYPHAK8SSERVICENAME:
           configMapKeyRef:
             name: calico-config

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -19,7 +19,7 @@ services:
   kubeadm:
     apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
-    kubernetesVersion: v1.24.0
+    kubernetesVersion: v1.25.2
     controlPlaneEndpoint: '{{ cluster_name }}:6443'
     networking:
       podSubnet: '{% if nodes[0]["internal_address"]|isipv4 %}10.128.0.0/14{% else %}fd02::/48{% endif %}'


### PR DESCRIPTION
### Description
* `Calico` plugin installation fails in case of using a custom registry


### Solution
* Change `defaults.yaml`
* Implement the image source processing with or without the custom registry


### How to apply
Not applicable


### Test Cases

**TestCase 1**
Check if the fix works

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 20.04
- Inventory: AllInOne

Steps:

1. Run installation procedure. The `cluster.yaml` must have the following section:
```
plugin_defaults:
  installation:
    registry: <some-private-registry:port>
```

Results:

| Before | After |
| ------ | ------ |
| Fail | Success |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts




