### PR TITLE
[PSUPCLPL-11428] Update defaults.yaml and global.yaml - parametrize local-path-provisioner and busybox image version

### DIFF
--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -691,8 +691,8 @@ plugins:
       name: local-path
       is-default: "false"
     volume-dir: /opt/local-path-provisioner
-    image: 'rancher/local-path-provisioner:{{globals.compatibility_map.software["local-path-provisioner"][services.kubeadm.kubernetesVersion|minorversion].version}}'
-    helper-pod-image: 'library/busybox:{{globals.compatibility_map.software["busybox"][services.kubeadm.kubernetesVersion|minorversion].version}}'
+    image: 'rancher/local-path-provisioner:{{ globals.compatibility_map.software["local-path-provisioner"][services.kubeadm.kubernetesVersion|minorversion].version }}'
+    helper-pod-image: 'library/busybox:{{ globals.compatibility_map.software["busybox"][services.kubeadm.kubernetesVersion|minorversion].version }}'
 
 rbac:
   account_defaults:

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -691,8 +691,8 @@ plugins:
       name: local-path
       is-default: "false"
     volume-dir: /opt/local-path-provisioner
-    image: rancher/local-path-provisioner:v0.0.23
-    helper-pod-image: library/busybox:1.35.0
+    image: 'rancher/local-path-provisioner:{{globals.compatibility_map.software["local-path-provisioner"][services.kubeadm.kubernetesVersion|minorversion].version}}'
+    helper-pod-image: 'library/busybox:{{globals.compatibility_map.software["busybox"][services.kubeadm.kubernetesVersion|minorversion].version}}'
 
 rbac:
   account_defaults:

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -548,15 +548,15 @@ compatibility_map:
         version: v0.0.23
     busybox:
       v1.21:
-        version: 1.35.0
+        version: 1.31.2
       v1.22:
-        version: 1.35.0
+        version: 1.31.2
       v1.23:
-        version: 1.35.0
+        version: 1.31.2
       v1.24:
         version: 1.31.2
       v1.25:
-        version: 1.35.0
+        version: 1.31.2
     pause:
       v1.21:
         version: 3.4.1

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -554,7 +554,7 @@ compatibility_map:
       v1.23:
         version: 1.35.0
       v1.24:
-        version: 1.35.0
+        version: 1.31.2
       v1.25:
         version: 1.35.0
     pause:

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -546,6 +546,17 @@ compatibility_map:
         version: v0.0.22
       v1.25:
         version: v0.0.23
+    busybox:
+      v1.21:
+        version: 1.35.0
+      v1.22:
+        version: 1.35.0
+      v1.23:
+        version: 1.35.0
+      v1.24:
+        version: 1.35.0
+      v1.25:
+        version: 1.35.0
     pause:
       v1.21:
         version: 3.4.1


### PR DESCRIPTION
### Description
Versions for local-path-provisioner and busybox are set in globals.yaml depending on k8s versions. On the other hand local-path-provisioner and busybox image version is hardcoded in defaults.yaml 

Fixes # (issue)
PSUPCLPL-11428

### Solution
image version for local-path-provisioner and busybox in default.yaml set parametrized, depending on versions in globals.yaml

### How to apply
-


### Test Cases
1. Deploy local-path-provisioner in k8s v1.25
ER: local-path-provisioner v0.0.23 is deployed. 

2. Deploy local-path-provisioner in k8s < v1.25
ER: local-path-provisioner v0.0.22 is deployed.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
-


