### PR TITLE
[MANOPD-81950] - fix help sections

### DIFF
--- a/kubemarine/core/flow.py
+++ b/kubemarine/core/flow.py
@@ -159,6 +159,7 @@ def create_empty_context(args: dict = None, procedure: str = None):
 
 
 def create_context(parser: argparse.ArgumentParser, cli_arguments: list, procedure: str = None):
+    parser.prog = procedure
     args = vars(parse_args(parser, cli_arguments))
 
     if args.get('exclude_cumulative_points_methods', '').strip() != '':

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -689,7 +689,7 @@ def main(cli_arguments=None):
                         action='store_true',
                         help='forcibly disable HTML report file creation')
 
-    context = flow.create_context(parser, cli_arguments, procedure='iaas')
+    context = flow.create_context(parser, cli_arguments, procedure='check_iaas')
     context['testsuite'] = TestSuite()
     context['preserve_inventory'] = False
 

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1361,7 +1361,7 @@ def main(cli_arguments=None):
                         action='store_true',
                         help='forcibly disable HTML report file creation')
 
-    context = flow.create_context(parser, cli_arguments, procedure='paas')
+    context = flow.create_context(parser, cli_arguments, procedure='check_paas')
     context['testsuite'] = TestSuite()
     context['preserve_inventory'] = False
 

--- a/kubemarine/procedures/do.py
+++ b/kubemarine/procedures/do.py
@@ -24,6 +24,12 @@ from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.group import NodeGroup
 from kubemarine.core.resources import DynamicResources
 
+HELP_DESCRIPTION = """
+Script for executing shell command
+    
+additional arguments:
+    shell_command       command to execute on nodes
+"""
 
 class CLIAction(Action):
     def __init__(self, node_group_provider: Callable[[KubernetesCluster], NodeGroup], remote_args, no_stream):
@@ -60,7 +66,7 @@ def main(cli_arguments=None):
     remote_args = []
 
     if '--' not in cli_arguments:
-        remote_args = cli_arguments
+        kubemarine_args = cli_arguments
     else:
         split = False
         for argument in cli_arguments:
@@ -72,25 +78,27 @@ def main(cli_arguments=None):
             else:
                 remote_args.append(argument)
 
-    if kubemarine_args:
-        parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
+                                     prog='do',
+                                     description=HELP_DESCRIPTION,
+                                     usage='%(prog)s [-h] [-c CONFIG] [-n NODE] [-g GROUP] [--no_stream] -- shell_command')
 
-        parser.add_argument('-c', '--config',
+    parser.add_argument('-c', '--config',
                             default='cluster.yaml',
                             help='define main cluster configuration file')
 
-        parser.add_argument('-n', '--node',
+    parser.add_argument('-n', '--node',
                             help='node(s) name to execute on, can be combined with groups')
 
-        parser.add_argument('-g', '--group',
+    parser.add_argument('-g', '--group',
                             help='group(s) name to execute on, can be combined with nodes')
 
-        parser.add_argument('--no_stream',
+    parser.add_argument('--no_stream',
                             action='store_true',
                             help='do not stream all remote results in real-time, show node names')
 
-        arguments = vars(parser.parse_args(kubemarine_args))
-        configfile_path = arguments.get('config')
+    arguments = vars(parser.parse_args(kubemarine_args))
+    configfile_path = arguments.get('config')
 
     context = flow.create_empty_context({
         'disable_dump': True,

--- a/kubemarine/procedures/do.py
+++ b/kubemarine/procedures/do.py
@@ -59,24 +59,12 @@ def main(cli_arguments=None):
     if not cli_arguments:
         cli_arguments = sys.argv
 
-    configfile_path = 'cluster.yaml'
-    arguments = vars()
-
-    kubemarine_args = []
-    remote_args = []
-
-    if '--' not in cli_arguments:
-        kubemarine_args = cli_arguments
+    if '--' in cli_arguments:
+        kubemarine_args = cli_arguments[:cli_arguments.index('--')]
+        remote_args = cli_arguments[cli_arguments.index('--') + 1:]
     else:
-        split = False
-        for argument in cli_arguments:
-            if argument == '--':
-                split = True
-                continue
-            if not split:
-                kubemarine_args.append(argument)
-            else:
-                remote_args.append(argument)
+        kubemarine_args = cli_arguments
+        remote_args = []
 
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                                      prog='do',
@@ -110,7 +98,7 @@ def main(cli_arguments=None):
     context['preserve_inventory'] = False
 
     def node_group_provider(cluster: KubernetesCluster):
-        if kubemarine_args:
+        if arguments.get('node', None) is not None or arguments.get('group', None) is not None:
             executor_lists = {
                     'node': [],
                     'group': []


### PR DESCRIPTION
### Description
1. Help sections for procedures don't contain procedure name;
2. Help section for do procedure doesn't contain information about shell command;
3. Help section for do procedure runs with command `do -h --`;
4. Do procedure fails, if we don't add `-n` or `-g` options;


### Solution
1. Procedure names were added to help sections;
2. Procedure names for chack-paas and check-iaas were renamed;
3. Help section for do procedure was updated;
4. Do procedure without `-n` and `-g` options was fixed;
5. Do procedure collects kubemarine options instead of remote options, if separator `--` is not defined;


### How to apply
No steps


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Steps:

1. Run `kubemarine <procedre> -h` for any procedure

Results:

| Before | After |
| ------ | ------ |
| Help section contains `usage: __main__.py <options>` | Help section contains `usage: <procedure> <options>` |

2. Run `kubemarine do -h --`

Results:

| Before | After |
| ------ | ------ |
| Help section contains `usage: do <options>` | Help section contains `usage: do <options> -- shell_command` |

3. Run `kubemarine do -h`

Results:

| Before | After |
| ------ | ------ |
| Procedure fails because of nonexisted config.yaml or not found nodes and groups | Help section is shown |

5. Run `kubemarine -c <some-config> -- python3 --version`

Results:

| Before | After |
| ------ | ------ |
| Procedure fails because of nonexisted config.yaml or not found nodes and groups | Procedure does for any memner |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


