### PR TITLE
[MANOPD-82730] Kubectl exec doesn't work

### DIFF
--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -34,7 +34,6 @@ services:
         audit-log-maxage: "30"
         audit-log-maxbackup: "10"
         audit-log-maxsize: "100"
-        kubelet-certificate-authority: /etc/kubernetes/pki/ca.crt
       extraVolumes:
         - name: audit
           hostPath: '{{ services["kubeadm"]["apiServer"]["extraArgs"]["audit-policy-file"] }}'


### PR DESCRIPTION
### Description
* `kubectl exec` doesn't work on clusters deployed with `KubMarine` 0.10.0

### Solution
* The hot-fix solution is to revert the previous changes in `defaults.yaml` 


### How to apply
* Manual steps for clusters that were deployed by `KubMarine` 0.10.0:
1. Remove the `kubelet-certificate-authority: /etc/kubernetes/pki/ca.crt` string in `kubeadm-config` configMap
2. Remove the `` string in `/etc/kubernetes/manifests/kube-apiserver.yaml` on every masters



### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 

Steps:

1. 

Results:

| Before | After |
| ------ | ------ |
|  |  |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


