### PR TITLE
[MANOPD-81951][MANOPD-81795] - Check thirdparty avaliable & check iaas for all-in-one

### DIFF
--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -22,6 +22,10 @@ This section provides information about the Kubecheck functionality.
       - [007 RAM Amount - Control-planes](#007-ram-amount-control-planes)
       - [007 RAM Amount - Workers](#007-ram-amount-workers)
     - [008 Distributive](#008-distributive)
+    - [009 PodSubnet](#009-podsubnet)
+    - [010 ServiceSubnet](#010-servicesubnet)
+    - [011 TCPPorts](#011-tcpports)
+    - [012 Access To Thirdparties](#012-access-to-thirdparties)
   - [PAAS Procedure](#paas-procedure)
     - [201 Service Status](#201-service-status)
       - [201 Haproxy Status](#201-haproxy-status)
@@ -139,6 +143,7 @@ The task tree is as follows:
   * pod_subnet_connectivity
   * service_subnet_connectivity
   * check_tcp_ports
+  * thirdparties_available
 * hardware
   * members_amount
     * vips
@@ -287,6 +292,12 @@ This test checks the connectivity between nodes inside the service's subnetwork.
 *Task*: `network.check_tcp_ports`
 
 This test checks if necessary ports are opened on the nodes.
+
+##### 012 Access To Thirdparties
+
+*Task*: `network.thirdparties_available`
+
+This test checks if thirdparties are available from sources on needed nodes.
 
 #### PAAS Procedure
 

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -296,7 +296,7 @@ def check_access_to_thirdparties(cluster: KubernetesCluster):
                 else:
                     broken.append(f"{host.host}, {destination}: {result.stderr}")
 
-    with TestCase(cluster.context['testsuite'], '009', 'System', 'Access to trirdparties') as tc:
+    with TestCase(cluster.context['testsuite'], '012', 'Network', 'Access to trirdparties') as tc:
         if broken:
             raise TestFailure('Some thirdparties are unavailable', hint=yaml.safe_dump(broken))
         if uninstalled_curl_hosts:
@@ -645,7 +645,8 @@ tasks = OrderedDict({
     'network': {
         'pod_subnet_connectivity': pod_subnet_connectivity,
         'service_subnet_connectivity': service_subnet_connectivity,
-        'check_tcp_ports': check_tcp_ports
+        'check_tcp_ports': check_tcp_ports,
+        'thirdparties_available': check_access_to_thirdparties
     },
     'hardware': {
         'members_amount': {
@@ -667,8 +668,7 @@ tasks = OrderedDict({
         }
     },
     'system': {
-        'distributive': system_distributive,
-        'thirdparties_available': check_access_to_thirdparties
+        'distributive': system_distributive
     }
 })
 

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -549,21 +549,21 @@ compatibility_map:
   hardware:
     minimal:
       balancer:
-        amount: 1
+        amount: 0
         vcpu: 1
         ram: 1
       control-plane:
-        amount: 3
+        amount: 1
         vcpu: 2
         ram: 2
       worker:
-        amount: 3
+        amount: 1
         vcpu: 4
         ram: 4
       vip:
         amount: 0
       all:
-        amount: 3
+        amount: 1
     recommended:
       balancer:
         amount: 2


### PR DESCRIPTION
### Description
Now kubemarine doesn't check, if thidparties are available on cluster nodes. User can handle this situation only during installation/add node procedure, when trirdparties should be actually installer.
Also check iaas always fails on all-in-one scheme because of hardware minimal requirements, described for HA scheme.
* 

Fixes # (issue)
* Additional check iaas task was added for checking thirdparties;
* Hardware minimal requirements were reduced to support all-in-one scheme;

### How to apply
Provide steps how to apply on top previous Kubemarine version to execute on existing clusters
* [Check iaas task/s](documentation/Kubecheck.md#iaas-procedure)


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration: all-in-one cluster

Steps:
1. Run check iaas

Results:

| Before | After |
| ------ | ------ |
| Check iaas failed because of minimal requirements | Check iaas completed with warnings because of not recommended requirements |

**TestCase 2**

Test Configuration: cluster with different thirdparties (avaliable or not) in cluster yaml

Steps:
1. Run check iaas

Results:

| Before | After |
| ------ | ------ |
| Check iaas doesn't thirdparties availability check | Check iaas check, if thirdparty can be downloaded from source |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


