### PR TITLE
Kubemarine: procedure for removing default taint on nodes having the roles of master and worker

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -1014,7 +1014,7 @@ By default, the installer uses the following parameters:
 
 |Parameter|Default Value|
 |---|---|
-|kubernetesVersion|`v1.24.0`|
+|kubernetesVersion|`v1.24.2`|
 |controlPlaneEndpoint|`{{ cluster_name }}:6443`|
 |networking.podSubnet|`10.128.0.0/14` for IPv4 or `fd02::/48` for IPv6|
 |networking.serviceSubnet|`172.30.0.0/16` for IPv4 or `fd03::/112` for IPv6|
@@ -1091,12 +1091,12 @@ services:
 
 #### Kubernetes version
 
-By default, the `1.24.0` version of the Kubernetes is installed. See the table of supported versions for details in [Supported versions section](#supported-versions). However, we recommend that you explicitly specify the version you are about to install. This version applies into all the dependent parameters - images, binaries, rpms, configurations: all these are downloaded and used according to your choice. To specify the version, use the following parameter as in example:
+By default, the `1.24.2` version of the Kubernetes is installed. See the table of supported versions for details in [Supported versions section](#supported-versions). However, we recommend that you explicitly specify the version you are about to install. This version applies into all the dependent parameters - images, binaries, rpms, configurations: all these are downloaded and used according to your choice. To specify the version, use the following parameter as in example:
 
 ```yaml
 services:
   kubeadm:
-    kubernetesVersion: v1.22.2
+    kubernetesVersion: v1.24.2
 ```
 
 #### Cloud Provider Plugin

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -187,14 +187,14 @@ etcd:
 If the cluster is located in an isolated environment, it is possible to specify the custom paths to new thirdparties with the same syntax as in the `cluster.yaml` as shown in the following script:
 
 ```yaml
-v1.24.0:
+v1.24.2:
   thirdparties:
       /usr/bin/kubeadm:
-        source: https://example.com/thirdparty.files/kubernetes/kubeadm/v1.24.0/bin/linux/amd64/kubeadm
+        source: https://example.com/thirdparty.files/kubernetes/kubeadm/v1.24.2/bin/linux/amd64/kubeadm
       /usr/bin/kubelet:
-        source: https://example.com/thirdparty.files/kubernetes/kubelet/v1.24.0/bin/linux/amd64/kubelet
+        source: https://example.com/thirdparty.files/kubernetes/kubelet/v1.24.2/bin/linux/amd64/kubelet
       /usr/bin/kubectl:
-        source: https://example.com/thirdparty.files/kubernetes/kubectl/v1.24.0/bin/linux/amd64/kubectl
+        source: https://example.com/thirdparty.files/kubernetes/kubectl/v1.24.2/bin/linux/amd64/kubectl
       /usr/bin/calicoctl:
         source: https://example.com/thirdparty.files/projectcalico/calico/v3.22.2/calicoctl-linux-amd64
 ```

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -370,7 +370,14 @@ def join_control_plane(group, node, join_dict):
             },
             'taints': []
         }
-    else:
+    elif group.cluster.inventory['services']['kubeadm']['controllerManager']['extraArgs'].get(
+            'external-cloud-volume-plugin'):
+        join_config['nodeRegistration'] = {
+            'kubeletExtraArgs': {
+                'cloud-provider': 'external'
+            }
+        }
+    elif 'worker' in node['roles']:
         join_config['nodeRegistration'] = {
             'taints': []
         }
@@ -453,7 +460,14 @@ def init_first_control_plane(group):
             },
             'taints': []
         }
-    else:
+    elif group.cluster.inventory['services']['kubeadm']['controllerManager']['extraArgs'].get(
+            'external-cloud-volume-plugin'):
+        init_config['nodeRegistration'] = {
+            'kubeletExtraArgs': {
+                'cloud-provider': 'external'
+            }
+        }
+    elif 'worker' in first_control_plane['roles']:
         init_config['nodeRegistration'] = {
             'taints': []
         }

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -363,14 +363,14 @@ def join_control_plane(group, node, join_dict):
     }
 
     if group.cluster.inventory['services']['kubeadm']['controllerManager']['extraArgs'].get(
-            'external-cloud-volume-plugin'):
+            'external-cloud-volume-plugin') and 'worker' in node['roles']:
         join_config['nodeRegistration'] = {
             'kubeletExtraArgs': {
                 'cloud-provider': 'external'
-            }
+            },
+            'taints': []
         }
-
-    if 'worker' in node['roles']:
+    else:
         join_config['nodeRegistration'] = {
             'taints': []
         }
@@ -446,14 +446,14 @@ def init_first_control_plane(group):
     }
 
     if group.cluster.inventory['services']['kubeadm']['controllerManager']['extraArgs'].get(
-            'external-cloud-volume-plugin'):
+            'external-cloud-volume-plugin') and 'worker' in first_control_plane['roles']:
         init_config['nodeRegistration'] = {
             'kubeletExtraArgs': {
                 'cloud-provider': 'external'
-            }
+            },
+            'taints': []
         }
-
-    if 'worker' in first_control_plane['roles']:
+    else:
         init_config['nodeRegistration'] = {
             'taints': []
         }

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -342,7 +342,7 @@ def join_new_control_plane(group):
 def join_control_plane(group, node, join_dict):
     log = group.cluster.log
 
-    join_config = {
+    join_config: dict = {
         'apiVersion': group.cluster.inventory["services"]["kubeadm"]['apiVersion'],
         'kind': 'JoinConfiguration',
         'discovery': {
@@ -363,24 +363,15 @@ def join_control_plane(group, node, join_dict):
     }
 
     if group.cluster.inventory['services']['kubeadm']['controllerManager']['extraArgs'].get(
-            'external-cloud-volume-plugin') and 'worker' in node['roles']:
-        join_config['nodeRegistration'] = {
-            'kubeletExtraArgs': {
-                'cloud-provider': 'external'
-            },
-            'taints': []
-        }
-    elif group.cluster.inventory['services']['kubeadm']['controllerManager']['extraArgs'].get(
             'external-cloud-volume-plugin'):
         join_config['nodeRegistration'] = {
             'kubeletExtraArgs': {
                 'cloud-provider': 'external'
             }
         }
-    elif 'worker' in node['roles']:
-        join_config['nodeRegistration'] = {
-            'taints': []
-        }
+
+    if 'worker' in node['roles']:
+        join_config.setdefault('nodeRegistration', {})['taints'] = []
 
     configure_container_runtime(group.cluster, join_config)
 
@@ -444,7 +435,7 @@ def init_first_control_plane(group):
     first_control_plane = group.get_first_member(provide_node_configs=True)
     first_control_plane_group = first_control_plane["connection"]
 
-    init_config = {
+    init_config: dict = {
         'apiVersion': group.cluster.inventory["services"]["kubeadm"]['apiVersion'],
         'kind': 'InitConfiguration',
         'localAPIEndpoint': {
@@ -453,24 +444,15 @@ def init_first_control_plane(group):
     }
 
     if group.cluster.inventory['services']['kubeadm']['controllerManager']['extraArgs'].get(
-            'external-cloud-volume-plugin') and 'worker' in first_control_plane['roles']:
-        init_config['nodeRegistration'] = {
-            'kubeletExtraArgs': {
-                'cloud-provider': 'external'
-            },
-            'taints': []
-        }
-    elif group.cluster.inventory['services']['kubeadm']['controllerManager']['extraArgs'].get(
             'external-cloud-volume-plugin'):
         init_config['nodeRegistration'] = {
             'kubeletExtraArgs': {
                 'cloud-provider': 'external'
             }
         }
-    elif 'worker' in first_control_plane['roles']:
-        init_config['nodeRegistration'] = {
-            'taints': []
-        }
+
+    if 'worker' in first_control_plane['roles']:
+        init_config.setdefault('nodeRegistration', {})['taints'] = []
 
     configure_container_runtime(group.cluster, init_config)
 

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -261,6 +261,8 @@ def verify_upgrade_plan(upgrade_plan):
     previous_version = None
     for i in range(0, len(upgrade_plan)):
         version = upgrade_plan[i]
+        if version == 'v1.24.0':
+            raise Exception('Attempt to upgrade to an unstable version of kubernetes')
         if previous_version is not None:
             kubernetes.test_version_upgrade_possible(previous_version, version)
         previous_version = version

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -19,7 +19,7 @@ services:
   kubeadm:
     apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
-    kubernetesVersion: v1.24.0
+    kubernetesVersion: v1.24.2
     controlPlaneEndpoint: '{{ cluster_name }}:6443'
     networking:
       podSubnet: '{% if nodes[0]["internal_address"]|isipv4 %}10.128.0.0/14{% else %}fd02::/48{% endif %}'

--- a/kubemarine/resources/schemas/definitions/services/kubeadm.json
+++ b/kubemarine/resources/schemas/definitions/services/kubeadm.json
@@ -5,7 +5,7 @@
   "properties": {
     "kubernetesVersion": {
       "type":  "string",
-      "default": "v1.24.0",
+      "default": "v1.24.2",
       "description": "Specify the version to install and maintain. This version applies into all the dependent parameters - images, binaries, rpms, configurations."
     },
     "imageRepository": {

--- a/test/unit/test_thirdparties.py
+++ b/test/unit/test_thirdparties.py
@@ -82,7 +82,7 @@ class SHACalculationTest(unittest.TestCase):
         cluster = demo.new_cluster(inventory, fake=False)
 
         self.assertNotIn('sha1', cluster.inventory['services']['thirdparties']["/usr/bin/etcdctl"])
-        self.assertEqual(cluster.globals['compatibility_map']['software']['kubeadm']['v1.24.0']['sha1'],
+        self.assertEqual(cluster.globals['compatibility_map']['software']['kubeadm']['v1.24.2']['sha1'],
                          cluster.inventory['services']['thirdparties']["/usr/bin/kubeadm"]['sha1'])
         self.assertNotIn('sha1', cluster.inventory['services']['thirdparties']["/usr/bin/kubelet"])
         self.assertEqual(self.customized_services['thirdparties']['/usr/bin/kubectl']['sha1'],

--- a/test/unit/test_thirdparties.py
+++ b/test/unit/test_thirdparties.py
@@ -33,7 +33,7 @@ class SHACalculationTest(unittest.TestCase):
 
     customized_services = {
         'kubeadm': {
-            'kubernetesVersion': "v1.24.0"
+            'kubernetesVersion': "v1.24.2"
         },
         'thirdparties': {
             '/usr/bin/kubelet': {
@@ -62,11 +62,11 @@ class SHACalculationTest(unittest.TestCase):
         cluster = demo.new_cluster(inventory, fake=False)
 
         self.assertIsNone(thirdparties.get_thirdparty_recommended_sha("/usr/bin/etcdctl", cluster))
-        self.assertEqual(cluster.globals['compatibility_map']['software']['kubeadm']['v1.24.0']['sha1'],
+        self.assertEqual(cluster.globals['compatibility_map']['software']['kubeadm']['v1.24.2']['sha1'],
                          thirdparties.get_thirdparty_recommended_sha("/usr/bin/kubeadm", cluster))
-        self.assertEqual(cluster.globals['compatibility_map']['software']['kubelet']['v1.24.0']['sha1'],
+        self.assertEqual(cluster.globals['compatibility_map']['software']['kubelet']['v1.24.2']['sha1'],
                          thirdparties.get_thirdparty_recommended_sha("/usr/bin/kubelet", cluster))
-        self.assertEqual(cluster.globals['compatibility_map']['software']['kubectl']['v1.24.0']['sha1'],
+        self.assertEqual(cluster.globals['compatibility_map']['software']['kubectl']['v1.24.2']['sha1'],
                          thirdparties.get_thirdparty_recommended_sha("/usr/bin/kubectl", cluster))
         self.assertEqual(cluster.globals['compatibility_map']['software']['calico']['v1.24']['sha1'],
                          thirdparties.get_thirdparty_recommended_sha("/usr/bin/calicoctl", cluster))


### PR DESCRIPTION
### Description

* It is necessary to remove the default taint on nodes that have the roles of master and worker at the same time. Instead of the old procedure that removed these taints in the `apply_taints` procedure

### Solution
* The procedure of deleting default taints on nodes having roles  of master and worker has been redesigned and transferred to another place (the moment of kubeadm init and join).
* Remove from `enrich_inventory` the procedure for adding standard taints for deletion in the `apply_taints` procedure.
* Update default.yaml
* Update documents
* Update Json schema
* Update unit test

### Note
* The possibility of updating to version 1.24.0 has been removed 
* When trying to upgrade to this version, an exception will be output

### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

TestCase 1

Test Configuration:

Hardware: Any
OS: Ubuntu 20.04
Inventory: MiniHA

Steps:

1. Run `install`.

Results:

| Before | After |
| ------ | ------ |
| Procedure of deleting taints in apply_taints  | Procedure of deleting taints in deploy_kubernetes_init  |

2. Run `upgrade`.

| Before | After |
| ------ | ------ |
| Procedure of deleting taints in apply_taints  | Procedure of deleting taints in deploy_kubernetes_init  |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts
