### PR TITLE
MANOPD-83734 Actualize and ensure mandatory thirdparty packages

### DIFF
--- a/ci/default_config.yaml
+++ b/ci/default_config.yaml
@@ -9,10 +9,3 @@ nodes:
   roles: ["control-plane", "worker"]
 
 cluster_name: "test-local-k8s.com"
-
-services:
-    packages:
-        install:
-        - conntrack
-        - kmod
-        - curl

--- a/ci/extended_config.yaml
+++ b/ci/extended_config.yaml
@@ -18,15 +18,9 @@ cluster_name: "test-local-k8s.com"
 services:
   packages:
     install:
-    - conntrack
-    - kmod
     - ethtool
     - ebtables
     - socat
-    - curl
-    - openssl
-    - unzip
-    - policycoreutils-python-utils
 
 plugins:
   kubernetes-dashboard:

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -216,7 +216,6 @@ If you have other solution, remove or switch off the IP firewall before the inst
   * kmod
   * semanage
   * conntrack
-  * audit
   * unzip. By default it is not required. Install if you intend to unzip third-party files with **.zip** extension.
 * Recommended
   Installation of the below packages is highly recommended; however, Kubernetes is able to work without them, but may show warnings:
@@ -2374,7 +2373,7 @@ services:
 
 *Can restart service*: Always yes, `auditd`.
 
-*OS specific*: Yes, `prepare.system.audit.install` task is performed only on the Debian OS family.
+*OS specific*: No
 
 ```yaml
 services:
@@ -4809,7 +4808,7 @@ The following is the installation tasks tree:
     * **modprobe** - Configures Linux Kernel modules. For more information about parameters for this task, see [modprobe](#modprobe).
     * **sysctl** - Configures Linux Kernel parameters. For more information about parameters for this task, see [sysctl](#sysctl).
     * **audit**
-      * **install** - Installs auditd daemon on Ubuntu/Debian nodes.
+      * **install** - Installs auditd daemon on nodes.
       * **configure_daemon** - Configures Linux audit rules. For more information about parameters for this task, see [audit-daemon](#audit-daemon).
       * **configure_policy** - Configures Kubernetes audit rules. For more information about parameters for this task, see [audit-Kubernetes Policy](#audit-Kubernetes-Policy)
       

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -4654,7 +4654,6 @@ Application of the list merge strategy is allowed in the following sections:
 * `services.packages.install`
 * `services.packages.upgrade`
 * `services.packages.remove`
-* `services.packages.package_manager.repositories`
 * `plugins.nginx-ingress-controller.ports`
 * `plugins.kubernetes-dashboard.ingress.spec.tls`
 * `plugins.kubernetes-dashboard.ingress.spec.rules`

--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -14,13 +14,13 @@ This section provides information about the Kubecheck functionality.
       - [005 Workers Amount](#005-workers-amount)
       - [005 Total Nodes Amount](#005-total-nodes-amount)
     - [006 VCPUs Amount](#006-vcpus-amount)
-      - [006 VCPUs Amount - Balancers](#006-vcpus-amount-balancers)
-      - [006 VCPUs Amount - Control-planes](#006-vcpus-amount-control-planes)
-      - [006 VCPUs Amount - Workers](#006-vcpus-amount-workers)
+      - [006 VCPUs Amount - Balancers](#006-vcpus-amount---balancers)
+      - [006 VCPUs Amount - Control-planes](#006-vcpus-amount---control-planes)
+      - [006 VCPUs Amount - Workers](#006-vcpus-amount---workers)
     - [007 RAM Amount](#007-ram-amount)
-      - [007 RAM Amount - Balancers](#007-ram-amount-balancers)
-      - [007 RAM Amount - Control-planes](#007-ram-amount-control-planes)
-      - [007 RAM Amount - Workers](#007-ram-amount-workers)
+      - [007 RAM Amount - Balancers](#007-ram-amount---balancers)
+      - [007 RAM Amount - Control-planes](#007-ram-amount---control-planes)
+      - [007 RAM Amount - Workers](#007-ram-amount---workers)
     - [008 Distributive](#008-distributive)
     - [009 PodSubnet](#009-podsubnet)
     - [010 ServiceSubnet](#010-servicesubnet)
@@ -34,22 +34,26 @@ This section provides information about the Kubecheck functionality.
       - [201 Keepalived Status](#201-keepalived-status)
       - [201 Container Runtime Status](#201-container-runtime-status)
       - [201 Kubelet Status](#201-kubelet-status)
-    - [202 Kubelet Version](#202-kubelet-version)
-    - [203 Recommended packages versions](#203-recommended-packages-version)  
-    - [204 Docker Version](#204-cri-versions)
-    - [204 HAproxy Version](#204-haproxy-version)
-    - [204 Keepalived Version](#204-keepalived-version)
-    - [205 Generic Packages Version](#205-generic-packages-version)
-    - [206 Pods Condition](#206-pods-condition)
-    - [207 Dashboard Availability](#207-dashboard-availability)
-    - [208 Nodes Existence](#208-nodes-existence)
-    - [209 Nodes Roles](#209-nodes-roles)
-    - [210 Nodes Condition](#210-nodes-condition)
-      - [210 Nodes Condition - NetworkUnavailable](#210-nodes-condition-networkunavailable)
-      - [210 Nodes Condition - MemoryPressure](#210-nodes-condition-memorypressure)
-      - [210 Nodes Condition - DiskPressure](#210-nodes-condition-diskpressure)
-      - [210 Nodes Condition - PIDPressure](#210-nodes-condition-pidpressure)
-      - [210 Nodes Condition - Ready](#210-nodes-condition-ready)
+        - [202 Nodes pid_max](#202-nodes-pid_max)
+        - [203 Kubelet Version](#203-kubelet-version)
+    - [204 Recommended packages versions](#204-recommended-packages-version)
+    - [205 System packages versions](#205-system-packages-version)
+      - [205 CRI Versions](#205-cri-versions)
+      - [205 HAproxy Version](#205-haproxy-version)
+      - [205 Keepalived Version](#205-keepalived-version)
+      - [205 Audit Version](#205-audit-version)
+      - [205 Mandatory Package Versions](#205-mandatory-package-versions)
+    - [206 Generic Packages Version](#206-generic-packages-version)
+    - [207 Pods Condition](#207-pods-condition)
+    - [208 Dashboard Availability](#208-dashboard-availability)
+    - [209 Nodes Existence](#209-nodes-existence)
+    - [210 Nodes Roles](#210-nodes-roles)
+    - [211 Nodes Condition](#211-nodes-condition)
+      - [211 Nodes Condition - NetworkUnavailable](#211-nodes-condition---networkunavailable)
+      - [211 Nodes Condition - MemoryPressure](#211-nodes-condition---memorypressure)
+      - [211 Nodes Condition - DiskPressure](#211-nodes-condition---diskpressure)
+      - [211 Nodes Condition - PIDPressure](#211-nodes-condition---pidpressure)
+      - [211 Nodes Condition - Ready](#211-nodes-condition---ready)
     - [213 Selinux security policy](#213-selinux-security-policy)
     - [214 Selinux configuration](#214-selinux-configuration)
     - [215 Firewalld status](#215-firewalld-status)
@@ -324,6 +328,21 @@ The PAAS procedure verifies the platform solution. For example, it checks the he
 The task tree is as follows:
 
 * services
+  * security
+    * selinux
+      * status
+      * config
+    * apparmor
+      * status
+      * config
+    * firewalld
+      * status
+  * system
+    * time
+    * swap
+      * status
+    * modprobe
+      * rules
   * haproxy
     * status
   * keepalived
@@ -332,8 +351,24 @@ The task tree is as follows:
     * status
   * kubelet
     * status
+    * configuration
+    * version
+  * packages
+    * system
+      * recommended_versions
+      * cri_version
+      * haproxy_version
+      * keepalived_version
+      * audit_version
+      * mandatory_versions
+    * generic
+      * version
+* thirdparties
+  * hashes
 * kubernetes
-  * version
+  * pods
+  * plugins
+    * dashboard
   * nodes
     * existence
     * roles
@@ -343,6 +378,18 @@ The task tree is as follows:
       * disk
       * pid
       * ready
+  * admission
+* etcd
+  * health_status
+* control_plane
+  * configuration_status
+  * health_status
+* default_services
+  * configuration_status
+  * health_status
+* calico
+  * config_check
+* geo_check
 
 ##### 201 Service Status
 
@@ -386,31 +433,47 @@ This test checks the Kubelet version on all hosts in a cluster.
 
 ##### 204 Recommended Packages Version
 
-*Task*: `packages.system.recommened_versions`
+*Task*: `services.packages.system.recommended_versions`
 
 This test checks that system package versions in the inventory are recommended.
 
-##### 205 CRI Versions
+##### 205 System Packages Version
 
-*Task*: `packages.system.cri_version`
+Tests of this type check that the system packages are installed and have equal versions.
+
+###### 205 CRI Versions
+
+*Task*: `services.packages.system.cri_version`
 
 This test checks that the configured CRI package is installed on all nodes and has an equal version.
 
-##### 205 HAproxy Version
+###### 205 HAproxy Version
 
-*Task*: `packages.system.haproxy`
+*Task*: `services.packages.system.haproxy_version`
 
 This test checks that the configured HAproxy package is installed on all nodes and has an equal version.
 
-##### 205 Keepalived Version
+###### 205 Keepalived Version
 
-*Task*: `packages.system.keepalived`
+*Task*: `services.packages.system.keepalived_version`
 
 This test checks that the configured Keepalived package is installed on all nodes and has an equal version.
 
+###### 205 Audit Version
+
+*Task*: `services.packages.system.audit_version`
+
+This test checks that the configured Audit package is installed on all nodes and has an equal version.
+
+###### 205 Mandatory Package Versions
+
+*Task*: `services.packages.system.mandatory_versions`
+
+This test checks that the configured mandatory packages are installed on all nodes and have equal versions.
+
 ##### 206 Generic Packages Version
 
-*Task*: `packages.generic.versions`
+*Task*: `services.packages.generic.version`
 
 This test checks that the configured generic packages are installed on all nodes and have equal versions.
 
@@ -569,7 +632,7 @@ The test checks status of Pod Security Admissions, default PSS(Pod Security Stan
 
 ###### 226 Geo connectivity status
 
-*Task*: `geo_monitor`
+*Task*: `geo_check`
 
 The task checks status of DNS resolving, pod-to-service and pod-to-pod connectivity between cluster in geographically
 distributed schemas. This task works only if procedure config file is provided with information about `paas-geo-monitor`,

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -228,7 +228,7 @@ This task is executed to restore the required CoreDNS configuration.
 
 #### Packages Upgrade Section and Task
 
-This inventory section contains the configuration to upgrade custom and system packages, such as docker, containerd, haproxy, and keepalived. The system packages are upgraded by default, if necessary. You can influence the system packages' upgrade and specify custom packages for the upgrade/installation/removal using the `packages` section as follows:
+This inventory section contains the configuration to upgrade custom and system packages, such as docker, containerd, and podman. The system packages are upgraded by default, if necessary. You can influence the system packages' upgrade and specify custom packages for the upgrade/installation/removal using the `packages` section as follows:
 
 ```yaml
 v1.18.8:

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -55,10 +55,7 @@ def clean(group, **kwargs) -> NodeGroupResult:
     return group.sudo(DEBIAN_HEADERS + "apt clean", **kwargs)
 
 
-def install(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
-    if include is None:
-        raise Exception('You must specify included packages to install')
-
+def get_install_cmd(include: str or list, exclude=None) -> str:
     if isinstance(include, list):
         include = ' '.join(include)
     command = DEBIAN_HEADERS + 'apt update && ' + \
@@ -68,6 +65,15 @@ def install(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
         if isinstance(exclude, list):
             exclude = ','.join(exclude)
         command += ' --exclude=%s' % exclude
+
+    return command
+
+
+def install(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
+    if include is None:
+        raise Exception('You must specify included packages to install')
+
+    command = get_install_cmd(include, exclude)
 
     return group.sudo(command, **kwargs)
     # apt fails to install (downgrade) package if it is already present and has higher version,

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -119,7 +119,7 @@ class KubernetesCluster(Environment):
         return self.make_group(ips)
 
     def create_group_from_groups_nodes_names(self, groups_names: List[str], nodes_names: List[str]) -> NodeGroup:
-        common_group = None
+        common_group = self.make_group([])
 
         if nodes_names:
             common_group = self.make_group_from_nodes(nodes_names)
@@ -131,10 +131,7 @@ class KubernetesCluster(Environment):
                     self.log.verbose('Group \'%s\' is requested for usage, but this group is not exists.' % group)
                     continue
 
-                if common_group is None:
-                    common_group = self.nodes[group]
-                else:
-                    common_group = common_group.include_group(self.nodes[group])
+                common_group = common_group.include_group(self.nodes[group])
 
         return common_group
 

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -318,38 +318,6 @@ class KubernetesCluster(Environment):
         os_family = self.get_os_family_for_node(host)
         return self._get_package_associations_for_os(os_family, package, association_key)
 
-    def get_package_association_for_group(self, group: NodeGroup, package: str, association_key: str) -> dict:
-        """
-        Returns the specified association dict for the specified package from inventory for entire NodeGroup.
-
-        :param group: NodeGroup for which required to find the association
-        :param package: The package name to get the association for
-        :param association_key: Association key to get
-        :return: Association values for every host in group, e.g. { host -> value }
-        """
-        results = {}
-        for node in group.get_ordered_members_list(provide_node_configs=True):
-            association_value = self.get_package_association_for_node(node['connect_to'], package, association_key)
-            results[node['connect_to']] = association_value
-        return results
-
-    def get_package_association_str_for_group(self, group: NodeGroup,
-                                              package: str, association_key: str) -> str or list:
-        """
-        Returns the specified association string or list for the specified package from inventory for entire NodeGroup.
-        If association value is different between some nodes, an exception will be thrown.
-
-        :param group: NodeGroup for which required to find the association
-        :param package: The package name to get the association for
-        :param association_key: Association key to get
-        :return: Association string or list value
-        """
-        results = self.get_package_association_for_group(group, package, association_key)
-        results_values = list(set(results.values()))
-        if len(results_values) == 1:
-            return results_values[0]
-        raise Exception(f'Too many values returned for package associations str "{association_key}" for package "{package}"')
-
     def make_finalized_inventory(self):
         from kubemarine.core import defaults
         from kubemarine.procedures import remove_node

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -61,6 +61,7 @@ DEFAULT_ENRICHMENT_FNS = [
     "kubemarine.system.verify_inventory",
     "kubemarine.system.enrich_etc_hosts",
     "kubemarine.packages.enrich_inventory_include_all",
+    "kubemarine.audit.verify_inventory",
     "kubemarine.plugins.enrich_inventory",
     "kubemarine.plugins.verify_inventory",
     "kubemarine.coredns.enrich_add_hosts_config",

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -301,7 +301,7 @@ class RemoteExecutor:
 
                 if output != "":
                     output += "\n"
-                output += "\t%s (%s): code=%i" % (conn, token, result.exited)
+                output += "\t%s (%s): code=%i" % (conn.host, token, result.exited)
                 if result.stdout:
                     output += "\n\t\tSTDOUT: %s" % result.stdout.replace("\n", "\n\t\t        ")
                 if result.stderr:

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -219,7 +219,7 @@ class RemoteExecutor:
         Merges last tokenized results into NodeGroupResult.
 
         The method is useful to check exceptions, to check result in case only one command per node is executed,
-        or to check result of specific commands in the batch if tokens parameter is provided.
+        or to check result of specific commands in the batch if filter_tokens parameter is provided.
 
         :param filter_tokens: tokens to filter result of specific commands in the batch
         :return: None or NodeGroupResult

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -360,10 +360,10 @@ class NodeGroup:
 
         return group_result
 
-    def run(self, *args, **kwargs) -> NodeGroupResult:
+    def run(self, *args, **kwargs) -> NodeGroupResult or int:
         return self.do("run", *args, **kwargs)
 
-    def sudo(self, *args, **kwargs) -> NodeGroupResult:
+    def sudo(self, *args, **kwargs) -> NodeGroupResult or int:
         return self.do("sudo", *args, **kwargs)
 
     def put(self, local_file: Union[io.StringIO, str], remote_file: str, **kwargs):

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -875,6 +875,12 @@ class NodeGroup:
             result.append(node['name'])
         return result
 
+    def get_node_name(self) -> str:
+        if len(self.nodes) != 1:
+            raise Exception("Cannot get the only name from not a single node")
+
+        return self.get_first_member(provide_node_configs=True)['name']
+
     def get_hosts(self) -> List[str]:
         members = self.get_ordered_members_list(provide_node_configs=True)
         return [node['connect_to'] for node in members]

--- a/kubemarine/packages.py
+++ b/kubemarine/packages.py
@@ -33,6 +33,8 @@ ERROR_MULTIPLE_PACKAGE_VERSIONS_DETECTED = \
     "Align them to the single version manually or using corresponding task of install procedure. " \
     "Alternatively, specify cache_versions=false for corresponding association."
 
+ERROR_SEMANAGE_NOT_MANAGED_DEBIAN = "semanage is not managed for debian OS family by KubeMarine"
+
 
 def enrich_inventory_associations(inventory, cluster: KubernetesCluster):
     associations: dict = inventory['services']['packages']['associations']
@@ -58,7 +60,7 @@ def enrich_inventory_associations(inventory, cluster: KubernetesCluster):
             default_merger.merge(enriched_associations[os_family], associations)
 
     if 'semanage' in enriched_associations['debian']:
-        raise Exception("semanage is not managed for debian OS family by KubeMarine")
+        raise Exception(ERROR_SEMANAGE_NOT_MANAGED_DEBIAN)
 
     inventory['services']['packages']['associations'] = enriched_associations
 

--- a/kubemarine/packages.py
+++ b/kubemarine/packages.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from copy import deepcopy
 from typing import List, Dict
 
 import fabric
@@ -36,13 +36,17 @@ ERROR_MULTIPLE_PACKAGE_VERSIONS_DETECTED = \
 
 def enrich_inventory_associations(inventory, cluster: KubernetesCluster):
     associations: dict = inventory['services']['packages']['associations']
-    os_propagated_associations = {}
+    enriched_associations = {}
 
-    # move associations for OS families as-is
+    # Move associations for OS families and merge with globals
     for association_name in get_associations_os_family_keys():
-        os_propagated_associations[association_name] = associations.pop(association_name)
-
-    inventory['services']['packages']['associations'] = os_propagated_associations
+        os_associations: dict = deepcopy(cluster.globals['packages']['common_associations'])
+        if association_name == 'debian':
+            del os_associations['semanage']
+        for association_params in os_associations.values():
+            del association_params['groups']
+        default_merger.merge(os_associations, associations.pop(association_name))
+        enriched_associations[association_name] = os_associations
 
     # Check remained associations section if they are customized at global level.
     if associations:
@@ -51,7 +55,12 @@ def enrich_inventory_associations(inventory, cluster: KubernetesCluster):
             raise Exception(ERROR_GLOBAL_ASSOCIATIONS_REDEFINED_MULTIPLE_OS)
         elif os_family not in ('unknown', 'unsupported'):
             # move remained associations properties to the specific OS family section and merge with priority
-            default_merger.merge(os_propagated_associations[os_family], associations)
+            default_merger.merge(enriched_associations[os_family], associations)
+
+    if 'semanage' in enriched_associations['debian']:
+        raise Exception("semanage is not managed for debian OS family by KubeMarine")
+
+    inventory['services']['packages']['associations'] = enriched_associations
 
     return inventory
 
@@ -76,7 +85,7 @@ def enrich_inventory_include_all(inventory: dict, _):
     return inventory
 
 
-def cache_package_versions(cluster: KubernetesCluster, inventory: dict, ensured_associations_only=False) -> dict:
+def cache_package_versions(cluster: KubernetesCluster, inventory: dict, by_initial_nodes=False) -> dict:
     os_ids = cluster.get_os_identifiers()
     different_os = list(set(os_ids.values()))
     if len(different_os) > 1:
@@ -91,73 +100,126 @@ def cache_package_versions(cluster: KubernetesCluster, inventory: dict, ensured_
         cluster.log.debug("Skip caching of packages for unsupported OS.")
         return inventory
 
-    nodes_cache_versions = cluster.nodes['all'].get_final_nodes().get_sudo_nodes()
-    if nodes_cache_versions.is_empty():
+    group = cluster.nodes['all'].get_final_nodes()
+    if group.nodes_amount() != group.get_sudo_nodes().nodes_amount():
         # For add_node/install procedures we check that all nodes are sudoers in prepare.check.sudoer task.
-        # For check_iaas procedure the nodes might still be not sudoers, so skip caching.
-        cluster.log.debug(f"There are no nodes with sudo privileges, packages will not be cached.")
+        # For check_iaas procedure the nodes might still be not sudoers.
+        # Skip caching if any not-sudoer node found.
+        cluster.log.debug(f"Some nodes are not sudoers, packages will not be cached.")
         return inventory
 
-    packages_list = _get_packages_to_detect_versions(cluster, inventory, ensured_associations_only)
-    detected_packages = detect_installed_packages_version_groups(nodes_cache_versions, packages_list)
+    if by_initial_nodes:
+        group = group.get_initial_nodes()
 
-    _cache_package_associations(cluster, inventory, detected_packages, ensured_associations_only)
-    _cache_custom_packages(cluster, inventory, detected_packages, ensured_associations_only)
+    hosts_to_packages = get_all_managed_packages_for_group(group, inventory, by_initial_nodes)
+    detected_packages = detect_installed_packages_version_hosts(cluster, hosts_to_packages)
+
+    _cache_package_associations(group, inventory, detected_packages, by_initial_nodes)
+    _cache_custom_packages(cluster, inventory, detected_packages, by_initial_nodes)
 
     cluster.log.debug('Package versions detection finished')
     return inventory
 
 
-def _get_associations(cluster: KubernetesCluster, inventory: dict):
-    return inventory['services']['packages']['associations'][cluster.get_os_family()]
+def get_all_managed_packages_for_group(group: NodeGroup, inventory: dict, ensured_association_only: bool = False) \
+        -> Dict[str, List[str]]:
+    """
+    Returns hosts with list of all managed packages for them.
+    For associations, only subset of hosts is considered on which the associations are managed by KubeMarine.
+
+    :param group: Group of nodes to get the manager packages for.
+    :param inventory: Inventory of the cluster. May be different from the inventory of the cluster instance,
+                      if used during finalization.
+    :param ensured_association_only: Specify whether to take 'cache_versions' property into account for associations.
+                                     Additionally, if true, will skip custom packages.
+    :return: List of packages for each relevant host.
+    """
+    packages_section = inventory['services']['packages']
+    hosts_to_packages = {}
+    for node in group.get_ordered_members_list():
+        os_family = node.get_nodes_os()
+        node_associations = packages_section['associations'].get(os_family, {})
+        for association_name in node_associations.keys():
+            packages = get_association_hosts_to_packages(
+                node, inventory, association_name, ensured_association_only)
+
+            packages = next(iter(packages.values()), [])
+            hosts_to_packages.setdefault(node.get_host(), []).extend(packages)
+
+    custom_install_packages = inventory['services']['packages'].get('install', {}).get('include', [])
+    if not ensured_association_only and custom_install_packages:
+        for host in group.get_hosts():
+            hosts_to_packages.setdefault(host, []).extend(custom_install_packages)
+
+    return hosts_to_packages
 
 
-def _get_package_names_for_association(cluster: KubernetesCluster, inventory: dict, association_name: str) -> list:
-    if association_name in get_associations_os_family_keys():
-        return []
+def get_association_hosts_to_packages(group: NodeGroup, inventory: dict, association_name: str,
+                                      ensured_association_only: bool = False) \
+        -> Dict[str, List[str]]:
+    """
+    Returns hosts with associated packages list for the specified association name.
+    Only subset of hosts is returned on which the association is managed by KubeMarine.
 
-    associated_packages = _get_associations(cluster, inventory)[association_name].get('package_name')
-    if isinstance(associated_packages, str):
-        associated_packages = [associated_packages]
-    elif not isinstance(associated_packages, list):
-        raise Exception('Unsupported associated packages object type')
+    :param group: Group of nodes to check the applicability of the association.
+    :param inventory: Inventory of the cluster. May be different from the inventory of the cluster instance,
+                      if used during finalization.
+    :param association_name: target association name
+    :param ensured_association_only: Specify whether to take 'cache_versions' property into account.
+    :return: List of packages for each relevant host.
+    """
+    cluster = group.cluster
 
-    return associated_packages
+    packages_section = inventory['services']['packages']
+    if not packages_section['mandatory'].get(association_name, True):
+        return {}
+
+    hosts_to_packages = {}
+
+    if association_name == 'unzip':
+        from kubemarine import thirdparties
+        relevant_group = thirdparties.get_group_require_unzip(cluster, inventory)
+    else:
+        groups = cluster.globals['packages']['common_associations'].get(association_name, {}).get('groups', [])
+        relevant_group = cluster.create_group_from_groups_nodes_names(groups, [])
+
+    if association_name in ('docker', 'containerd') \
+            and association_name != inventory['services']['cri']['containerRuntime']:
+        relevant_group = cluster.make_group([])
+
+    relevant_group = relevant_group.intersection_group(group)
+
+    global_cache_versions = packages_section['cache_versions']
+    for node in relevant_group.get_ordered_members_list():
+        os_family = node.get_nodes_os()
+        package_associations = packages_section['associations'].get(os_family, {}).get(association_name, {})
+        packages = package_associations.get('package_name', [])
+
+        if isinstance(packages, str):
+            packages = [packages]
+
+        if ensured_association_only and not (global_cache_versions and package_associations.get('cache_versions', True)):
+            packages = []
+
+        if packages:
+            hosts_to_packages[node.get_host()] = packages
+
+    return hosts_to_packages
 
 
-def _get_packages_for_associations_to_detect(cluster: KubernetesCluster, inventory: dict, association_name: str,
-                                             ensured_association_only: bool) -> list:
-    packages_list = _get_package_names_for_association(cluster, inventory, association_name)
-    if not packages_list:
-        return []
-
-    global_cache_versions = inventory['services']['packages']['cache_versions']
-    associated_params = _get_associations(cluster, inventory)[association_name]
-    if not ensured_association_only or (global_cache_versions and associated_params.get('cache_versions', True)):
-        return packages_list
-
-    return []
-
-
-def _get_packages_to_detect_versions(cluster: KubernetesCluster, inventory: dict, ensured_association_only: bool) -> list:
-    packages_list = []
-    for association_name in _get_associations(cluster, inventory).keys():
-        packages_list.extend(_get_packages_for_associations_to_detect(
-            cluster, inventory, association_name, ensured_association_only))
-
-    if not ensured_association_only and inventory['services']['packages'].get('install', {}):
-        packages_list.extend(inventory['services']['packages']['install']['include'])
-
-    return packages_list
-
-
-def _cache_package_associations(cluster: KubernetesCluster, inventory: dict,
+def _cache_package_associations(group: NodeGroup, inventory: dict,
                                 detected_packages: Dict[str, Dict[str, List]], ensured_association_only: bool):
-    for association_name, associated_params in _get_associations(cluster, inventory).items():
-        packages_list = _get_packages_for_associations_to_detect(
-            cluster, inventory, association_name, ensured_association_only)
-        if not packages_list:
+    cluster = group.cluster
+    associations = inventory['services']['packages']['associations'][cluster.get_os_family()]
+    for association_name, associated_params in associations.items():
+        hosts_to_packages = get_association_hosts_to_packages(
+            group, inventory, association_name, ensured_association_only)
+        if not hosts_to_packages:
             continue
+
+        # Since all nodes have the same OS family in this case,
+        # the packages list is the same for all relevant hosts, so take any available.
+        packages_list = next(iter(hosts_to_packages.values()))
 
         final_packages_list = []
         for package in packages_list:
@@ -179,13 +241,12 @@ def _cache_custom_packages(cluster: KubernetesCluster, inventory: dict,
         return
     # packages from direct installation section
     custom_install_packages = inventory['services']['packages'].get('install', {})
-    if custom_install_packages:
+    if custom_install_packages.get('include', []):
         final_packages_list = []
         for package in custom_install_packages['include']:
             final_package = _detect_final_package(cluster, detected_packages, package, False)
             final_packages_list.append(final_package)
         custom_install_packages['include'] = final_packages_list
-    return detected_packages
 
 
 def _detect_final_package(cluster: KubernetesCluster, detected_packages: Dict[str, Dict[str, List]],
@@ -306,66 +367,41 @@ def _parse_node_detected_package(result: fabric.runners.Result, package: str) ->
     return node_detected_package
 
 
-def detect_installed_association_packages(group: NodeGroup, association_name: str) -> Dict[str, List[str]]:
-    cluster = group.cluster
-
-    result = {}
-    host_to_packages = {}
-    with RemoteExecutor(cluster) as exe:
-        for node in group.get_ordered_members_list(provide_node_configs=True):
-            the_node: NodeGroup = node['connection']
-            host: str = node['connect_to']
-
-            packages = cluster.get_package_association_for_node(host, association_name, 'package_name')
-            if isinstance(packages, str):
-                packages = [packages]
-
-            host_to_packages[host] = packages
-            for pkg in packages:
-                _detect_installed_package_version(the_node, pkg)
-
-    for conn, multiple_results in exe.get_last_results().items():
-        host = conn.host
-        multiple_results = list(multiple_results.values())
-        for i, package in enumerate(host_to_packages[host]):
-            node_detected_package = _parse_node_detected_package(multiple_results[i], package)
-            result.setdefault(host, []).append(node_detected_package)
-
-    return result
-
-
-def detect_installed_packages_version_groups(group: NodeGroup, packages_list: List or str) -> Dict[str, Dict[str, List]]:
+def detect_installed_packages_version_hosts(cluster: KubernetesCluster, hosts_to_packages: Dict[str, List[str]]) \
+        -> Dict[str, Dict[str, List]]:
     """
-    Detect grouped packages versions on remote group from specified list of packages.
-    :param group: Group of nodes, where packages should be found
-    :param packages_list: Single package or list of packages, which versions should be detected.
+    Detect grouped packages versions for specified list of packages for each remote host.
+
+    :param cluster: KubernetesCluster instance
+    :param hosts_to_packages: Remote hosts with list of packages to detect versions.
     :return: Dictionary with grouped versions for each queried package, pointing to list of hosts,
         e.g. {"foo" -> {"foo-1": [host1, host2]}, "bar" -> {"bar-1": [host1], "bar-2": [host2]}}
     """
-
-    cluster = group.cluster
-
-    if isinstance(packages_list, str):
-        packages_list = [packages_list]
-    # deduplicate
-    packages_list = list(set(packages_list))
-    if not packages_list:
-        return {}
+    for host, packages_list in hosts_to_packages.items():
+        if isinstance(packages_list, str):
+            packages_list = [packages_list]
+        # deduplicate
+        hosts_to_packages[host] = list(set(packages_list))
 
     with RemoteExecutor(cluster) as exe:
-        for package in packages_list:
-            _detect_installed_package_version(group, package)
+        for host, packages_list in hosts_to_packages.items():
+            node = cluster.make_group([host])
+            for package in packages_list:
+                _detect_installed_package_version(node, package)
 
     raw_result = exe.get_last_results()
+    if not raw_result:
+        return {}
+
     results: Dict[str, Dict[str, List]] = {}
 
-    for i, package in enumerate(packages_list):
-        detected_grouped_packages = {}
-        for conn, multiple_results in raw_result.items():
+    for conn, multiple_results in raw_result.items():
+        multiple_results = list(multiple_results.values())
+        host = conn.host
+        packages_list = hosts_to_packages[host]
+        for i, package in enumerate(packages_list):
             node_detected_package = _parse_node_detected_package(multiple_results[i], package)
-            detected_grouped_packages.setdefault(node_detected_package, []).append(conn.host)
-
-        results[package] = detected_grouped_packages
+            results.setdefault(package, {}).setdefault(node_detected_package, []).append(host)
 
     return results
 

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -22,7 +22,9 @@ The whole directory is automatically cleared and reset after new version of Kube
 from typing import List
 
 from kubemarine.core.patch import Patch
+from kubemarine.patches.p1_mandatory_packages_off import MandatoryPackagesOff
 
 patches: List[Patch] = [
+    MandatoryPackagesOff()
 ]
 """List of patches which can be executed strictly in the declared order"""

--- a/kubemarine/patches/p1_mandatory_packages_off.py
+++ b/kubemarine/patches/p1_mandatory_packages_off.py
@@ -1,0 +1,36 @@
+from textwrap import dedent
+
+from kubemarine.core import static
+from kubemarine.core.action import Action
+from kubemarine.core.patch import Patch
+from kubemarine.core.resources import DynamicResources
+
+
+class TheAction(Action):
+    def __init__(self):
+        super().__init__("Turn mandatory packages off for backward compatibility", recreate_inventory=True)
+
+    def run(self, res: DynamicResources):
+        for package in static.DEFAULTS["services"]["packages"]['mandatory'].keys():
+            res.formatted_inventory().setdefault('services', {}).setdefault('packages', {})\
+                .setdefault('mandatory', {})[package] = False
+
+
+class MandatoryPackagesOff(Patch):
+    def __init__(self):
+        super().__init__("mandatory_packages_off")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            New KubeMarine automatically installs and manages all mandatory packages.
+            Old users had to specify them inside services.packages.install section.
+            For backward compatibility KubeMarine should not manage mandatory packages for old clusters.
+            The patch turns off the management in the inventory.
+            """.rstrip()
+        )

--- a/kubemarine/patches/p1_mandatory_packages_off.py
+++ b/kubemarine/patches/p1_mandatory_packages_off.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from textwrap import dedent
 
 from kubemarine.core import static

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -546,8 +546,8 @@ def verify_thirdparty(cluster, thirdparty):
                         % (thirdparty, defined_thirdparties))
 
 
-def apply_thirdparty(cluster, thirdparty, plugin_name=None):
-    return thirdparties.install_thirdparty(cluster, thirdparty)
+def apply_thirdparty(cluster: KubernetesCluster, thirdparty: str, plugin_name=None):
+    return thirdparties.install_thirdparty(cluster.nodes['all'], thirdparty)
 
 
 # **** SHELL ****
@@ -563,7 +563,7 @@ def convert_shell(cluster, config):
 def verify_shell(cluster, config):
     out_vars = config.get('out_vars', [])
     explicit_group = cluster.create_group_from_groups_nodes_names(config.get('groups', []), config.get('nodes', []))
-    if out_vars and explicit_group and explicit_group.nodes_amount() != 1:
+    if out_vars and explicit_group.nodes_amount() > 1:
         raise Exception('Shell output variables could be used for single-node groups, but multi-node group was found')
 
     in_vars = config.get('in_vars', [])

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -563,7 +563,7 @@ def convert_shell(cluster, config):
 def verify_shell(cluster, config):
     out_vars = config.get('out_vars', [])
     explicit_group = cluster.create_group_from_groups_nodes_names(config.get('groups', []), config.get('nodes', []))
-    if out_vars and explicit_group.nodes_amount() > 1:
+    if out_vars and explicit_group.nodes_amount() != 1:
         raise Exception('Shell output variables could be used for single-node groups, but multi-node group was found')
 
     in_vars = config.get('in_vars', [])

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -562,8 +562,10 @@ def convert_shell(cluster, config):
 
 def verify_shell(cluster, config):
     out_vars = config.get('out_vars', [])
-    explicit_group = cluster.create_group_from_groups_nodes_names(config.get('groups', []), config.get('nodes', []))
-    if out_vars and explicit_group.nodes_amount() != 1:
+    groups = config.get('groups', [])
+    nodes = config.get('nodes', [])
+    explicit_group = cluster.create_group_from_groups_nodes_names(groups, nodes)
+    if out_vars and (groups or nodes) and explicit_group.nodes_amount() != 1:
         raise Exception('Shell output variables could be used for single-node groups, but multi-node group was found')
 
     in_vars = config.get('in_vars', [])

--- a/kubemarine/procedures/add_node.py
+++ b/kubemarine/procedures/add_node.py
@@ -96,7 +96,7 @@ def cache_installed_packages(cluster: KubernetesCluster):
     It is called first during "add_node" procedure,
     so that new nodes install exactly the same packages as on other already existing nodes.
     """
-    packages.cache_package_versions(cluster, cluster.inventory, ensured_associations_only=True)
+    packages.cache_package_versions(cluster, cluster.inventory, by_initial_nodes=True)
 
 
 tasks = OrderedDict(copy.deepcopy(install.tasks))

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -429,14 +429,14 @@ def check_access_to_package_repositories(cluster: KubernetesCluster):
         all_group.put(local_path, random_temp_path, binary=False)
 
         if repository_urls:
-            with RemoteExecutor(cluster, ignore_failed=True) as exe:
+            with RemoteExecutor(cluster) as exe:
                 for node in all_group.get_ordered_members_list(provide_node_configs=True):
                     # Check with script
                     python_executable = cluster.context['nodes'][node['connect_to']]['python']['executable']
                     for repository_url in repository_urls:
                         node['connection'].run('%s %s %s %s || echo "Package repository is unavailable"'
                                                % (python_executable, random_temp_path, repository_url,
-                                                  cluster.inventory['timeout_download']), warn=True)
+                                                  cluster.inventory['timeout_download']))
 
             for conn, url_results in exe.get_last_results().items():
                 # Check if resolv.conf is actual
@@ -498,12 +498,12 @@ def check_access_to_packages(cluster: KubernetesCluster):
         check_package_repositories(cluster)
         broken = []
         warnings = []
-        with RemoteExecutor(cluster, ignore_failed=True) as exe:
+        with RemoteExecutor(cluster) as exe:
             for node in cluster.nodes['all'].get_ordered_members_list(provide_node_configs=True):
                 packages_to_check = get_packages_to_install(node)
                 cluster.log.debug(f"Packages to check for node {node['connect_to']}: {packages_to_check}")
                 for package in packages_to_check:
-                    packages.search_package(node['connection'], package, warn=True)
+                    packages.search_package(node['connection'], package)
 
         # Check packages from install section
         for conn, results in exe.get_last_results().items():

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -17,7 +17,7 @@ import sys
 import time
 from collections import OrderedDict
 import re
-from typing import List
+from typing import List, Dict
 
 import yaml
 import ruamel.yaml
@@ -184,20 +184,33 @@ def system_packages_versions(cluster: KubernetesCluster, pckg_alias: str):
     """
     with TestCase(cluster.context['testsuite'], '205', "Services", f"{pckg_alias} version") as tc:
         _check_same_os(cluster)
-        if pckg_alias == "docker" or pckg_alias == "containerd":
-            group = cluster.nodes['control-plane'].include_group(cluster.nodes.get('worker'))
-        elif pckg_alias == "keepalived" or pckg_alias == "haproxy":
-            if "balancer" in cluster.nodes and not cluster.nodes['balancer'].is_empty():
-                group = cluster.nodes['balancer']
-            else:
-                raise TestWarn("balancer group is not present")
-        else:
-            raise Exception(f"Unknown system package alias: {pckg_alias}")
+        hosts_to_packages = pckgs.get_association_hosts_to_packages(cluster.nodes['all'], cluster.inventory, pckg_alias)
+        if not hosts_to_packages:
+            raise TestWarn(f"No nodes to check {pckg_alias!r} version")
 
-        packages = cluster.get_package_association(pckg_alias, 'package_name')
-        if not isinstance(packages, list):
-            packages = [packages]
-        return check_packages_versions(cluster, tc, group, packages)
+        return check_packages_versions(cluster, tc, hosts_to_packages)
+
+
+def mandatory_packages_versions(cluster: KubernetesCluster):
+    """
+    Verifies that mandatory packages are installed on required nodes and have equal versions.
+    Failure is shown if check is not successful.
+    :param cluster: main cluster object.
+    """
+    with TestCase(cluster.context['testsuite'], '205', "Services", "Mandatory package versions") as tc:
+        _check_same_os(cluster)
+        hosts_to_packages = {}
+        group = cluster.nodes['all']
+        for package in cluster.inventory["services"]["packages"]['mandatory'].keys():
+            packages = pckgs.get_association_hosts_to_packages(group, cluster.inventory, package)
+
+            for host, packages_list in packages.items():
+                hosts_to_packages.setdefault(host, []).extend(packages_list)
+
+        if not hosts_to_packages:
+            raise TestWarn(f"No mandatory packages to check")
+
+        return check_packages_versions(cluster, tc, hosts_to_packages)
 
 
 def generic_packages_versions(cluster: KubernetesCluster):
@@ -207,23 +220,23 @@ def generic_packages_versions(cluster: KubernetesCluster):
     """
     with TestCase(cluster.context['testsuite'], '206', "Services", f"Generic packages version") as tc:
         _check_same_os(cluster)
-        packages = cluster.inventory['services']['packages']['install']['include']
-        return check_packages_versions(cluster, tc, cluster.nodes['all'], packages, warn_on_bad_result=True)
+        packages = cluster.inventory['services']['packages'].get('install', {}).get('include', [])
+        hosts_to_packages = {host: packages for host in cluster.nodes['all'].get_hosts()}
+        return check_packages_versions(cluster, tc, hosts_to_packages, warn_on_bad_result=True)
 
 
-def check_packages_versions(cluster, tc, group, packages, warn_on_bad_result=False):
+def check_packages_versions(cluster, tc, hosts_to_packages: Dict[str, List[str]], warn_on_bad_result=False):
     """
     Verifies that all packages are installed on required nodes and have equal versions
     :param cluster: main cluster object
     :param tc: current test case object
-    :param group: nodes where to check packages
-    :param packages: list of packages to check
+    :param hosts_to_packages: hosts where to check packages
     :param warn_on_bad_result: if true then uses Warning instead of Failure. Default False.
     """
     bad_results = []
     good_results = []
 
-    packages_map = pckgs.detect_installed_packages_version_groups(group, packages)
+    packages_map = pckgs.detect_installed_packages_version_hosts(cluster, hosts_to_packages)
     for package, version_map in packages_map.items():
         if len(version_map) != 1:
             cluster.log.debug(f"Package {package} has different versions:")
@@ -372,6 +385,7 @@ def thirdparties_hashes(cluster):
             # SHA is correct, now check if it is an archive and if it does, then also check SHA for archive content
             if 'unpack' in config:
                 unpack_dir = config['unpack']
+                # TODO zip does not work!
                 res = group.sudo('tar tf %s | grep -vw "./" | while read file_name; do '  # for each file in archive
                                  '  echo ${file_name} '  # print   1) filename
                                  '    $(sudo tar xfO %s ${file_name} | openssl sha1 | cut -d\\  -f2) '  # 2) sha archive
@@ -617,7 +631,7 @@ def verify_selinux_status(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    if cluster.get_os_family() == 'debian':
+    if cluster.get_os_family() not in ('rhel', 'rhel8'):
         return
 
     with TestCase(cluster.context['testsuite'], '213', "Security", "Selinux security policy") as tc:
@@ -676,7 +690,7 @@ def verify_selinux_config(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    if cluster.get_os_family() == 'debian':
+    if cluster.get_os_family() not in ('rhel', 'rhel8'):
         return
 
     with TestCase(cluster.context['testsuite'], '214', "Security", "Selinux configuration") as tc:
@@ -1311,7 +1325,9 @@ tasks = OrderedDict({
                 'cri_version': lambda cluster:
                     system_packages_versions(cluster, cluster.inventory['services']['cri'][ 'containerRuntime']),
                 'haproxy_version': lambda cluster: system_packages_versions(cluster, 'haproxy'),
-                'keepalived_version': lambda cluster: system_packages_versions(cluster, 'keepalived')
+                'keepalived_version': lambda cluster: system_packages_versions(cluster, 'keepalived'),
+                'audit_version': lambda cluster: system_packages_versions(cluster, 'audit'),
+                'mandatory_versions': mandatory_packages_versions
             },
             'generic': {
                 'version': generic_packages_versions

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -385,7 +385,7 @@ def thirdparties_hashes(cluster):
             # SHA is correct, now check if it is an archive and if it does, then also check SHA for archive content
             if 'unpack' in config:
                 unpack_dir = config['unpack']
-                # TODO zip does not work!
+                # TODO support zip
                 res = group.sudo('tar tf %s | grep -vw "./" | while read file_name; do '  # for each file in archive
                                  '  echo ${file_name} '  # print   1) filename
                                  '    $(sudo tar xfO %s ${file_name} | openssl sha1 | cut -d\\  -f2) '  # 2) sha archive

--- a/kubemarine/procedures/do.py
+++ b/kubemarine/procedures/do.py
@@ -40,7 +40,7 @@ class CLIAction(Action):
 
     def run(self, res: DynamicResources):
         executors_group = self.node_group_provider(res.cluster())
-        if not executors_group or executors_group.nodes_amount() < 1:
+        if executors_group.is_empty():
             print('Failed to find any of specified nodes or groups')
             sys.exit(1)
 

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -165,12 +165,12 @@ def system_prepare_system_modprobe(group: NodeGroup):
 
 @_applicable_for_new_nodes_with_roles('control-plane', 'worker')
 def system_install_audit(group: NodeGroup):
-    group.cluster.log.debug(group.call(audit.install))
+    group.call(audit.install)
 
 
 @_applicable_for_new_nodes_with_roles('control-plane', 'worker')
 def system_prepare_audit_daemon(group: NodeGroup):
-    group.cluster.log.debug(group.call(audit.apply_audit_rules))
+    group.call(audit.apply_audit_rules)
 
 
 @_applicable_for_new_nodes_with_roles('control-plane')

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -276,6 +276,30 @@ def system_prepare_package_manager_configure(group: NodeGroup):
 
 @_applicable_for_new_nodes_with_roles('all')
 def system_prepare_package_manager_manage_packages(group: NodeGroup):
+    group.call_batch([
+        manage_mandatory_packages,
+        manage_custom_packages
+    ])
+
+
+def manage_mandatory_packages(group: NodeGroup):
+    cluster = group.cluster
+
+    with RemoteExecutor(cluster) as exe:
+        for node in group.get_ordered_members_list():
+            pkgs = []
+            for package in cluster.inventory["services"]["packages"]['mandatory'].keys():
+                hosts_to_packages = packages.get_association_hosts_to_packages(node, cluster.inventory, package)
+                pkgs.extend(next(iter(hosts_to_packages.values()), []))
+
+            if pkgs:
+                cluster.log.debug(f"Installing {pkgs} on {node.get_node_name()!r}")
+                packages.install(node, pkgs)
+
+    return exe.get_merged_result()
+
+
+def manage_custom_packages(group: NodeGroup):
     cluster = group.cluster
     batch_tasks = []
     batch_parameters = {}

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -86,12 +86,12 @@ def kubernetes_cleanup_nodes_versions(cluster):
     kubernetes_apply_taints(cluster)
 
 
-def upgrade_packages(cluster):
+def upgrade_packages(cluster: KubernetesCluster):
     upgrade_version = cluster.context["upgrade_version"]
 
     packages = cluster.procedure_inventory.get(upgrade_version, {}).get("packages", {})
     if packages.get("install") is not None or packages.get("upgrade") is not None or packages.get("remove") is not None:
-        install.system_prepare_package_manager_manage_packages(cluster)
+        install.manage_custom_packages(cluster.nodes['all'])
 
 
 def upgrade_plugins(cluster):

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -312,103 +312,81 @@ services:
 
   packages:
     cache_versions: true
+    mandatory:
+      conntrack: true
+      iptables: true
+      openssl: true
+      curl: true
+      unzip: true
+      semanage: true
+      kmod: true
     package_manager:
       replace-repositories: false
     associations:
       debian:
         docker:
-          executable_name: 'docker'
           package_name:
             - 'docker-ce={{ globals.compatibility_map.software.docker[services.kubeadm.kubernetesVersion].version_debian }}'
             - 'docker-ce-cli={{ globals.compatibility_map.software.docker[services.kubeadm.kubernetesVersion].version_debian }}'
             - 'containerd.io={{ globals.compatibility_map.software.containerdio[services.kubeadm.kubernetesVersion].version_debian }}'
-          service_name: 'docker'
-          config_location: '/etc/docker/daemon.json'
         containerd:
-          executable_name: 'containerd'
           package_name:
             - 'containerd={{ globals.compatibility_map.software.containerd[services.kubeadm.kubernetesVersion].version_debian }}'
             - 'podman={{ globals.compatibility_map.software.podman[services.kubeadm.kubernetesVersion].version_debian }}'
-          service_name: 'containerd'
-          config_location: '/etc/containerd/config.toml'
         haproxy:
           executable_name: 'haproxy'
           package_name: 'haproxy={{ globals.compatibility_map.software.haproxy[services.kubeadm.kubernetesVersion].version_debian }}'
           service_name: 'haproxy'
-          config_location: '/etc/haproxy/haproxy.cfg'
         keepalived:
-          executable_name: 'keepalived'
           package_name: 'keepalived={{ globals.compatibility_map.software.keepalived[services.kubeadm.kubernetesVersion].version_debian }}'
-          service_name: 'keepalived'
-          config_location: '/etc/keepalived/keepalived.conf'
         audit:
-          executable_name: 'auditctl'
           package_name: 'auditd'
-          service_name: 'auditd'
-          config_location: '/etc/audit/rules.d/predefined.rules'
+        conntrack:
+          package_name: 'conntrack'
       rhel:
         docker:
-          executable_name: 'docker'
           package_name:
             - 'docker-ce-{{ globals.compatibility_map.software.docker[services.kubeadm.kubernetesVersion].version_rhel }}'
             - 'docker-ce-cli-{{ globals.compatibility_map.software.docker[services.kubeadm.kubernetesVersion].version_rhel }}'
             - 'containerd.io-{{ globals.compatibility_map.software.containerdio[services.kubeadm.kubernetesVersion].version_rhel }}'
-          service_name: 'docker'
-          config_location: '/etc/docker/daemon.json'
         containerd:
-          executable_name: 'containerd'
           package_name:
             - 'containerd.io-{{ globals.compatibility_map.software.containerdio[services.kubeadm.kubernetesVersion].version_rhel }}'
             - 'podman-{{ globals.compatibility_map.software.podman[services.kubeadm.kubernetesVersion].version_rhel }}'
-          service_name: 'containerd'
-          config_location: '/etc/containerd/config.toml'
         haproxy:
           executable_name: '/opt/rh/rh-haproxy18/root/usr/sbin/haproxy'
           package_name: 'rh-haproxy18-haproxy-{{ globals.compatibility_map.software.haproxy[services.kubeadm.kubernetesVersion].version_rhel }}'
           service_name: 'rh-haproxy18-haproxy'
-          config_location: '/etc/haproxy/haproxy.cfg'
         keepalived:
-          executable_name: 'keepalived'
           package_name: 'keepalived-{{ globals.compatibility_map.software.keepalived[services.kubeadm.kubernetesVersion].version_rhel }}'
-          service_name: 'keepalived'
-          config_location: '/etc/keepalived/keepalived.conf'
         audit:
-          executable_name: 'auditctl'
           package_name: 'audit'
-          service_name: 'auditd'
-          config_location: '/etc/audit/rules.d/predefined.rules'
+        conntrack:
+          package_name: 'conntrack-tools'
+        semanage:
+          package_name: 'policycoreutils-python'
       rhel8:
         docker:
-          executable_name: 'docker'
           package_name:
             - 'docker-ce-{{ globals.compatibility_map.software.docker[services.kubeadm.kubernetesVersion].version_rhel8 }}'
             - 'docker-ce-cli-{{ globals.compatibility_map.software.docker[services.kubeadm.kubernetesVersion].version_rhel8 }}'
             - 'containerd.io-{{ globals.compatibility_map.software.containerdio[services.kubeadm.kubernetesVersion].version_rhel8 }}'
-          service_name: 'docker'
-          config_location: '/etc/docker/daemon.json'
         containerd:
-          executable_name: 'containerd'
           package_name:
             - 'containerd.io-{{ globals.compatibility_map.software.containerdio[services.kubeadm.kubernetesVersion].version_rhel8 }}'
             - 'podman-{{ globals.compatibility_map.software.podman[services.kubeadm.kubernetesVersion].version_rhel8 }}'
-          service_name: 'containerd'
-          config_location: '/etc/containerd/config.toml'
         haproxy:
           executable_name: '/usr/sbin/haproxy'
           package_name: 'haproxy-{{ globals.compatibility_map.software.haproxy[services.kubeadm.kubernetesVersion].version_rhel8 }}'
           service_name: 'haproxy'
-          config_location: '/etc/haproxy/haproxy.cfg'
         keepalived:
-          executable_name: 'keepalived'
           package_name: 'keepalived-{{ globals.compatibility_map.software.keepalived[services.kubeadm.kubernetesVersion].version_rhel8 }}'
-          service_name: 'keepalived'
-          config_location: '/etc/keepalived/keepalived.conf'
         audit:
-          executable_name: 'auditctl'
           package_name: 'audit'
-          service_name: 'auditd'
-          config_location: '/etc/audit/rules.d/predefined.rules'
- 
+        conntrack:
+          package_name: 'conntrack-tools'
+        semanage:
+          package_name: 'policycoreutils-python-utils'
 
 plugin_defaults:
   installation: {}

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -116,6 +116,63 @@ thirdparties:
   /usr/bin/crictl.tar.gz:
     software_name: crictl
 
+packages:
+  common_associations:
+    docker:
+      executable_name: 'docker'
+      service_name: 'docker'
+      config_location: '/etc/docker/daemon.json'
+      groups:
+        - control-plane
+        - worker
+    containerd:
+      executable_name: 'containerd'
+      service_name: 'containerd'
+      config_location: '/etc/containerd/config.toml'
+      groups:
+        - control-plane
+        - worker
+    haproxy:
+      config_location: '/etc/haproxy/haproxy.cfg'
+      groups:
+        - balancer
+    keepalived:
+      executable_name: 'keepalived'
+      service_name: 'keepalived'
+      config_location: '/etc/keepalived/keepalived.conf'
+      groups:
+        - keepalived
+    audit:
+      executable_name: 'auditctl'
+      service_name: 'auditd'
+      config_location: '/etc/audit/rules.d/predefined.rules'
+      groups:
+        - control-plane
+        - worker
+    conntrack:
+      groups:
+        - control-plane
+        - worker
+    iptables:
+      package_name: 'iptables'
+      groups:
+        - control-plane
+        - worker
+    openssl:
+      package_name: 'openssl'
+      groups: [ control-plane, worker, balancer ]
+    curl:
+      package_name: 'curl'
+      groups: [ control-plane, worker, balancer ]
+    unzip:
+      package_name: 'unzip'
+      groups: []
+    kmod:
+      package_name: 'kmod'
+      groups: [ control-plane, worker, balancer ]
+    semanage:
+      groups: [ control-plane, worker, balancer ]
+
 compatibility_map:
   software:
     docker:

--- a/kubemarine/resources/schemas/definitions/services/packages.json
+++ b/kubemarine/resources/schemas/definitions/services/packages.json
@@ -4,6 +4,40 @@
   "description": "Section for packages and their management",
   "allOf": [{"$ref": "#/definitions/Properties"}],
   "properties": {
+    "package_manager": {
+      "type": "object",
+      "description": "Additional package manager repositories for the cluster in closed environment",
+      "properties": {
+        "replace-repositories": {
+          "type": "boolean",
+          "default": false,
+          "description": "Deletes old repositories on hosts and installs new ones instead"
+        },
+        "repositories": {
+          "description": "List of new repositories. Can be specified as string with all repositories content, or as list for apt repositories, or as dictionary for yum repositories.",
+          "oneOf": [
+            {"type": "string"},
+            {"$ref": "#/definitions/YumRepositories"},
+            {"$ref": "#/definitions/AptRepositories"}
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "mandatory": {
+      "type": "object",
+      "description": "Specify whether to install or skip mandatory packages",
+      "properties": {
+        "conntrack": {"type": "boolean", "default": true},
+        "iptables": {"type": "boolean", "default": true},
+        "openssl": {"type": "boolean", "default": true},
+        "curl": {"type": "boolean", "default": true},
+        "unzip": {"type": "boolean", "default": true},
+        "semanage": {"type": "boolean", "default": true},
+        "kmod": {"type": "boolean", "default": true}
+      },
+      "additionalProperties": false
+    },
     "associations": {
       "$ref": "packages/associations.json",
       "description": "Configure predefined associations of package objects. If configured in the common section, the associations are automatically switched to the section corresponding to your operating system."
@@ -12,32 +46,12 @@
   "propertyNames": {
     "anyOf": [
       {"$ref": "#/definitions/PropertyNames"},
-      {"enum": ["associations"]}
+      {"enum": ["package_manager", "mandatory", "associations"]}
     ]
   },
   "definitions": {
     "Properties": {
       "properties": {
-        "package_manager": {
-          "type": "object",
-          "description": "Additional package manager repositories for the cluster in closed environment",
-          "properties": {
-            "replace-repositories": {
-              "type": "boolean",
-              "default": false,
-              "description": "Deletes old repositories on hosts and installs new ones instead"
-            },
-            "repositories": {
-              "description": "List of new repositories. Can be specified as string with all repositories content, or as list for apt repositories, or as dictionary for yum repositories.",
-              "oneOf": [
-                {"type": "string"},
-                {"$ref": "#/definitions/YumRepositories"},
-                {"$ref": "#/definitions/AptRepositories"}
-              ]
-            }
-          },
-          "additionalProperties": false
-        },
         "install": {
           "description": "List of custom packages to install. Can be specified as list or as two lists that are to be included and excluded during processing.",
           "oneOf": [
@@ -76,7 +90,7 @@
       }
     },
     "PropertyNames": {
-      "enum": ["package_manager", "install", "upgrade", "remove", "cache_versions"]
+      "enum": ["install", "upgrade", "remove", "cache_versions"]
     },
     "YumRepositories": {
       "type": "object",
@@ -91,7 +105,7 @@
       }
     },
     "AptRepositories": {
-      "$ref": "../common/utils.json#/definitions/MergeableSetOfStrings"
+      "$ref": "../common/utils.json#/definitions/NonEmptySetOfStrings"
     },
     "IncludeExcludePermissive": {
       "type": "object",

--- a/kubemarine/resources/schemas/definitions/services/packages/associations.json
+++ b/kubemarine/resources/schemas/definitions/services/packages/associations.json
@@ -14,14 +14,8 @@
     ]
   },
   "definitions": {
-    "PackageAssociations": {
-      "type": "object",
-      "description": "Associations related to specific package",
+    "PackageAssociationsProperties": {
       "properties": {
-        "executable_name": {
-          "type": "string",
-          "description": "Path to or name of the associated binary executable"
-        },
         "package_name": {
           "description": "Packages with versions to install if the associated service is required for the cluster",
           "oneOf": [
@@ -39,6 +33,33 @@
             }
           ]
         },
+        "cache_versions": {
+          "type": "boolean",
+          "default": true,
+          "description": "Specifies whether to install exactly the same package versions from package_name section during the add_node procedure"
+        }
+      }
+    },
+    "PackageAssociationsPropertyNames": {
+      "enum": ["package_name", "cache_versions"]
+    },
+    "PackageAssociations": {
+      "type": "object",
+      "description": "Associations related to specific package",
+      "allOf": [{"$ref": "#/definitions/PackageAssociationsProperties"}],
+      "propertyNames": {
+        "$ref": "#/definitions/PackageAssociationsPropertyNames"
+      }
+    },
+    "ServicePackageAssociations": {
+      "type": "object",
+      "description": "Associations related to specific package",
+      "allOf": [{"$ref": "#/definitions/PackageAssociationsProperties"}],
+      "properties": {
+        "executable_name": {
+          "type": "string",
+          "description": "Path to or name of the associated binary executable"
+        },
         "service_name": {
           "type": "string",
           "description": "Name of systemd service"
@@ -46,14 +67,14 @@
         "config_location": {
           "type": "string",
           "description": "Path to the configuration file of the associated service"
-        },
-        "cache_versions": {
-          "type": "boolean",
-          "default": true,
-          "description": "Specifies whether to install exactly the same package versions from package_name section during the add_node procedure"
         }
       },
-      "additionalProperties": false
+      "propertyNames": {
+        "anyOf": [
+          {"$ref": "#/definitions/PackageAssociationsPropertyNames"},
+          {"enum": ["executable_name", "service_name", "config_location"]}
+        ]
+      }
     },
     "OSFamilyAssociations": {
       "type": "object",
@@ -65,15 +86,25 @@
     },
     "Associations": {
       "properties": {
-        "docker": {"$ref": "#/definitions/PackageAssociations"},
-        "containerd": {"$ref": "#/definitions/PackageAssociations"},
-        "haproxy": {"$ref": "#/definitions/PackageAssociations"},
-        "keepalived": {"$ref": "#/definitions/PackageAssociations"},
-        "audit": {"$ref": "#/definitions/PackageAssociations"}
+        "docker": {"$ref": "#/definitions/ServicePackageAssociations"},
+        "containerd": {"$ref": "#/definitions/ServicePackageAssociations"},
+        "haproxy": {"$ref": "#/definitions/ServicePackageAssociations"},
+        "keepalived": {"$ref": "#/definitions/ServicePackageAssociations"},
+        "audit": {"$ref": "#/definitions/ServicePackageAssociations"},
+        "conntrack": {"$ref": "#/definitions/PackageAssociations"},
+        "iptables": {"$ref": "#/definitions/PackageAssociations"},
+        "openssl": {"$ref": "#/definitions/PackageAssociations"},
+        "curl": {"$ref": "#/definitions/PackageAssociations"},
+        "unzip": {"$ref": "#/definitions/PackageAssociations"},
+        "semanage": {"$ref": "#/definitions/PackageAssociations"},
+        "kmod": {"$ref": "#/definitions/PackageAssociations"}
       }
     },
     "AssociationsNames": {
-      "enum": ["docker", "containerd", "haproxy", "keepalived", "audit"]
+      "enum": [
+        "docker", "containerd", "haproxy", "keepalived", "audit",
+        "conntrack", "iptables", "openssl", "curl", "unzip", "semanage", "kmod"
+      ]
     }
   }
 }

--- a/kubemarine/resources/schemas/migrate_cri.json
+++ b/kubemarine/resources/schemas/migrate_cri.json
@@ -27,7 +27,7 @@
           "description": "Specify associations for containerd",
           "properties": {
             "containerd": {
-              "$ref": "definitions/services/packages/associations.json#/definitions/PackageAssociations"
+              "$ref": "definitions/services/packages/associations.json#/definitions/ServicePackageAssociations"
             }
           },
           "additionalProperties": false

--- a/kubemarine/resources/schemas/upgrade.json
+++ b/kubemarine/resources/schemas/upgrade.json
@@ -50,10 +50,11 @@
           "associations": {
             "type": "object",
             "description": "Configure associations of package objects to be used during upgrade",
-            "allOf": [{"$ref": "definitions/services/packages/associations.json#/definitions/Associations"}],
-            "propertyNames": {
-              "$ref": "definitions/services/packages/associations.json#/definitions/AssociationsNames"
-            }
+            "properties": {
+              "docker": {"$ref": "definitions/services/packages/associations.json#/definitions/ServicePackageAssociations"},
+              "containerd": {"$ref": "definitions/services/packages/associations.json#/definitions/ServicePackageAssociations"}
+            },
+            "additionalProperties": false
           }
         },
         "propertyNames": {

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -155,7 +155,7 @@ def get_system_packages_for_upgrade(cluster):
 
 
 def get_system_packages(cluster):
-    return ["haproxy", "keepalived", cluster.inventory['services']['cri']['containerRuntime']]
+    return [cluster.inventory['services']['cri']['containerRuntime']]
 
 
 def fetch_os_versions(cluster: KubernetesCluster):

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -201,12 +201,13 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
         extension = destination.split('.')[-1]
         if extension == 'zip':
             cluster.log.verbose('Unzip will be used for unpacking')
+            # TODO re-installation waits forever
             remote_commands += ' && sudo unzip %s -d %s' % (destination, config['unpack'])
         else:
             cluster.log.verbose('Tar will be used for unpacking')
             remote_commands += ' && sudo tar -zxf %s -C %s' % (destination, config['unpack'])
 
-        # TODO zip does not work!
+        # TODO acсess rights do not work for zip
         remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chmod %s %s/FILE' \
                            % (destination, config['mode'], config['unpack'])
         remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chown %s %s/FILE' \

--- a/kubemarine/yum.py
+++ b/kubemarine/yum.py
@@ -56,10 +56,7 @@ def clean(group, mode="all", **kwargs):
     return group.sudo("yum clean %s" % mode, **kwargs)
 
 
-def install(group, include=None, exclude=None, **kwargs):
-    if include is None:
-        raise Exception('You must specify included packages to install')
-
+def get_install_cmd(include: str or list, exclude=None) -> str:
     if isinstance(include, list):
         include = ' '.join(include)
     command = 'yum install -y %s' % include
@@ -71,9 +68,17 @@ def install(group, include=None, exclude=None, **kwargs):
     command += f"; rpm -q {include}; if [ $? != 0 ]; then echo \"Failed to check version for some packages. " \
                f"Make sure packages are not already installed with higher versions. " \
                f"Also, make sure user-defined packages have rpm-compatible names. \"; exit 1; fi "
-    install_result = group.sudo(command, **kwargs)
 
-    return install_result
+    return command
+
+
+def install(group, include=None, exclude=None, **kwargs):
+    if include is None:
+        raise Exception('You must specify included packages to install')
+
+    command = get_install_cmd(include, exclude)
+
+    return group.sudo(command, **kwargs)
 
 
 def remove(group, include=None, exclude=None, **kwargs):

--- a/test/unit/test_audit.py
+++ b/test/unit/test_audit.py
@@ -136,7 +136,7 @@ class NodeGroupResultsTest(unittest.TestCase):
         expected_results = demo.create_nodegroup_result(cluster.nodes['master'], stdout='restarted', code=0)
         cluster.fake_shell.add(expected_results, 'sudo', ['service %s restart' % package_name])
 
-        actual_results = audit.apply_audit_rules(cluster.nodes['master'], now=True)
+        actual_results = audit.apply_audit_rules(cluster.nodes['master'])
 
         self.assertEqual(expected_results, actual_results,
                          msg='Configuration task did not did not finished with restart result')

--- a/test/unit/test_haproxy.py
+++ b/test/unit/test_haproxy.py
@@ -148,7 +148,7 @@ def get_result_str(results):
     for conn, result in results.items():
         if output != "":
             output += "\n"
-        output += "\t%s (%s): code=%i" % (conn, 0, result.exited)
+        output += "\t%s (%s): code=%i" % (conn.host, 0, result.exited)
         if result.stdout:
             output += "\n\t\tSTDOUT: %s" % result.stdout.replace("\n", "\n\t\t        ")
         if result.stderr:

--- a/test/unit/test_haproxy.py
+++ b/test/unit/test_haproxy.py
@@ -16,7 +16,7 @@
 
 import unittest
 
-from kubemarine import haproxy
+from kubemarine import haproxy, yum
 from kubemarine import demo
 
 
@@ -107,11 +107,7 @@ class TestHaproxyInstallation(unittest.TestCase):
         cluster.fake_shell.add(missing_package_result, 'sudo', missing_package_command)
 
         # simulate package installation
-        installation_command = ['yum install -y %s; rpm -q %s; if [ $? != 0 ]; then echo '
-                                '\"Failed to check version for some packages. '
-                                'Make sure packages are not already installed with higher versions. '
-                                'Also, make sure user-defined packages have rpm-compatible names. \"; exit 1; fi '
-                                % (package_associations['package_name'], package_associations['package_name'])]
+        installation_command = [yum.get_install_cmd(package_associations['package_name'])]
         expected_results = demo.create_nodegroup_result(cluster.nodes['balancer'], code=0,
                                                         stdout='Successfully installed haproxy')
         cluster.fake_shell.add(expected_results, 'sudo', installation_command)

--- a/test/unit/test_install.py
+++ b/test/unit/test_install.py
@@ -1,0 +1,90 @@
+import unittest
+
+from kubemarine import demo, packages
+from kubemarine.core import static
+from kubemarine.procedures import install
+
+
+class ManageMandatoryPackages(unittest.TestCase):
+    def setUp(self) -> None:
+        self.inventory = demo.generate_inventory(**demo.FULLHA_KEEPALIVED)
+        self.context = demo.create_silent_context()
+        self.context['nodes'] = demo.generate_nodes_context(self.inventory, os_name='ubuntu', os_version='20.04')
+        self.mandatory_pkgs_setup = {}
+        for package in static.DEFAULTS["services"]["packages"]['mandatory'].keys():
+            self.mandatory_pkgs_setup[package] = []
+        for node in self.inventory['nodes']:
+            host = node['address']
+            for pkg in ('conntrack', 'iptables'):
+                if 'master' in node['roles'] or 'worker' in node['roles']:
+                    self.mandatory_pkgs_setup[pkg].append(host)
+            for pkg in ('openssl', 'curl', 'kmod'):
+                self.mandatory_pkgs_setup[pkg].append(host)
+
+    def _new_cluster(self):
+        cluster = demo.new_cluster(self.inventory, context=self.context)
+        for node in cluster.nodes['all'].get_ordered_members_list():
+            installation_command = self._get_install_cmd(cluster, node.get_host())
+            results = demo.create_hosts_result([node.get_host()], stdout=f'Successfully installed')
+            cluster.fake_shell.add(results, 'sudo', installation_command)
+
+        return cluster
+
+    def _get_install_cmd(self, cluster: demo.FakeKubernetesCluster, host: str):
+        os_family = cluster.get_os_family()
+        package_names = []
+        for pkg, hosts in self.mandatory_pkgs_setup.items():
+            if host in hosts:
+                package_names.append(
+                    cluster.inventory['services']['packages']['associations'][os_family][pkg]['package_name'])
+
+        return [packages.get_package_manager(cluster.nodes['all']).get_install_cmd(package_names)]
+
+    def _assert_installed(self, cluster: demo.FakeKubernetesCluster):
+        for node in cluster.nodes['all'].get_ordered_members_list():
+            installation_command = self._get_install_cmd(cluster, node.get_host())
+            history = cluster.fake_shell.history_find(node.get_host(), 'sudo', installation_command)
+            self.assertTrue(len(history) == 1 and history[0]["used_times"] == 1,
+                            "Installation command should be called once")
+
+    def test_default_install_debian(self):
+        cluster = self._new_cluster()
+        install.system_prepare_package_manager_manage_packages(cluster)
+        self._assert_installed(cluster)
+
+    def test_default_install_rhel(self):
+        self.context['nodes'] = demo.generate_nodes_context(self.inventory)
+        for node in self.inventory['nodes']:
+            self.mandatory_pkgs_setup.setdefault('semanage', []).append(node['address'])
+        cluster = self._new_cluster()
+        install.system_prepare_package_manager_manage_packages(cluster)
+        self._assert_installed(cluster)
+
+    def test_skip_not_managed(self):
+        del self.mandatory_pkgs_setup['conntrack']
+        del self.mandatory_pkgs_setup['openssl']
+        mandatory_section = self.inventory.setdefault('services', {}).setdefault('packages', {}).setdefault('mandatory', {})
+        mandatory_section['conntrack'] = False
+        mandatory_section['openssl'] = False
+        cluster = self._new_cluster()
+        install.system_prepare_package_manager_manage_packages(cluster)
+        self._assert_installed(cluster)
+
+    def test_install_unzip(self):
+        thirdparties = self.inventory.setdefault('services', {}).setdefault('thirdparties', {})
+        nodes = ['balancer-1', 'master-2']
+        thirdparties['target.zip'] = {
+            "source": "source.zip",
+            "unpack": "target/dir",
+            "nodes": nodes
+        }
+        for node in self.inventory['nodes']:
+            if node['name'] in nodes:
+                self.mandatory_pkgs_setup.setdefault('unzip', []).append(node['address'])
+        cluster = self._new_cluster()
+        install.system_prepare_package_manager_manage_packages(cluster)
+        self._assert_installed(cluster)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_install.py
+++ b/test/unit/test_install.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 from kubemarine import demo, packages

--- a/test/unit/test_keepalived.py
+++ b/test/unit/test_keepalived.py
@@ -16,7 +16,7 @@
 
 import unittest
 
-from kubemarine import demo, keepalived
+from kubemarine import demo, keepalived, yum
 
 
 class TestKeepalivedDefaultsEnrichment(unittest.TestCase):
@@ -183,11 +183,7 @@ class TestKeepalivedInstallation(unittest.TestCase):
         cluster.fake_shell.add(missing_package_result, 'sudo', missing_package_command)
 
         # simulate package installation
-        installation_command = ['yum install -y %s; rpm -q %s; if [ $? != 0 ]; then echo '
-                                '\"Failed to check version for some packages. '
-                                'Make sure packages are not already installed with higher versions. '
-                                'Also, make sure user-defined packages have rpm-compatible names. \"; exit 1; fi '
-                                % (package_associations['package_name'], package_associations['package_name'])]
+        installation_command = [yum.get_install_cmd(package_associations['package_name'])]
         expected_results = demo.create_nodegroup_result(cluster.nodes['keepalived'], code=0,
                                                         stdout='Successfully installed keepalived')
         cluster.fake_shell.add(expected_results, 'sudo', installation_command)


### PR DESCRIPTION
### Description
* KubeMarine and Kubernetes require the list of mandatory thirdparty packages, but they are not installed by default.

### Solution
* All mandatory packages are now installed by default.
    * Audit is now installed on any OS, and not only on Debian nodes.
    * Added `iptables` to the list of mandatory packages.
    * `semanage` is installed only on RHEL nodes.
    * `unzip` is installed only if it is required by `services.thirdparties`.
    * `conntrack`, `iptables` are installed only on control-plane, worker nodes.
    * The remained `openssl`, `curl`, and `kmod` packages are installed on all nodes.
* Mandatory packages are managed the same as other system packages (docker, haproxy, etc.) and installed during `prepare.package_manager.manage_packages` task.
* Added `services.packages.mandatory` section that allows to turn mandatory packages off.
* Added `mandatory_packages_off` patch of existing inventories to turn automatic managing of mandatory packages off for backward compatibility.
* Fixed JSON schema for `upgrade` procedure. Now it allows packages associations only for `docker` and `containerd` because there is no process to upgrade other system packages. It now also prohibits `package_manager` section.
* Fixed package detection process to take only relevant nodes into account (for example, control-plane nodes are not checked when detecting of haproxy).
* Default packages associations are partially moved to `globals.yaml` for deduplication.
* `check_iaas` checks that mandatory packages are available.
* Added tasks to `check_paas` to check that audit and mandatory packages have equal versions on the relevant nodes.

### How to apply
Run `migrate_kubemarine --force-apply mandatory_packages_off`

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Empty `services.packages.install` section.

Steps:

1. Run `install`.

Results:

| Before | After |
| ------ | ------ |
| Installation fails with lack of packages | Installation succeeds with possible warnings in `deploy.kubernetes.init` task. |

**TestCase 2**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Turn off some mandatory packages in `services.packages.mandatory`.

Steps:

1. Run `install`.

Results:

| Before | After |
| ------ | ------ |
| Not applicable | All except the explicitly turned off mandatory packages are installed. Installation might fail if the omitted package is not installed but required for correct KubeMarine/Kubernetes work. |

**TestCase 3**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Any

Steps:

1. Run `kubemarine_migrate --force-apply mandatory_packages_off`.

Results:

| Before | After |
| ------ | ------ |
| Not applicable | Inventory is patched and all mandatory packages are turned off |

**TestCase 4**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Any

Steps:

1. Run any procedure.

Results:

| Before | After |
| ------ | ------ |
| Not applicable | Mandatory package versions are detected and cached in `cluster_finalized.yaml`. |

**TestCase 5**

Test Configuration:

- Hardware: Any
- OS: Any
- Inventory: Any

Steps:

1. Run `check_iaas`, `check_paas`.

Results:

| Before | After |
| ------ | ------ |
| Not applicable | `check_iaas` checks that mandatory packages are available in repositories. `check_paas` checks that mandatory packages and audit have equal versions. |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_executor.py - added tests for minor fixes/improvements of RemoteExecutor.
test_audit.py - added tests for installation on centos.
test_install.py - new tests for mandatory packages installation.
test_packages.py - added tests for improved packages versions detection, including support of mandatory packages.
