### PR TITLE
Cumulative points fixes

### DIFF
--- a/kubemarine/core/flow.py
+++ b/kubemarine/core/flow.py
@@ -349,7 +349,7 @@ def parse_args(parser, arguments: list = None):
     return args
 
 
-def schedule_cumulative_point(cluster, point_method):
+def schedule_cumulative_point(cluster: c.KubernetesCluster, point_method):
     _check_within_flow(cluster)
 
     point_fullname = point_method.__module__ + '.' + point_method.__qualname__
@@ -372,7 +372,7 @@ def schedule_cumulative_point(cluster, point_method):
         cluster.log.verbose('Method %s already scheduled' % point_fullname)
 
 
-def proceed_cumulative_point(cluster, points_list, point_task_path):
+def proceed_cumulative_point(cluster: c.KubernetesCluster, points_list, point_task_path):
     _check_within_flow(cluster)
 
     if cluster.context['execution_arguments'].get('disable_cumulative_points', False):
@@ -393,7 +393,7 @@ def proceed_cumulative_point(cluster, points_list, point_task_path):
 
             cluster.log.info("*** CUMULATIVE POINT %s ***" % point_method_fullname)
 
-            call_result = cluster.nodes["all"].get_new_nodes_or_self().call(point_method)
+            call_result = point_method(cluster)
             if point_method in scheduled_methods:
                 scheduled_methods.remove(point_method)
             results[point_method_fullname] = call_result

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -316,7 +316,8 @@ def system_prepare_package_manager_manage_packages(group: NodeGroup):
     for action, results in batch_results.items():
         cluster.log.verbose('Verifying packages changes after \'%s\' action...' % action)
         for conn, result in results.items():
-            if "Nothing to do" not in result.stdout:
+            if "Nothing to do" not in result.stdout \
+                    and "0 upgraded, 0 newly installed, 0 to remove" not in result.stdout:
                 cluster.log.verbose('Packages changed at %s' % conn.host)
                 any_changes_found = True
 

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -584,10 +584,10 @@ cumulative_points = {
     # - net.ipv6.ip_nonlocal_bind = 1
     # - net.ipv6.conf.all.forwarding = 1
     # That is why reboot required BEFORE this task
-    'kubemarine.system.reboot_nodes': [
+    system.reboot_nodes: [
         "prepare.system.sysctl"
     ],
-    'kubemarine.system.verify_system': [
+    system.verify_system: [
         "prepare.system.sysctl"
     ]
 

--- a/kubemarine/procedures/reboot.py
+++ b/kubemarine/procedures/reboot.py
@@ -39,7 +39,7 @@ def reboot(cluster):
         nodes.append(node['name'])
         cluster.log.verbose('  - ' + node['name'])
 
-    system.reboot_nodes(cluster.make_group_from_nodes(nodes),
+    system.reboot_group(cluster.make_group_from_nodes(nodes),
                         try_graceful=cluster.procedure_inventory.get("graceful_reboot"))
 
 

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -246,7 +246,7 @@ def import_etcd(cluster: KubernetesCluster):
 
 
 def reboot(cluster):
-    system.reboot_nodes(cluster.nodes['all'], try_graceful=False)
+    system.reboot_group(cluster.nodes['all'], try_graceful=False)
     kubernetes.wait_for_nodes(cluster.nodes['control-plane'])
 
 

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -411,11 +411,6 @@ def is_swap_disabled(group):
 
 
 def disable_swap(group):
-
-
-    group.cluster.schedule_cumulative_point(reboot_nodes)
-    group.cluster.schedule_cumulative_point(verify_system)
-
     log = group.cluster.log
 
     already_disabled, result = is_swap_disabled(group)

--- a/test/unit/core/test_flow.py
+++ b/test/unit/core/test_flow.py
@@ -17,6 +17,7 @@ import random
 import socket
 import unittest
 import ast
+from copy import deepcopy
 from typing import Optional
 
 import invoke
@@ -68,6 +69,7 @@ class FlowTest(unittest.TestCase):
 
         expected_res = {'deploy': {'loadbalancer': {'haproxy': 'a'}}}
         self.assertEqual(expected_res, test_res, "Incorrect filtered flow.")
+        self.assertEqual(["deploy.loadbalancer.haproxy"], final_list, "Incorrect filtered flow.")
 
     def test_filter_flow_2(self):
         test_tasks = ["deploy"]
@@ -77,6 +79,8 @@ class FlowTest(unittest.TestCase):
 
         expected_res = {'deploy': {'accounts': 'a', 'loadbalancer': {'haproxy': 'a', 'keepalived': 'a'}}}
         self.assertEqual(expected_res, test_res, "Incorrect filtered flow.")
+        self.assertEqual(["deploy.loadbalancer.haproxy", "deploy.loadbalancer.keepalived", "deploy.accounts"],
+                         final_list, "Incorrect filtered flow.")
 
     def test_filter_flow_3(self):
         test_tasks = ["deploy.loadbalancer.haproxy", "overview"]
@@ -86,6 +90,8 @@ class FlowTest(unittest.TestCase):
 
         expected_res = {'deploy': {'loadbalancer': {'haproxy': 'a'}}, 'overview': 'a'}
         self.assertEqual(expected_res, test_res, "Incorrect filtered flow.")
+        self.assertEqual(["deploy.loadbalancer.haproxy", "overview"],
+                         final_list, "Incorrect filtered flow.")
 
     def test_filter_flow_excluded(self):
         test_tasks = ["deploy"]
@@ -96,6 +102,7 @@ class FlowTest(unittest.TestCase):
 
         expected_res = {'deploy': {'accounts': 'a'}}
         self.assertEqual(expected_res, test_res, "Incorrect filtered flow.")
+        self.assertEqual(["deploy.accounts"], final_list, "Incorrect filtered flow.")
 
     def test_filter_flow_excluded_whitespaces(self):
         test_tasks = ["deploy"]
@@ -106,6 +113,7 @@ class FlowTest(unittest.TestCase):
 
         expected_res = {'deploy': {'accounts': 'a'}}
         self.assertEqual(expected_res, test_res, "Incorrect filtered flow.")
+        self.assertEqual(["deploy.accounts"], final_list, "Incorrect filtered flow.")
 
     def test_filter_flow_excluded_all_subtree(self):
         test_tasks = ["deploy"]
@@ -116,6 +124,7 @@ class FlowTest(unittest.TestCase):
 
         expected_res = {}
         self.assertEqual(expected_res, test_res, "Incorrect filtered flow.")
+        self.assertEqual([], final_list, "Incorrect filtered flow.")
 
     def test_incorrect_task_endswith_correct(self):
         test_tasks = ["my.deploy.loadbalancer.haproxy"]
@@ -125,6 +134,7 @@ class FlowTest(unittest.TestCase):
 
         expected_res = {}
         self.assertEqual(expected_res, test_res, "Incorrect filtered flow.")
+        self.assertEqual([], final_list, "Incorrect filtered flow.")
 
     def test_incorrect_task_startswith_correct(self):
         test_tasks = ["deploy.loadbalancer.haproxy.xxx"]
@@ -134,6 +144,7 @@ class FlowTest(unittest.TestCase):
 
         expected_res = {}
         self.assertEqual(expected_res, test_res, "Incorrect filtered flow.")
+        self.assertEqual([], final_list, "Incorrect filtered flow.")
 
     def test_union_of_incorrect_tasks_is_incorrect(self):
         for test_tasks in [["my.deploy"], ["loadbalancer"], ["my.deploy", "loadbalancer"]]:
@@ -143,6 +154,7 @@ class FlowTest(unittest.TestCase):
 
             expected_res = {}
             self.assertEqual(expected_res, test_res, f"Incorrect filtered flow for initial tasks {test_tasks}.")
+            self.assertEqual([], final_list, "Incorrect filtered flow.")
 
     def test_incorrect_group_and_task_substring_of_correct(self):
         test_tasks = ["deploy.loadbalancer.h"]
@@ -152,6 +164,7 @@ class FlowTest(unittest.TestCase):
 
         expected_res = {}
         self.assertEqual(expected_res, test_res, "Incorrect filtered flow.")
+        self.assertEqual([], final_list, "Incorrect filtered flow.")
 
     def test_schedule_cumulative_point(self):
         cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA))
@@ -181,28 +194,14 @@ class FlowTest(unittest.TestCase):
         self.assertEqual(1, cluster.context.get("test_info"),
                          f"It had to be one call of test_func for {method_full_name} cumulative point")
 
-    def test_force_proceed_cumulative_point(self):
-        context = demo.create_silent_context(['--force-cumulative-points'],
-                                             parser=flow.new_tasks_flow_parser("Help text"))
-        cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA), context=context)
-        method_full_name = test_func.__module__ + '.' + test_func.__qualname__
-        cumulative_points = {
-            test_func: ['prepare.system.modprobe']
-        }
-        flow.init_tasks_flow(cluster)
-        # no schedule, but the cumulative points should still be executed because of explicit cli option
-        res = flow.proceed_cumulative_point(cluster, cumulative_points, "prepare.system.modprobe")
-        self.assertIn(test_msg, str(res.get(method_full_name)))
-        self.assertEqual(1, cluster.context.get("test_info"),
-                         f"It had to be one call of test_func for {method_full_name} cumulative point")
-
     def test_run_flow(self):
         cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA))
         flow.init_tasks_flow(cluster)
-        flow.run_flow(tasks, cluster, {})
+        final_task_names = ["deploy.loadbalancer.haproxy", "deploy.loadbalancer.keepalived",
+                            "deploy.accounts", "overview"]
+        flow.run_flow(tasks, final_task_names, cluster, {}, [])
 
-        self.assertEqual(4, cluster.context["test_info"], "Here should be 4 calls of test_func for: \
-         deploy.loadbalancer.haproxy, deploy.loadbalancer.keepalived, deploy.accounts, overview.")
+        self.assertEqual(4, cluster.context["test_info"], f"Here should be 4 calls of test_func for: {final_task_names}")
 
     def test_run_tasks(self):
         context = demo.create_silent_context(['--tasks', 'deploy.loadbalancer.haproxy'],
@@ -212,6 +211,44 @@ class FlowTest(unittest.TestCase):
         flow.run_tasks(demo.FakeResources(context, inventory, cluster=cluster), tasks)
         self.assertEqual(1, cluster.context["test_info"],
                          "It had to be one call of test_func for deploy.loadbalancer.haproxy action")
+
+    def test_force_proceed_cumulative_point_task_present(self):
+        context = demo.create_silent_context(['--force-cumulative-points', '--tasks', 'deploy.loadbalancer.haproxy'],
+                                             parser=flow.new_tasks_flow_parser("Help text"))
+        inventory = demo.generate_inventory(**demo.FULLHA)
+        cluster = demo.new_cluster(inventory, context=context)
+        cumulative_points = {
+            test_func: ['deploy.loadbalancer.haproxy']
+        }
+        flow.run_tasks(demo.FakeResources(context, inventory, cluster=cluster), tasks, cumulative_points=cumulative_points)
+        self.assertEqual(2, cluster.context.get("test_info"),
+                         f"Both task and cumulative points should be run")
+
+    def test_force_proceed_cumulative_point_task_absent(self):
+        context = demo.create_silent_context(['--force-cumulative-points', '--tasks', 'deploy.loadbalancer.keepalived'],
+                                             parser=flow.new_tasks_flow_parser("Help text"))
+        inventory = demo.generate_inventory(**demo.FULLHA)
+        cluster = demo.new_cluster(inventory, context=context)
+        cumulative_points = {
+            test_func: ['deploy.loadbalancer.haproxy']
+        }
+        flow.run_tasks(demo.FakeResources(context, inventory, cluster=cluster), tasks, cumulative_points=cumulative_points)
+        self.assertEqual(1, cluster.context.get("test_info"),
+                         f"Cumulative point should be skipped as task is not run")
+
+    def test_scheduled_cumulative_point_task_absent(self):
+        context = demo.create_silent_context(['--force-cumulative-points', '--tasks', 'deploy.loadbalancer.haproxy'],
+                                             parser=flow.new_tasks_flow_parser("Help text"))
+        inventory = demo.generate_inventory(**demo.FULLHA)
+        cluster = demo.new_cluster(inventory, context=context)
+        cumulative_points = {
+            test_func: ['overview']
+        }
+        tasks_copy = deepcopy(tasks)
+        tasks_copy['deploy']['loadbalancer']['haproxy'] = lambda cluster: flow.schedule_cumulative_point(cluster, test_func)
+        flow.run_tasks(demo.FakeResources(context, inventory, cluster=cluster), tasks_copy, cumulative_points=cumulative_points)
+        self.assertEqual(1, cluster.context.get("test_info"),
+                         f"Cumulative point should be executed despite the related task is not run")
 
     def test_detect_nodes_context(self):
         inventory = demo.generate_inventory(**demo.FULLHA)

--- a/test/unit/test_demo.py
+++ b/test/unit/test_demo.py
@@ -60,7 +60,7 @@ class TestFakeShell(unittest.TestCase):
         self.cluster.fake_shell.add(demo.create_nodegroup_result(self.cluster.nodes['all'], stdout='example result 2'),
                                     'run', ["sudo -S -p '[sudo] password: ' last reboot"], usage_limit=1)
 
-        system.reboot_nodes(self.cluster.nodes['master'])
+        system.reboot_group(self.cluster.nodes['master'])
 
         for host in self.cluster.nodes['master'].get_hosts():
             self.assertEqual(1,


### PR DESCRIPTION
### Description
* KubeMarine performs unnecessary reboot during `install` procedure in some cases especially is cluster is reinstalled.
* Cumulative points are not executed if the related task is skipped, and the system is not verified in such cases.

### Solution
* Remove unnecessary reboot schedule from disable swap.
* Fix packages changes detection for Ubuntu.
* Flow now always iterates over all tasks to proceed cumulative points, but only necessary tasks are finally run.
* Other refactoring, removed dynamic imports.

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: Ubuntu
- Inventory: should contain non-empty `services.packages.install` section.

Steps:

1. Run `install` procedure twice.

Results:

| Before | After |
| ------ | ------ |
| Both runs reboot the nodes | The second run should not reboot the nodes |

**TestCase 2**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Any

Steps:

1. Install and/or enable `firewalld`.
1. Run `install --tasks prepare.system.disable_firewalld`.

Results:

| Before | After |
| ------ | ------ |
| Nodes are not rebooted and the system is not verified after reboot | The nodes are rebooted and the system is verified |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_flow.py - added new tests and changed the existing to adopt to the changed methods signatures.
