### PR TITLE
[MANOPD-82386] - add task list in help section

### DIFF
--- a/kubemarine/procedures/add_node.py
+++ b/kubemarine/procedures/add_node.py
@@ -128,7 +128,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_procedure_parser(cli_help)
+    parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure='add_node')
 
     flow.run_actions(context, [AddNodeAction()])

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -451,7 +451,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_procedure_parser(cli_help)
+    parser = flow.new_procedure_parser(cli_help, tasks=tasks)
 
     context = flow.create_context(parser, cli_arguments, procedure='backup')
     context['execution_arguments']['disable_dump'] = False

--- a/kubemarine/procedures/cert_renew.py
+++ b/kubemarine/procedures/cert_renew.py
@@ -71,7 +71,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_procedure_parser(cli_help)
+    parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure='cert_renew')
 
     flow.run_actions(context, [CertRenewAction()])

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -706,7 +706,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_tasks_flow_parser(cli_help)
+    parser = flow.new_tasks_flow_parser(cli_help, tasks=tasks)
 
     parser.add_argument('--csv-report',
                         default='report.csv',

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1391,7 +1391,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_procedure_parser(cli_help, optional_config=True)
+    parser = flow.new_procedure_parser(cli_help, optional_config=True, tasks=tasks)
 
     parser.add_argument('--csv-report',
                         default='report.csv',

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -617,7 +617,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_tasks_flow_parser(cli_help)
+    parser = flow.new_tasks_flow_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure='install')
 
     install = InstallAction()

--- a/kubemarine/procedures/manage_psp.py
+++ b/kubemarine/procedures/manage_psp.py
@@ -49,7 +49,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_procedure_parser(cli_help)
+    parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure='manage_psp')
 
     flow.run_actions(context, [PSPAction()])

--- a/kubemarine/procedures/manage_pss.py
+++ b/kubemarine/procedures/manage_pss.py
@@ -47,7 +47,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_procedure_parser(cli_help)
+    parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure='manage_pss')
 
     flow.run_actions(context, [PSSAction()])

--- a/kubemarine/procedures/migrate_cri.py
+++ b/kubemarine/procedures/migrate_cri.py
@@ -330,7 +330,7 @@ def main(cli_arguments=None):
 
         '''
 
-    parser = flow.new_procedure_parser(cli_help)
+    parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure="migrate_cri")
 
     flow.run_actions(context, [MigrateCRIAction()])

--- a/kubemarine/procedures/reboot.py
+++ b/kubemarine/procedures/reboot.py
@@ -65,7 +65,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_tasks_flow_parser(cli_help)
+    parser = flow.new_tasks_flow_parser(cli_help, tasks=tasks)
 
     parser.add_argument('procedure_config', nargs='?', metavar='procedure_config', type=str,
                         help='config file for reboot procedure')

--- a/kubemarine/procedures/remove_node.py
+++ b/kubemarine/procedures/remove_node.py
@@ -154,7 +154,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_procedure_parser(cli_help)
+    parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure='remove_node')
 
     flow.run_actions(context, [RemoveNodeAction()])

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -283,7 +283,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_procedure_parser(cli_help)
+    parser = flow.new_procedure_parser(cli_help, tasks=tasks)
 
     context = flow.create_context(parser, cli_arguments, procedure='restore')
     args = context['execution_arguments']

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -218,7 +218,7 @@ def main(cli_arguments=None):
 
     '''
 
-    parser = flow.new_procedure_parser(cli_help)
+    parser = flow.new_procedure_parser(cli_help, tasks=tasks)
 
     context = flow.create_context(parser, cli_arguments, procedure='upgrade')
     args = context['execution_arguments']


### PR DESCRIPTION
### Description
In procedure help sections we don't have task list for this procedure.

Fixes # (issue)


### Solution
Task list was added in the end of help section for all procedures with tasks


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Steps:

1.  Run `kubemarine <any procedure except do and migrate_kubemarine> -h`

Results:

| Before | After |
| ------ | ------ |
| Help section **without** task list | Help section **with** task list |

Example:
```
$ kubemarine upgrade -h
usage: upgrade [-h] [-c CONFIG] [--ansible-inventory-location ANSIBLE_INVENTORY_LOCATION] [--dump-location DUMP_LOCATION] [--disable-dump] [--disable-dump-cleanup] [--log [LOG ...]] [-w WORKDIR]
               [--without-act] [--tasks TASKS] [--exclude EXCLUDE] [--disable-cumulative-points] [--force-cumulative-points] [--exclude-cumulative-points-methods EXCLUDE_CUMULATIVE_POINTS_METHODS]
               procedure_config

    Script for automated upgrade of the entire Kubernetes cluster to a new version.

    How to use:



positional arguments:
  procedure_config      config file for the procedure

optional arguments:
  -h, --help            show this help message and exit
  -c CONFIG, --config CONFIG
                        define main cluster configuration file
  --ansible-inventory-location ANSIBLE_INVENTORY_LOCATION
                        auto-generated ansible-compatible inventory file location
  --dump-location DUMP_LOCATION
                        dump directory for intermediate files
  --disable-dump        prevent dump directory creation
  --disable-dump-cleanup
                        prevent dump directory cleaning on process launch
  --log [LOG ...]       Logging options, can be specified multiple times
  -w WORKDIR, --workdir WORKDIR
                        Custom path of the workdir
  --without-act         prevent tasks to be executed
  --tasks TASKS         define comma-separated tasks to be executed
  --exclude EXCLUDE     exclude comma-separated tasks from execution
  --disable-cumulative-points
                        disable cumulative points execution (use only when you understand what you are doing!)
  --force-cumulative-points
                        force cumulative points execution - they will be executed regardless of whether it was scheduled or not (use only when you understand what you are doing!)
  --exclude-cumulative-points-methods EXCLUDE_CUMULATIVE_POINTS_METHODS
                        comma-separated cumulative points methods names to be excluded from execution

tasks list:
    verify_upgrade_versions
    thirdparties
    prepull_images
    configure_policy
    kubernetes
    kubernetes_cleanup
    packages
    upgrade_containerd
    plugins
    overview
```

1.  Run `kubemarine <do or migrate_kubemarine> -h`

Results:

| Before | After |
| ------ | ------ |
| Help section **without** task list | Help section **without** task list |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


