### PR TITLE
Update defaults.yaml

### DIFF
--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -131,6 +131,7 @@ services:
     kernel.panic: 10
     vm.overcommit_memory: 1
     kernel.panic_on_oops: 1
+    fs.may_detach_mounts: 1
 
   etc_hosts:
     127.0.0.1:


### PR DESCRIPTION
### Description
* Pods stuck in the "Terminating" status during redeploy and were in this state for a long time


### Solution
* Add parameter **fs.may_detach_mounts=1** in **/etc/sysctl.conf**


### Test Cases
Should be enabled on hosts where container runtimes are being used:
https://access.redhat.com/solutions/5430091
https://github.com/containerd/containerd/issues/3667#issuecomment-802373736


Test Configuration:

- Hardware: Any
- OS: Linux
- Inventory: Any


| Before | After |
| ------ | ------ |
| Pods stuck in "Terminating" status during redeploy | When redeploying, "old" pods are terminating and do not stuck in this status |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


