### PR TITLE
[MANOPD-81799] Absolute path

### DIFF
--- a/kubemarine/plugins/calico.py
+++ b/kubemarine/plugins/calico.py
@@ -18,6 +18,7 @@ import ruamel.yaml
 from copy import deepcopy
 
 from kubemarine import plugins
+from kubemarine.core import utils
 
 
 
@@ -55,7 +56,8 @@ def apply_calico_yaml(cluster, calico_original_yaml, calico_yaml):
     """
 
     # get original YAML and parse it into dict of objects
-    obj_list = load_multiple_yaml(calico_original_yaml)
+    calico_original_yaml_path = utils.determine_resource_absolute_path(calico_original_yaml)
+    obj_list = load_multiple_yaml(calico_original_yaml_path)
 
     validate_original(cluster, obj_list)
 

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -430,8 +430,8 @@ plugins:
             module: plugins/calico.py
             method: apply_calico_yaml
             arguments:
-              calico_original_yaml: 'kubemarine/plugins/yaml/calico-{{ plugins.calico.version }}.yaml.original'
-              calico_yaml: 'dump/calico-{{ plugins.calico.version }}.yaml'
+              calico_original_yaml: 'plugins/yaml/calico-{{ plugins.calico.version }}.yaml.original'
+              calico_yaml: './dump/calico-{{ plugins.calico.version }}.yaml'
         - expect:
             daemonsets:
               - calico-node


### PR DESCRIPTION
### Description
* Installation on OpsPortal fails


### Solution
* Transform the `calico_original_yaml` to the absolute path


### How to apply
Not applicable



### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


