### PR TITLE
[MANOPD-82181] - support string plugin.install values

### DIFF
--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -116,7 +116,7 @@ def make_ansible_inventory(location, cluster):
         if inventory.get(group) is not None:
             for service_name, service_configs in inventory[group].items():
                 # write to inventory only plugins, which will be installed
-                if group != 'plugins' or service_configs.get('install', False) is True:
+                if group != 'plugins' or true_or_false(service_configs.get('install', False)) == 'true':
 
                     config['cluster:vars'].append('\n# %s.%s' % (group, service_name))
 

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -295,6 +295,21 @@ def load_yaml(filepath) -> dict:
         do_fail(f"Failed to load {filepath}", exc)
 
 
+def true_or_false(value):
+    """
+    The method check string and boolean value
+    :param value: Value that should be checked
+    """
+    input_string = str(value)
+    if input_string in ['true', 'True', 'TRUE']:
+        result = "true"
+    elif input_string in ['false', 'False', 'FALSE']:
+        result = "false"
+    else:
+        result = "undefined"
+    return result
+
+
 class ClusterStorage:
     """
     File preservation:

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -135,7 +135,8 @@ def install(cluster, plugins=None):
     plugins_queue = []
     max_priority = 0
     for plugin_name, plugin_item in plugins.items():
-        if plugin_item.get("install", False) and plugin_item.get("installation", {}).get('procedures') is not None:
+        if utils.true_or_false(plugin_item.get("install", False)) == 'true' and \
+                plugin_item.get("installation", {}).get('procedures') is not None:
             plugin_item['plugin_name'] = plugin_name
             plugins_queue.append(plugin_item)
             if plugin_item.get("installation", {}).get('priority') is not None \

--- a/kubemarine/plugins/calico.py
+++ b/kubemarine/plugins/calico.py
@@ -86,7 +86,7 @@ def apply_calico_yaml(cluster, calico_original_yaml, calico_yaml):
         else:
             # enrich 'calico-typha' objects only if it's enabled in 'cluster.yaml'
             # in other case those objects must be excluded
-            str_value = true_or_false(str(cluster.inventory['plugins']['calico']['typha']['enabled']))
+            str_value = utils.true_or_false(cluster.inventory['plugins']['calico']['typha']['enabled'])
             if str_value == 'false':
                 obj_list.pop(key)
                 excluded_list.append(key)
@@ -128,7 +128,7 @@ def enrich_configmap_calico_config(cluster, obj_list):
     val = cluster.inventory['plugins']['calico']['mtu']
     obj_list[key]['data']['veth_mtu'] = str(val)
     cluster.log.verbose(f"The {key} has been patched in 'data.veth_mtu' with '{val}'")
-    str_value = true_or_false(str(cluster.inventory['plugins']['calico']['typha']['enabled']))
+    str_value = utils.true_or_false(cluster.inventory['plugins']['calico']['typha']['enabled'])
     if str_value == "true":
         val = "calico-typha"
     elif str_value == "false":
@@ -221,7 +221,7 @@ def enrich_daemonset_calico_node(cluster, obj_list):
                         env_list.append({'name': name, 'valueFrom': value})
                     cluster.log.verbose(f"The {key} has been patched in "
                                         f"'spec.template.spec.containers.[{num}].env.{name}' with '{value}'")
-                if cluster.inventory['plugins']['calico']['typha']['enabled'] and \
+                if utils.true_or_false(cluster.inventory['plugins']['calico']['typha']['enabled']) == "true" and \
                         name == 'FELIX_TYPHAK8SSERVICENAME':
                     env_list.append({'name': name, 'valueFrom': value})
                     cluster.log.verbose(f"The {key} has been patched in "
@@ -392,21 +392,6 @@ def save_multiple_yaml(filepath, multi_yaml) -> None:
             yaml.dump_all(source_yamls, stream)
     except Exception as exc:
         print(f"Failed to save {filepath}", exc)
-
-
-def true_or_false(input_string):
-    """
-    The method check string and boolean value
-    :param input_string: String that should be checked
-    """
-    if input_string in ['true', 'True', 'TRUE']:
-        result = "true"
-    elif input_string in ['false', 'False', 'FALSE']:
-        result = "false"
-    else:
-        result = "undefined"
-
-    return result
 
 
 def enrich_image(cluster, image):

--- a/kubemarine/plugins/calico.py
+++ b/kubemarine/plugins/calico.py
@@ -29,14 +29,14 @@ def enrich_inventory(inventory, cluster):
     # By default installation parameter is unset, means user did not made any decision
     if inventory["plugins"]["calico"].get("install") is None:
         # Is user defined Flannel plugin and set it to install?
-        flannel_required = inventory["plugins"].get("flannel", {}).get("install", False)
+        flannel_required = utils.true_or_false(inventory["plugins"].get("flannel", {}).get("install", False)) == 'true'
         # Is user defined Canal plugin and set it to install?
-        canal_required = inventory["plugins"].get("canal", {}).get("install", False)
+        canal_required = utils.true_or_false(inventory["plugins"].get("canal", {}).get("install", False)) == 'true'
         # If Flannel and Canal is unset or not required to install, then install Calico
         if not flannel_required and not canal_required:
             inventory["plugins"]["calico"]["install"] = True
 
-    if inventory["plugins"]["calico"]["install"] == True:
+    if utils.true_or_false(inventory["plugins"]["calico"]["install"]) == 'true':
         # Check if original YAML and final YAML have different paths (applicable for non Jinja2 template)
         items = inventory['plugins']['calico']['installation']['procedures']
         for item in items:

--- a/kubemarine/plugins/nginx_ingress.py
+++ b/kubemarine/plugins/nginx_ingress.py
@@ -19,7 +19,7 @@ from kubemarine.core.group import NodeGroup
 
 
 def verify_inventory(inventory, _):
-    if inventory["plugins"]["nginx-ingress-controller"]["install"] is not True:
+    if utils.true_or_false(inventory["plugins"]["nginx-ingress-controller"]["install"]) != "true":
         return inventory
 
     nginx_plugin = inventory["plugins"]["nginx-ingress-controller"]
@@ -43,7 +43,7 @@ def verify_inventory(inventory, _):
 
 
 def enrich_inventory(inventory, _):
-    if inventory["plugins"]["nginx-ingress-controller"]["install"] is not True:
+    if utils.true_or_false(inventory["plugins"]["nginx-ingress-controller"]["install"]) != "true":
         return inventory
 
     if inventory["plugins"]["nginx-ingress-controller"].get('custom_headers'):
@@ -63,7 +63,7 @@ def cert_renew_enrichment(inventory, cluster):
     nginx_plugin = inventory["plugins"]["nginx-ingress-controller"]
 
     # check that renewal is possible
-    if nginx_plugin["install"] is not True:
+    if utils.true_or_false(nginx_plugin["install"]) != 'true':
         raise Exception("Certificates can not be renewed for nginx plugin since it is not installed")
 
     # update certificates in inventory, other check will be performed in "verify_inventory" function


### PR DESCRIPTION
### Description
Because of using jinja we have to support string true/false values. But for `plugins.<name>.install` we support only bool types.
As result  `plugins.<name>.install='false'` don't skip this plugin installation or `plugins.nginx-ingress-controller.install='true'` throws exception during cert renew procedure for ingress-nginx.

### Solution
`true_or_false` function, what is used in calico plugin, was moved to utils. This function was used in conditional statements with `plugins.<name>.install`


### Test Cases

**TestCase 1**

Steps:

1.  Add `plugins.kubernetes-dashboard.install='false'` to cluster.yaml;
2. Run installation procedure;

Results:

| Before | After |
| ------ | ------ |
| kubernetes-dashboard is installed to cluster | kubernetes-dashboard isn't installed |

**TestCase 1**

Steps:

1.  Add `plugins.nginx-ingress-controller.install='true'` to cluster.yaml;
2. Run cert renew procedure with new cert for ingress-nginx;

Results:

| Before | After |
| ------ | ------ |
| Procedure fails with exception | cert is updated |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


