### PR TITLE
[MANOPD-82746] containerd.io versions fix

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2135,9 +2135,11 @@ services:
 For detailed description of the parameters, see [Installation without Internet Resources](#installation-without-internet-resources).
 For more information about Docker daemon parameters, refer to the official docker configuration file documentation at [https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file).
 
-**Note**: After applying the parameters, the docker is restarted on all nodes in the cluster.
+**Notes**: 
+* After applying the parameters, the docker is restarted on all nodes in the cluster.
+* Do not omit the `containerRuntime` parameter in cluster.yaml if you include `dockerConfig` or `containerdConfig` in `cri` section
 
-**Note**: Do not omit the `containerRuntime` parameter in cluster.yaml if you include `dockerConfig` or `containerdConfig` in `cri` section
+**Warning:** Kubernetes v1.24 and higher do not work with `docker` as a `cri`
 
 #### modprobe
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -81,6 +81,7 @@ where, `<patches>` are the patch identifiers separated by comma.
 * API versions `extensions/v1beta1` and `networking.k8s.io/v1beta1` are not supported starting from Kubernetes 1.22 and higher. Need to update ingress to the new API `networking.k8s.io/v1`. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122
 * Before starting the upgrade, make sure you make a backup. For more information, see the section [Backup Procedure](#backup-procedure).
 * The upgrade procedure only maintains upgrading from one `supported` version to the next `supported` version. For example, from 1.18 to 1.20 or from 1.20 to 1.21.
+* Kubernetes v1.24 and higher do not work with `docker` as a `cri`. Therefore, `cri` must be migrated to `containerd` before upgrade, in case of using `docker`.
 * Since Kubernetes v1.25 doesn't support PSP, any clusters with `PSP` enabled must be migrated to `PSS` **before the upgrade** procedure running. For more information see the [Admission Migration Procedure](#admission-migration-procedure). The migration procedure is very important for Kubernetes cluster. If solution doesn't have appropriate description what `PSS` profile should be used for every namespace, it's better not to migrate from PSP for a while.  
 
 The upgrade procedure allows you to automatically update Kubernetes cluster and its core components to a new version. To do this, you must specify the `upgrade_plan` in the procedure config, and fill in the new version of the Kubernetes cluster you want to upgrade to. For example:

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -22,7 +22,9 @@ The whole directory is automatically cleared and reset after new version of Kube
 from typing import List
 
 from kubemarine.core.patch import Patch
+from kubemarine.patches.p1_upgrade_containerdio_version import UpgrateContainerdioVersion
 
 patches: List[Patch] = [
+    UpgrateContainerdioVersion()
 ]
 """List of patches which can be executed strictly in the declared order"""

--- a/kubemarine/patches/p1_upgrade_containerdio_version.py
+++ b/kubemarine/patches/p1_upgrade_containerdio_version.py
@@ -1,0 +1,60 @@
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kubemarine.core import flow
+from kubemarine.core.action import Action
+from kubemarine.core.patch import Patch
+from kubemarine.core.resources import DynamicResources
+from kubemarine import cri
+from kubemarine import packages
+
+
+class TheAction(Action):
+    def __init__(self):
+        super().__init__("Upgrade containerd.io version")
+
+    def run(self, res: DynamicResources):
+        cluster = res.cluster()
+
+        # check the OS family
+        if cluster.get_os_family() == 'debian':
+            # check CRI
+            if cluster.inventory['services']['cri']['containerRuntime']:
+                # get installed version
+                group = cluster.nodes['all'].get_accessible_nodes()
+                result = packages.detect_installed_packages_version_groups(group, 'containerd.io')
+                version = list(result['containerd.io'])[0].split('=')[1]
+                if '.'.join(version.split('.')[:2]) == '1.4':
+                    group.call(cri.install)
+                else:
+                    cluster.log.debug("Cluster has applicable \"containerd.io\" version")
+            else:
+                cluster.log.debug("Cluster has \"Containerd\" as a CRI, so the \"containerd.io\" upgrade is not needed")
+        else:
+            cluster.log.debug("Cluster has different OS family, so the \"containerd.io\" upgrade is not needed")
+
+
+class UpgrateContainerdioVersion(Patch):
+    def __init__(self):
+        super().__init__("upgrade_containerdio_version")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return """\
+Upgrade containerd.io to v1.5.* for kubernetes clusters
+Equivalent to 'kubemarine install --tasks=prepare.cri' for that clusters."""

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -201,47 +201,47 @@ compatibility_map:
       v1.21.2:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.21.5:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.21.12:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.22.2:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.22.9:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.23.1:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.23.6:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.23.11:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.24.0:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.24.2:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.25.2:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
     podman:
       v1.21.2:
         version_rhel: 1.6.4*


### PR DESCRIPTION
### Description
* The official repositories for Ubuntu 20.04 and Ubuntu 22.04 have different set of `containerd.io` versions. The Kubernetes installation on Ubuntu 22.04 fails if `containerd.io` version set to 1.4.* whereas the installation on Ubuntu 20.04 goes smoothly


### Solution
*  Change the `compatibility_map` in `globals.yaml` and set it to the version that presents in both repositories, since we don't have separated versions for Ubuntu 22.04 and Ubuntu 20.04


### How to apply
* Those changes are not compatible with artifacts that were created by previous `KubeMarine` versions, in case of using the Ubuntu 22.04. For instance, `cluster_finalized.yzml` can't be used for `add_node` operation.
* The following procedure doesn't work on clusters that have several `containerd.io` version:
[Migrate kubemarine](documentation/Maintenance.md#kubemarine-migration-procedure)

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 22.04
- Inventory: AllInOne

Steps:

1. Run installation procedure. The `cluster.yaml` has  `services.cri.containerRuntime: docker` option

Results:

| Before | After |
| ------ | ------ |
| Fails on task `prepare.cri` | Success |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts



