### PR TITLE
MANOPD-82393 Final summary report

### DIFF
--- a/kubemarine.spec
+++ b/kubemarine.spec
@@ -24,6 +24,7 @@ a = Analysis(['./kubemarine/__main__.py'],
                 'kubemarine.plugins.calico',
                 'kubemarine.plugins.nginx_ingress',
                 'kubemarine.plugins.haproxy_ingress',
+                'kubemarine.plugins.kubernetes_dashboard',
                 'kubemarine.core.schema'
              ],
              pathex=['./'],

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -24,6 +24,7 @@ from jinja2 import Template
 
 from kubemarine import system, plugins, admission, etcd, packages
 from kubemarine.core import utils, static
+from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.executor import RemoteExecutor
 from kubemarine.core.group import NodeGroup
 from kubemarine.core.errors import KME
@@ -1142,3 +1143,55 @@ def images_prepull(group: NodeGroup):
     group.put(io.StringIO(config), '/etc/kubernetes/prepull-config.yaml', sudo=True)
 
     return group.sudo("kubeadm config images pull --config=/etc/kubernetes/prepull-config.yaml")
+
+
+def schedule_running_nodes_report(cluster: KubernetesCluster):
+    nodes_description = get_nodes_description(cluster)
+    actual_roles = get_actual_roles(nodes_description)
+    nodes_conditions = get_nodes_conditions(nodes_description)
+    nodes_names = actual_roles.keys()
+    for role in ('control-plane', 'worker'):
+        members = 0
+        ready = 0
+        for name in nodes_names:
+            if role in actual_roles[name]:
+                members += 1
+                if nodes_conditions[name].get('Ready', {}).get('status') == 'True':
+                    ready += 1
+
+        property = utils.SummaryItem.CONTROL_PLANES if role == 'control-plane' else utils.SummaryItem.WORKERS
+        value = f'{ready}/{members}'
+        utils.schedule_summary_report(cluster.context, property, value)
+
+
+def get_nodes_description(cluster: KubernetesCluster) -> dict:
+    result = cluster.nodes['control-plane'].get_final_nodes().get_any_member().sudo('kubectl get node -o yaml')
+    cluster.log.verbose(result)
+    return yaml.safe_load(list(result.values())[0].stdout)
+
+
+def get_actual_roles(nodes_description: dict) -> Dict[str, List[str]]:
+    result = {}
+    for node_description in nodes_description['items']:
+        node_name = node_description['metadata']['name']
+        labels = node_description['metadata']['labels']
+        result[node_name] = []
+        # TODO check label accordingly to Kubernetes version
+        if 'node-role.kubernetes.io/master' in labels or 'node-role.kubernetes.io/control-plane' in labels:
+            result[node_name].append('control-plane')
+        if 'node-role.kubernetes.io/worker' in labels:
+            result[node_name].append('worker')
+
+    return result
+
+
+def get_nodes_conditions(nodes_description: dict) -> Dict[str, Dict[str, dict]]:
+    result = {}
+    for node_description in nodes_description['items']:
+        node_name = node_description['metadata']['name']
+        conditions_by_type = {}
+        result[node_name] = conditions_by_type
+        for condition in node_description['status']['conditions']:
+            conditions_by_type[condition['type']] = condition
+
+    return result

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -1164,8 +1164,13 @@ def schedule_running_nodes_report(cluster: KubernetesCluster):
         utils.schedule_summary_report(cluster.context, property, value)
 
 
+def get_nodes_description_cmd() -> str:
+    return 'kubectl get node -o yaml'
+
+
 def get_nodes_description(cluster: KubernetesCluster) -> dict:
-    result = cluster.nodes['control-plane'].get_final_nodes().get_any_member().sudo('kubectl get node -o yaml')
+    cmd = get_nodes_description_cmd()
+    result = cluster.nodes['control-plane'].get_final_nodes().get_any_member().sudo(cmd)
     cluster.log.verbose(result)
     return yaml.safe_load(list(result.values())[0].stdout)
 

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 import io
+import os
 
 import yaml
 
 from kubemarine.core import utils
+from kubemarine.core.cluster import KubernetesCluster
+
 
 def enrich_inventory(inventory, cluster):
     rbac = inventory['rbac']
@@ -64,7 +67,7 @@ def enrich_inventory(inventory, cluster):
     return inventory
 
 
-def install(cluster):
+def install(cluster: KubernetesCluster):
     rbac = cluster.inventory['rbac']
     if not rbac.get("accounts"):
         cluster.log.debug("No accounts specified to install, skipping...")
@@ -117,7 +120,9 @@ def install(cluster):
         })
 
     cluster.log.debug('\nSaving tokens...')
-    token_filename = './account-tokens.yaml'
+    token_filename = os.path.abspath('account-tokens.yaml')
     with open(token_filename, 'w') as tokenfile:
         tokenfile.write(yaml.dump(tokens, default_flow_style=False))
         cluster.log.debug('Tokens saved to %s' % token_filename)
+
+    utils.schedule_summary_report(cluster.context, utils.SummaryItem.ACCOUNT_TOKENS, token_filename)

--- a/kubemarine/plugins/kubernetes_dashboard.py
+++ b/kubemarine/plugins/kubernetes_dashboard.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from kubemarine.core import utils
 from kubemarine.core.cluster import KubernetesCluster
 

--- a/kubemarine/plugins/kubernetes_dashboard.py
+++ b/kubemarine/plugins/kubernetes_dashboard.py
@@ -1,0 +1,9 @@
+from kubemarine.core import utils
+from kubemarine.core.cluster import KubernetesCluster
+
+
+def schedule_summary_report(cluster: KubernetesCluster):
+    plugin_item = cluster.inventory['plugins']['kubernetes-dashboard']
+    hostname = plugin_item['hostname']
+    # Currently we declare that Dashboard UI is available only via HTTPS
+    utils.schedule_summary_report(cluster.context, utils.SummaryItem.DASHBOARD_URL, f'https://{hostname}')

--- a/kubemarine/procedures/add_node.py
+++ b/kubemarine/procedures/add_node.py
@@ -29,7 +29,7 @@ def deploy_kubernetes_join(cluster):
 
     group = cluster.nodes['control-plane'].include_group(cluster.nodes.get('worker')).get_new_nodes()
 
-    if cluster.context['initial_procedure'] == 'add_node' and group.is_empty():
+    if group.is_empty():
         cluster.log.debug("No kubernetes nodes to perform")
         return
 
@@ -44,12 +44,9 @@ def deploy_kubernetes_join(cluster):
         kubernetes.apply_taints
     ])
 
-    if group.is_empty():
-        cluster.log.debug("Skipped: no kubernetes nodes to wait")
-        return
-    else:
-        cluster.log.debug("Waiting for new kubernetes nodes...")
-        kubernetes.wait_for_nodes(group)
+    cluster.log.debug("Waiting for new kubernetes nodes...")
+    kubernetes.wait_for_nodes(group)
+    kubernetes.schedule_running_nodes_report(cluster)
 
 
 def add_node_finalize_inventory(cluster, inventory_to_finalize):

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -945,7 +945,7 @@ def main(cli_arguments=None):
     context['testsuite'] = TestSuite()
     context['preserve_inventory'] = False
 
-    cluster = flow.run_actions(context, [IaasAction()], print_final_message=False)
+    cluster = flow.run_actions(context, [IaasAction()], print_summary=False)
 
     # Final summary should be printed only to stdout with custom formatting
     # If test results are required for parsing, they can be found in the test results files

--- a/kubemarine/procedures/do.py
+++ b/kubemarine/procedures/do.py
@@ -18,7 +18,7 @@ import argparse
 import sys
 from typing import Callable
 
-from kubemarine.core import flow
+from kubemarine.core import flow, resources
 from kubemarine.core.action import Action
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.group import NodeGroup
@@ -124,7 +124,8 @@ def main(cli_arguments=None):
             return cluster.nodes['control-plane'].get_any_member()
 
     no_stream = arguments.get('no_stream')
-    flow.run_actions(context, [CLIAction(node_group_provider, remote_args, no_stream)], silent=True)
+    res = resources.DynamicResources(context, silent=False)
+    flow.run_actions(res, [CLIAction(node_group_provider, remote_args, no_stream)], print_summary=False)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -451,7 +451,7 @@ def deploy_kubernetes_prepull_images(group: NodeGroup):
     group.call(kubernetes.images_grouped_prepull)
 
 
-def deploy_kubernetes_init(cluster):
+def deploy_kubernetes_init(cluster: KubernetesCluster):
     cluster.nodes['control-plane'].call_batch([
         kubernetes.init_first_control_plane,
         kubernetes.join_other_control_planes
@@ -466,6 +466,8 @@ def deploy_kubernetes_init(cluster):
         kubernetes.apply_labels,
         kubernetes.apply_taints
     ])
+
+    kubernetes.schedule_running_nodes_report(cluster)
 
 
 def deploy_coredns(cluster):

--- a/kubemarine/procedures/remove_node.py
+++ b/kubemarine/procedures/remove_node.py
@@ -58,8 +58,14 @@ def loadbalancer_remove_keepalived(cluster: KubernetesCluster):
 
 
 def remove_kubernetes_nodes(cluster: KubernetesCluster):
-    cluster.nodes['control-plane'].include_group(cluster.nodes.get('worker')).get_nodes_for_removal() \
-        .call(kubernetes.reset_installation_env)
+    group = cluster.nodes['control-plane'].include_group(cluster.nodes.get('worker')).get_nodes_for_removal()
+
+    if group.is_empty():
+        cluster.log.debug("No kubernetes nodes to perform")
+        return
+
+    group.call(kubernetes.reset_installation_env)
+    kubernetes.schedule_running_nodes_report(cluster)
 
 
 def remove_node_finalize_inventory(cluster: KubernetesCluster, inventory_to_finalize):

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -246,7 +246,7 @@ def main(cli_arguments=None):
 
     # todo inventory is preserved few times, probably need to preserve it once instead.
     actions = [UpgradeAction(version) for version in upgrade_plan]
-    flow.run_actions(context, actions, resources=resources)
+    flow.run_actions(resources, actions)
 
     if verification_version_result:
         print(verification_version_result)

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -644,6 +644,9 @@ plugins:
               - kubernetes-dashboard
               - dashboard-metrics-scraper
         - template: templates/plugins/dashboard-ingress.yaml.j2
+        - python:
+            module: plugins/kubernetes_dashboard.py
+            method: schedule_summary_report
     hostname: 'dashboard.{{ cluster_name }}'
     dashboard:
       image: 'kubernetesui/dashboard:{{ plugins["kubernetes-dashboard"].version }}'

--- a/test/unit/core/test_run_actions.py
+++ b/test/unit/core/test_run_actions.py
@@ -45,7 +45,7 @@ class RunActionsTest(unittest.TestCase):
                 super().__init__('test', recreate_inventory=True)
 
         res = FakeResources(self.context, {"p1": "v1"})
-        flow.run_actions(self.context, [TheAction()], resources=res, print_final_message=False)
+        flow.run_actions(res, [TheAction()], print_summary=False)
         self.assertEqual(res.recreated_inventory, {"p1": "v1", "p2": "v2"})
 
     def test_patch_cluster(self):
@@ -64,7 +64,7 @@ class RunActionsTest(unittest.TestCase):
         self.assertFalse('successfully_performed' in self.cluster.context)
 
         res = FakeResources(self.context, self.inventory, cluster=self.cluster)
-        flow.run_actions(self.context, [TheAction()], resources=res, print_final_message=False)
+        flow.run_actions(res, [TheAction()], print_summary=False)
         for host in nodes.get_hosts():
             history = fake_shell.history_find(host, 'sudo', ['whoami'])
             self.assertTrue(len(history) == 1 and history[0]["used_times"] == 1)

--- a/test/unit/test_kubernetes.py
+++ b/test/unit/test_kubernetes.py
@@ -1,0 +1,56 @@
+import unittest
+from textwrap import dedent
+
+from kubemarine import demo, kubernetes
+from kubemarine.core import utils
+
+
+class TestInventoryValidation(unittest.TestCase):
+    def test_schedule_running_nodes_report(self):
+        cluster = demo.new_cluster(demo.generate_inventory(**demo.ALLINONE))
+        stdout = dedent(
+            """\
+            items:
+            - metadata:
+                labels:
+                  node-role.kubernetes.io/control-plane: ""
+                  node-role.kubernetes.io/worker: worker
+                name: k8s-control-plane-1
+              status:
+                conditions:
+                - status: "False"
+                  type: Ready
+            - metadata:
+                labels:
+                  node-role.kubernetes.io/control-plane: ""
+                  node-role.kubernetes.io/worker: worker
+                name: k8s-control-plane-2
+              status:
+                conditions:
+                - status: "True"
+                  type: Ready
+            - metadata:
+                labels:
+                  node-role.kubernetes.io/worker: worker
+                name: k8s-control-plane-3
+              status:
+                conditions:
+                - status: "True"
+                  type: Ready
+            """.rstrip()
+        )
+        get_nodes = demo.create_nodegroup_result(cluster.nodes['control-plane'], stdout=stdout)
+        cluster.fake_shell.add(get_nodes, 'sudo', [kubernetes.get_nodes_description_cmd()])
+        kubernetes.schedule_running_nodes_report(cluster)
+        summary_report = cluster.context.get('summary_report')
+        self.assertEquals(
+            {
+                utils.SummaryItem.CONTROL_PLANES: "1/2",
+                utils.SummaryItem.WORKERS: "2/3",
+            },
+            summary_report
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_kubernetes.py
+++ b/test/unit/test_kubernetes.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 from textwrap import dedent
 


### PR DESCRIPTION
### Description
* Need to print short summary after successful installation.

### Solution
* Schedule different report items during run of particular tasks:
    * Ready/Number of running Control Planes and Workers during `deploy.kubernetes.init` task of `install` procedure and corresponding tasks of `add_node`, `remove_node` procedures.
    * Dashboard URL if `kubernetes-dashboard` plugin is (re)installed.
    * Absolute path to account-tokens.yaml during `deploy.accounts` task of `install` procedure.
* Print all summary items just before exiting.

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Any

Steps:

1. Run `install` procedure.

Results:

| Before | After |
| ------ | ------ |
| Not applicable | Summary is printed in the end of logs |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_kubernetes.py - add test for parsing of `kubectl get node` command.
