### PR TITLE
MANOPD-82393 Summary fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Project-specific excludes
-config
+kubeconfig
 /local_chart_folder
 !examples/*
 /dump

--- a/kubemarine/core/summary.py
+++ b/kubemarine/core/summary.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import enum
 from functools import total_ordering
 from typing import Dict, Callable

--- a/kubemarine/core/summary.py
+++ b/kubemarine/core/summary.py
@@ -8,6 +8,7 @@ from kubemarine.core.cluster import KubernetesCluster
 
 @total_ordering
 class SummaryItem(enum.Enum):
+    KUBECONFIG = (0, "Kubeconfig")
     DASHBOARD_URL = (1, "Dashboard URL")
     CONTROL_PLANES = (2, "Running Control Planes")
     WORKERS = (3, "Running Workers")

--- a/kubemarine/core/summary.py
+++ b/kubemarine/core/summary.py
@@ -1,0 +1,45 @@
+import enum
+from functools import total_ordering
+from typing import Dict, Callable
+
+from kubemarine.core import log
+from kubemarine.core.cluster import KubernetesCluster
+
+
+@total_ordering
+class SummaryItem(enum.Enum):
+    DASHBOARD_URL = (1, "Dashboard URL")
+    CONTROL_PLANES = (2, "Running Control Planes")
+    WORKERS = (3, "Running Workers")
+    ACCOUNT_TOKENS = (4, "Account Tokens File")
+    EXECUTION_TIME = (5, "Elapsed")
+
+    def __init__(self, order, text):
+        self.order = order
+        self.text = text
+
+    def __lt__(self, other):
+        return self.order < other.order
+
+
+def schedule_report(context: dict, property: SummaryItem, value: str):
+    context.setdefault('summary_report', {})[property] = value
+
+
+def schedule_delayed_report(cluster: KubernetesCluster, call: Callable[[KubernetesCluster], None]):
+    cluster.context.setdefault('delayed_summary_report', []).append(call)
+    cluster.schedule_cumulative_point(exec_delayed)
+
+
+def print_summary(context: dict, logger: log.EnhancedLogger):
+    summary_items: Dict[SummaryItem, str] = context.get('summary_report', {})
+    max_length = max(len(si.text) for si in summary_items.keys())
+    logger.info('')
+    for si, value in sorted(summary_items.items()):
+        key = si.text + ': ' + (' ' * (max_length - len(si.text)))
+        logger.info(key + value)
+
+
+def exec_delayed(cluster: KubernetesCluster):
+    for call in cluster.context.get('delayed_summary_report', []):
+        call(cluster)

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import enum
 import io
 import json
 import os
@@ -19,16 +18,14 @@ import shutil
 import sys
 import time
 import tarfile
-from functools import total_ordering
 
-from typing import Union, Dict
+from typing import Union
 
 import yaml
 from copy import deepcopy
 from datetime import datetime
 from collections import OrderedDict
 
-from kubemarine.core import log
 from kubemarine.core.executor import RemoteExecutor
 from kubemarine.core.errors import pretty_print_error
 
@@ -429,32 +426,3 @@ class ClusterStorage:
             group.put(get_dump_filepath(self.cluster.context, "dump_log_cluster.tar.gz"),
                       "/tmp/dump_log_cluster.tar.gz", sudo=True)
             group.sudo(f'tar -C / -xzvf /tmp/dump_log_cluster.tar.gz')
-
-
-@total_ordering
-class SummaryItem(enum.Enum):
-    DASHBOARD_URL = (1, "Dashboard URL")
-    CONTROL_PLANES = (2, "Running Control Planes")
-    WORKERS = (3, "Running Workers")
-    ACCOUNT_TOKENS = (4, "Account Tokens File")
-    EXECUTION_TIME = (5, "Elapsed")
-
-    def __init__(self, order, text):
-        self.order = order
-        self.text = text
-
-    def __lt__(self, other):
-        return self.order < other.order
-
-
-def schedule_summary_report(context: dict, property: SummaryItem, value: str):
-    context.setdefault('summary_report', {})[property] = value
-
-
-def print_summary(context: dict, logger: log.EnhancedLogger):
-    summary_items: Dict[SummaryItem, str] = context.get('summary_report', {})
-    max_length = max(len(si.text) for si in summary_items.keys())
-    logger.info('')
-    for si, value in sorted(summary_items.items()):
-        key = si.text + ': ' + (' ' * (max_length - len(si.text)))
-        logger.info(key + value)

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -17,7 +17,7 @@ import os
 
 import yaml
 
-from kubemarine.core import utils
+from kubemarine.core import utils, summary
 from kubemarine.core.cluster import KubernetesCluster
 
 
@@ -122,4 +122,4 @@ def install(cluster: KubernetesCluster):
         tokenfile.write(yaml.dump(tokens, default_flow_style=False))
         cluster.log.debug('Tokens saved to %s' % token_filename)
 
-    utils.schedule_summary_report(cluster.context, utils.SummaryItem.ACCOUNT_TOKENS, token_filename)
+    summary.schedule_report(cluster.context, summary.SummaryItem.ACCOUNT_TOKENS, token_filename)

--- a/kubemarine/plugins/kubernetes_dashboard.py
+++ b/kubemarine/plugins/kubernetes_dashboard.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kubemarine.core import utils
+from kubemarine.core import summary
 from kubemarine.core.cluster import KubernetesCluster
 
 
@@ -20,4 +20,4 @@ def schedule_summary_report(cluster: KubernetesCluster):
     plugin_item = cluster.inventory['plugins']['kubernetes-dashboard']
     hostname = plugin_item['hostname']
     # Currently we declare that Dashboard UI is available only via HTTPS
-    utils.schedule_summary_report(cluster.context, utils.SummaryItem.DASHBOARD_URL, f'https://{hostname}')
+    summary.schedule_report(cluster.context, summary.SummaryItem.DASHBOARD_URL, f'https://{hostname}')

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -27,7 +27,7 @@ from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.errors import KME
 from kubemarine import system, sysctl, haproxy, keepalived, kubernetes, plugins, \
     kubernetes_accounts, selinux, thirdparties, admission, audit, coredns, cri, packages, apparmor
-from kubemarine.core import flow, utils
+from kubemarine.core import flow, utils, summary
 from kubemarine.core.executor import RemoteExecutor
 from kubemarine.core.group import NodeGroup
 from kubemarine.core.resources import DynamicResources
@@ -616,8 +616,10 @@ cumulative_points = {
     ],
     system.verify_system: [
         "prepare.system.sysctl"
+    ],
+    summary.exec_delayed: [
+        flow.END_OF_TASKS
     ]
-
 }
 
 

--- a/kubemarine/procedures/remove_node.py
+++ b/kubemarine/procedures/remove_node.py
@@ -17,7 +17,7 @@
 from collections import OrderedDict
 
 from kubemarine import kubernetes, haproxy, keepalived, coredns
-from kubemarine.core import flow
+from kubemarine.core import flow, summary
 from kubemarine.core.action import Action
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.group import NodeGroup
@@ -144,12 +144,19 @@ tasks = OrderedDict({
 })
 
 
+cumulative_points = {
+    summary.exec_delayed: [
+        flow.END_OF_TASKS
+    ]
+}
+
+
 class RemoveNodeAction(Action):
     def __init__(self):
         super().__init__('remove node', recreate_inventory=True)
 
     def run(self, res: DynamicResources):
-        flow.run_tasks(res, tasks)
+        flow.run_tasks(res, tasks, cumulative_points=cumulative_points)
         res.make_final_inventory()
 
 

--- a/test/unit/test_kubernetes.py
+++ b/test/unit/test_kubernetes.py
@@ -16,7 +16,7 @@ import unittest
 from textwrap import dedent
 
 from kubemarine import demo, kubernetes
-from kubemarine.core import utils
+from kubemarine.core import summary
 
 
 class TestInventoryValidation(unittest.TestCase):
@@ -34,6 +34,8 @@ class TestInventoryValidation(unittest.TestCase):
                 conditions:
                 - status: "False"
                   type: Ready
+                - status: "True"
+                  type: NetworkUnavailable
             - metadata:
                 labels:
                   node-role.kubernetes.io/control-plane: ""
@@ -43,6 +45,8 @@ class TestInventoryValidation(unittest.TestCase):
                 conditions:
                 - status: "True"
                   type: Ready
+                - status: "False"
+                  type: NetworkUnavailable
             - metadata:
                 labels:
                   node-role.kubernetes.io/worker: worker
@@ -51,16 +55,18 @@ class TestInventoryValidation(unittest.TestCase):
                 conditions:
                 - status: "True"
                   type: Ready
+                - status: "True"
+                  type: NetworkUnavailable
             """.rstrip()
         )
         get_nodes = demo.create_nodegroup_result(cluster.nodes['control-plane'], stdout=stdout)
         cluster.fake_shell.add(get_nodes, 'sudo', [kubernetes.get_nodes_description_cmd()])
-        kubernetes.schedule_running_nodes_report(cluster)
+        kubernetes.exec_running_nodes_report(cluster)
         summary_report = cluster.context.get('summary_report')
         self.assertEquals(
             {
-                utils.SummaryItem.CONTROL_PLANES: "1/2",
-                utils.SummaryItem.WORKERS: "2/3",
+                summary.SummaryItem.CONTROL_PLANES: "1/2",
+                summary.SummaryItem.WORKERS: "1/3",
             },
             summary_report
         )


### PR DESCRIPTION
### Description
1. Need to fetch kubeconfig and print path to it in the installation summary.
1. Sometimes KubeMarine prints that 0 of N nodes are running after the installation.

### Solution
1. Added fetching of the kubeconfig (/etc/kubernetes/admin.conf) during init of the first control-plane in `deploy.kubernetes.init` task.
1. Previously number of running control-planes / workers was fetched during `deploy.kubernetes.init` task in which the nodes are not yet ready. Implemented delayed collecting of summary information using improved cumulative points flow.

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: Ubuntu 20.04
- Inventory: FullHA

Steps:

1. Run `install`.

Results:

| Before | After |
| ------ | ------ |
| Summary contains `Running Control Planes: 0/N` and no `Kubeconfig` | Summary contains `Running Control Planes: N/N` and  `Kubeconfig` path  |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_flow.py - added tests for improved cumulative points flow.
