### PR TITLE
The AppArmor check fails

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1240,7 +1240,7 @@ def verify_apparmor_status(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    if system.get_os_family(cluster) in ['rhel', 'rhel8']:
+    if cluster.get_os_family() in ['rhel', 'rhel8']:
         return
 
     with TestCase(cluster.context['testsuite'], '227', "Security", "Apparmor security policy") as tc:
@@ -1268,7 +1268,7 @@ def verify_apparmor_config(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    if system.get_os_family(cluster) in ['rhel', 'rhel8']:
+    if cluster.get_os_family() in ['rhel', 'rhel8']:
         return
 
     with TestCase(cluster.context['testsuite'], '228', "Security", "Apparmor security policy") as tc:


### PR DESCRIPTION
### Description
* `check_paas` procedure fails on `services.security.apparmor` tasks because of `get_os_family` method has been moved


### Solution
* Change code


### How to apply
Not applicable


### Test Cases

**TestCase 1**
Check if the tests work

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 22
- Inventory: AllInOne

Steps:

1. Run `check_paas` procedure with `--tasks="services.security.apparmor"`

Results:

| Before | After |
| ------ | ------ |
| Fail | Success |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts



