### PR TITLE
[MANOPD-82072] fix containerd version

### DIFF
--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -201,47 +201,47 @@ compatibility_map:
       v1.21.2:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.21.5:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.21.12:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.22.2:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.22.9:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.23.1:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.23.6:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.23.11:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.24.0:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.24.2:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
       v1.25.2:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.4.*
+        version_debian: 1.5.*
     podman:
       v1.21.2:
         version_rhel: 1.6.4*


### PR DESCRIPTION
### Description
It ihas been identified during kubemarine operations that containerd 1.4 version might not be stable. 1.5 provided approved stable run.  Need to use 1.5 for new created clusters.

Fixes #MANOPD-82072 

### How to apply
* prepare.cri


### Test Cases


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


