### PR TITLE
MANOPD-84031 Input files encoding rework and non-ASCII upload

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -159,6 +159,7 @@ System clock should be synchronized the same way as for Cluster nodes system clo
 
 There are the following restrictions when deploying from Windows:
 * [ansible](#ansible) plugin procedures are not supported.
+* All KubeMarine input text files must be in utf-8 encoding.
 
 ## Prerequisites for Cluster Nodes
 
@@ -2168,7 +2169,6 @@ This is configured in the `services.thirdparties` section. The contents of this 
 |**groups**|no|`None`|The list of group names to whose hosts the file should be uploaded.|
 |**node**|no|`None`|The name of node where the file should be uploaded.|
 |**nodes**|no|`None`|The list of node names where the file should be uploaded.|
-|**binary**|no|`true`|Specifies whether to treat the file as a binary or as a text. This is applicable, for example, for bash scripts. It is required to specify the property carefully in case of deploying from Windows deployer.|
 
 **Warning**: verify that you specified the path to the correct version of the thirdparty.
 
@@ -4318,6 +4318,11 @@ All the parameters match with [template](#template).
 |---|---|---|---|
 |**do_render**|**no**|**True**| Allows you not to render the contents of the file.|
 
+**Note**: If `do_render: false` is specified, KubeMarine uploads the file without any transformation.
+It is desirable for such files to have LF line endings.
+This is especially relevant for Windows deployers
+and important if the files are aimed for services that are sensitive to line endings.
+
 ##### expect pods
 
 This procedure allows you to wait until the necessary pods are ready. You have to declare a procedure section and specify the list of the pod names that should be expected.
@@ -4482,16 +4487,19 @@ plugins:
   calico:
     installation:
       procedures:
-        - template:
+        - config:
             source: /var/data/plugins/script.sh
             destination: /etc/calico/script.sh
             destination_nodes: ['control-plane-1']
             apply_required: false
+            do_render: false
         - shell:
             command: bash -x /etc/calico/script.sh
             nodes: ['control-plane-1']
             sudo: true
 ```
+
+For more information, see [config](#config) procedure type.
 
 Example of runtime variables usage in shell procedure:
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -4321,7 +4321,7 @@ All the parameters match with [template](#template).
 **Note**: If `do_render: false` is specified, KubeMarine uploads the file without any transformation.
 It is desirable for such files to have LF line endings.
 This is especially relevant for Windows deployers
-and important if the files are aimed for services that are sensitive to line endings.
+and is important if the files are aimed for services that are sensitive to line endings.
 
 ##### expect pods
 
@@ -4499,7 +4499,7 @@ plugins:
             sudo: true
 ```
 
-For more information, see [config](#config) procedure type.
+For more information, see the [config](#config) procedure type.
 
 Example of runtime variables usage in shell procedure:
 

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -16,6 +16,7 @@ import io
 
 import fabric
 
+from kubemarine.core import utils
 from kubemarine.core.group import NodeGroupResult, NodeGroup
 
 DEBIAN_HEADERS = 'DEBIAN_FRONTEND=noninteractive '
@@ -49,7 +50,7 @@ def create_repo_file(group, repo_data, repo_file):
     if isinstance(repo_data, list):
         repo_data_str = "\n".join(repo_data) + "\n"
     else:
-        repo_data_str = str(repo_data)
+        repo_data_str = utils.read_external(repo_data)
     group.put(io.StringIO(repo_data_str), repo_file, sudo=True)
 
 

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -341,7 +341,7 @@ class KubernetesCluster(Environment):
         data = yaml.dump(inventory_for_dump)
         finalized_filename = "cluster_finalized.yaml"
         utils.dump_file(self, data, finalized_filename)
-        with open(finalized_filename, 'w') as f:
+        with utils.open_external(finalized_filename, 'w') as f:
             f.write(data)
 
     def preserve_inventory(self):

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -396,9 +396,7 @@ def calculate_nodegroups(inventory, cluster):
 
 
 def merge_defaults(inventory: dict, cluster: KubernetesCluster):
-    with open(utils.get_resource_absolute_path('resources/configurations/defaults.yaml',
-                                               script_relative=True), 'r') as stream:
-        base_inventory = yaml.safe_load(stream)
+    base_inventory = deepcopy(static.DEFAULTS)
 
     inventory = default_merger.merge(base_inventory, inventory)
     # it is necessary to temporary put half-compiled inventory to cluster inventory field

--- a/kubemarine/core/flow.py
+++ b/kubemarine/core/flow.py
@@ -62,11 +62,11 @@ def run_actions(context: Union[dict, res.DynamicResources], actions: List[action
         if not successfully_performed:
             # first action in group
             if resources.inventory_filepath:
-                with open(resources.inventory_filepath, "r") as stream:
+                with utils.open_external(resources.inventory_filepath, "r") as stream:
                     utils.dump_file(context, stream, "cluster_initial.yaml")
 
             if resources.procedure_inventory_filepath:
-                with open(resources.procedure_inventory_filepath, "r") as stream:
+                with utils.open_external(resources.procedure_inventory_filepath, "r") as stream:
                     utils.dump_file(context, stream, "procedure.yaml")
         try:
             log.info(f"Running action '{act.identifier}'")
@@ -86,7 +86,7 @@ def run_actions(context: Union[dict, res.DynamicResources], actions: List[action
 
         if act.recreate_inventory:
             if resources.inventory_filepath:
-                with open(resources.inventory_filepath, "r") as stream:
+                with utils.open_external(resources.inventory_filepath, "r") as stream:
                     # write original file data to backup file with timestamp
                     timestamp = utils.get_current_timestamp_formatted()
                     inventory_file_basename = os.path.basename(resources.inventory_filepath)

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -88,11 +88,10 @@ class DynamicResources:
             else:
                 logger.info(msg)
         try:
-            with open(self.inventory_filepath, 'r') as stream:
-                data = stream.read()
-                self._raw_inventory = yaml.safe_load(data)
-                # load inventory as ruamel.yaml to save original structure
-                self._formatted_inventory = _yaml_structure_preserver().load(data)
+            data = utils.read_external(self.inventory_filepath)
+            self._raw_inventory = yaml.safe_load(data)
+            # load inventory as ruamel.yaml to save original structure
+            self._formatted_inventory = _yaml_structure_preserver().load(data)
         except (yaml.YAMLError, ruamel.yaml.YAMLError) as exc:
             utils.do_fail("Failed to load inventory file", exc, log=logger)
 
@@ -110,7 +109,7 @@ class DynamicResources:
             return
 
         # replace initial inventory file with changed inventory
-        with open(self.inventory_filepath, "w+") as stream:
+        with utils.open_external(self.inventory_filepath, "w+") as stream:
             _yaml_structure_preserver().dump(self.formatted_inventory(), stream)
 
         self._raw_inventory = None

--- a/kubemarine/core/schema.py
+++ b/kubemarine/core/schema.py
@@ -36,14 +36,14 @@ def _verify_inventory_by_schema(cluster: KubernetesCluster, inventory: dict, sch
     for_procedure = "" if schema_name == 'cluster' else f" for procedure '{schema_name}'"
 
     root_schema_resource = f'resources/schemas/{schema_name}.json'
-    root_schema = utils.get_resource_absolute_path(root_schema_resource, script_relative=True)
+    root_schema = utils.get_internal_resource_path(root_schema_resource)
     root_schema = pathlib.Path(root_schema)
     if not root_schema.exists():
         if schema_name == 'cluster' or inventory:
             raise Exception(f"Failed to find schema to validate the inventory file{for_procedure}.")
         return
 
-    with open(root_schema, 'r') as f:
+    with utils.open_internal(root_schema_resource) as f:
         schema = json.load(f)
 
     validator_cls = jsonschema.validators.validator_for(schema)

--- a/kubemarine/core/static.py
+++ b/kubemarine/core/static.py
@@ -15,7 +15,7 @@
 from kubemarine.core import utils
 
 GLOBALS = utils.load_yaml(
-    utils.get_resource_absolute_path('resources/configurations/globals.yaml', script_relative=True))
+    utils.get_internal_resource_path('resources/configurations/globals.yaml'))
 
 DEFAULTS = utils.load_yaml(
-    utils.get_resource_absolute_path('resources/configurations/defaults.yaml', script_relative=True))
+    utils.get_internal_resource_path('resources/configurations/defaults.yaml'))

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -336,7 +336,7 @@ class FakeNodeGroup(group.NodeGroup):
     def __init__(self, connections: Connections, cluster_: FakeKubernetesCluster):
         super().__init__(connections, cluster_)
 
-    def get_local_file_sha1(self, filename, open_mode: str):
+    def get_local_file_sha1(self, filename):
         return '0'
 
     def get_remote_file_sha1(self, filename):

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -136,13 +136,13 @@ class FakeFS:
     # covered by test.test_demo.TestFakeFS.test_write_file_to_cluster
     def write(self, host, filename, data):
         with self._lock:
-            if isinstance(data, io.StringIO):
-                data = data.getvalue()
+            if isinstance(data, io.BytesIO):
+                data = data.getvalue().decode('utf-8')
             elif isinstance(data, str):
                 # this is for self-testing purpose
                 pass
             elif isinstance(data, io.IOBase):
-                data = data.read()
+                data = data.read().decode('utf-8')
             else:
                 raise ValueError("Unsupported data type " + str(type(data)))
             if self.storage.get(host) is None:

--- a/kubemarine/keepalived.py
+++ b/kubemarine/keepalived.py
@@ -174,7 +174,7 @@ def install(group: NodeGroup):
         installation_result = packages.install(group, include=package_associations['package_name'])
 
     service_name = package_associations['service_name']
-    patch_path = utils.get_resource_absolute_path("./resources/drop_ins/keepalived.conf", script_relative=True)
+    patch_path = "./resources/drop_ins/keepalived.conf"
     group.call(system.patch_systemd_service, service_name=service_name, patch_source=patch_path)
     group.call(install_haproxy_check_script)
     enable(group)
@@ -183,8 +183,8 @@ def install(group: NodeGroup):
 
 
 def install_haproxy_check_script(group: NodeGroup):
-    local_path = utils.get_resource_absolute_path("./resources/scripts/check_haproxy.sh", script_relative=True)
-    group.put(local_path, "/usr/local/bin/check_haproxy.sh", sudo=True, binary=False)
+    script = utils.read_internal("./resources/scripts/check_haproxy.sh")
+    group.put(io.StringIO(script), "/usr/local/bin/check_haproxy.sh", sudo=True)
     group.sudo("chmod +x /usr/local/bin/check_haproxy.sh")
 
 
@@ -247,10 +247,10 @@ def generate_config(inventory, node):
                 if i_node['name'] == record['name'] and i_node['internal_address'] != ips['source']:
                     ips['peers'].append(i_node['internal_address'])
 
-        template_location = utils.get_resource_absolute_path('templates/keepalived.conf.j2', script_relative=True)
-        config += Template(open(template_location).read()).render(inventory=inventory, item=item, node=node,
-                                                                  interface=interface,
-                                                                  priority=priority, **ips) + "\n"
+        config_source = utils.read_internal('templates/keepalived.conf.j2')
+        config += Template(config_source).render(inventory=inventory, item=item, node=node,
+                                                 interface=interface,
+                                                 priority=priority, **ips) + "\n"
 
     return config
 

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -181,9 +181,7 @@ def enrich_inventory(inventory, cluster):
         raise KME("KME0004")
 
     # check ignorePreflightErrors value and add mandatory errors from defaults.yaml if they're absent
-    with open(utils.get_resource_absolute_path('resources/configurations/defaults.yaml', script_relative=True), 'r') \
-            as stream:
-        default_preflight_errors = yaml.safe_load(stream)["services"]["kubeadm_flags"]["ignorePreflightErrors"].split(",")
+    default_preflight_errors = static.DEFAULTS["services"]["kubeadm_flags"]["ignorePreflightErrors"].split(",")
     preflight_errors = inventory["services"]["kubeadm_flags"]["ignorePreflightErrors"].split(",")
 
     preflight_errors.extend(default_preflight_errors)
@@ -322,8 +320,7 @@ def install(group):
         for node in group.cluster.inventory["nodes"]:
             # perform only for current group members
             if node["connect_to"] in group.nodes.keys():
-                template = Template(open(utils.get_resource_absolute_path('templates/kubelet.service.j2',
-                                                                          script_relative=True)).read()).render(
+                template = Template(utils.read_internal('templates/kubelet.service.j2')).render(
                     hostname=node["name"])
                 log.debug("Uploading to '%s'..." % node["connect_to"])
                 node["connection"].put(io.StringIO(template + "\n"), '/etc/systemd/system/kubelet.service', sudo=True)
@@ -462,7 +459,7 @@ def fetch_admin_config(cluster: KubernetesCluster) -> str:
         kubeconfig = kubeconfig.replace(cluster_name, public_cluster_ip)
 
     kubeconfig_filename = os.path.abspath("kubeconfig")
-    with open(kubeconfig_filename, 'w') as f:
+    with utils.open_external(kubeconfig_filename, 'w') as f:
         f.write(kubeconfig)
 
     cluster.log.debug(f"Kubeconfig saved to {kubeconfig_filename}")
@@ -829,7 +826,7 @@ def upgrade_other_control_planes(version, upgrade_group, cluster, drain_timeout=
 
 def patch_kubeadm_configmap(first_control_plane, cluster):
     '''
-    Сhecks and patches the Kubeadm configuration for compliance with the current imageRepository, audit log path
+    Checks and patches the Kubeadm configuration for compliance with the current imageRepository, audit log path
     and the corresponding version of the CoreDNS path to the image.
     '''
     # TODO: get rid of this method after k8s 1.21 support stop

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -1319,7 +1319,7 @@ def create_kubeadm_patches_for_node(cluster, node):
             else:
                 template_filename = 'templates/patches/control-plane-pod.json.j2'
 
-            control_plane_patch = Template(open(utils.get_resource_absolute_path(template_filename, script_relative=True)).read()).render(flags=patched_flags)
+            control_plane_patch = Template(utils.read_internal(template_filename)).render(flags=patched_flags)
             node['connection'].put(io.StringIO(control_plane_patch + "\n"), '/etc/kubernetes/patches/' +
                                  control_plane_patch_files[control_plane_item], sudo=True)
             node['connection'].sudo('chmod 644 /etc/kubernetes/patches/' +

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -118,7 +118,7 @@ def install(cluster: KubernetesCluster):
 
     cluster.log.debug('\nSaving tokens...')
     token_filename = os.path.abspath('account-tokens.yaml')
-    with open(token_filename, 'w') as tokenfile:
+    with utils.open_external(token_filename, 'w') as tokenfile:
         tokenfile.write(yaml.dump(tokens, default_flow_style=False))
         cluster.log.debug('Tokens saved to %s' % token_filename)
 

--- a/kubemarine/plugins/calico.py
+++ b/kubemarine/plugins/calico.py
@@ -47,7 +47,7 @@ def enrich_inventory(inventory, cluster):
                 config = {
                     "source": calico_original_yaml
                 }
-                calico_original_yaml_path = plugins.get_source_absolute_pattern(config)
+                calico_original_yaml_path, _ = plugins.get_source_absolute_pattern(config)
                 if not os.path.isfile(calico_original_yaml_path):
                     raise Exception(f"Cannot find original Calico manifest {calico_original_yaml_path}")
 
@@ -73,7 +73,7 @@ def apply_calico_yaml(cluster, calico_original_yaml, calico_yaml):
     }
 
     # get original YAML and parse it into dict of objects
-    calico_original_yaml_path = plugins.get_source_absolute_pattern(config)
+    calico_original_yaml_path, _ = plugins.get_source_absolute_pattern(config)
     obj_list = load_multiple_yaml(calico_original_yaml_path, cluster)
 
     validate_original(cluster, obj_list)
@@ -388,7 +388,7 @@ def load_multiple_yaml(filepath, cluster) -> dict:
     yaml = ruamel.yaml.YAML()
     yaml_dict = {}
     try:
-        with open(filepath, 'r') as stream:
+        with utils.open_utf8(filepath, 'r') as stream:
             source_yamls = yaml.load_all(stream)
             for source_yaml in source_yamls:
                 if source_yaml:

--- a/kubemarine/plugins/nginx_ingress.py
+++ b/kubemarine/plugins/nginx_ingress.py
@@ -112,11 +112,11 @@ def put_custom_certificate(first_control_plane: NodeGroup, default_cert, crt_pat
         cert = io.StringIO(default_cert["data"]["cert"])
         key = io.StringIO(default_cert["data"]["key"])
     else:
-        cert = utils.get_resource_absolute_path(default_cert["paths"]["cert"])
-        key = utils.get_resource_absolute_path(default_cert["paths"]["key"])
+        cert = io.StringIO(utils.read_external(default_cert["paths"]["cert"]))
+        key = io.StringIO(utils.read_external(default_cert["paths"]["key"]))
 
-    first_control_plane.put(cert, crt_path, sudo=True, binary=False)
-    first_control_plane.put(key, key_path, sudo=True, binary=False)
+    first_control_plane.put(cert, crt_path, sudo=True)
+    first_control_plane.put(key, key_path, sudo=True)
 
 
 def verify_certificate_and_key(first_control_plane: NodeGroup, crt_path, key_path):

--- a/kubemarine/plugins/yaml/calico-v3.24.2.yaml.original
+++ b/kubemarine/plugins/yaml/calico-v3.24.2.yaml.original
@@ -963,10 +963,10 @@ spec:
                 - type: string
                 description: 'BPFPSNATPorts sets the range from which we randomly
                   pick a port if there is a source port collision. This should be
-                  within the ephemeral range as defined by RFC 6056 (1024-65535) and
+                  within the ephemeral range as defined by RFC 6056 (1024–65535) and
                   preferably outside the  ephemeral ranges used by common operating
-                  systems. Linux uses 32768-60999, while others mostly use the IANA
-                  defined range 49152-65535. It is not necessarily a problem if this
+                  systems. Linux uses 32768–60999, while others mostly use the IANA
+                  defined range 49152–65535. It is not necessarily a problem if this
                   range overlaps with the operating systems. Both ends of the range
                   are inclusive. [Default: 20000:29999]'
                 pattern: ^.*

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -438,13 +438,14 @@ def check_access_to_package_repositories(cluster: KubernetesCluster):
             path = utils.get_external_resource_path(repositories)
             if not os.path.isfile(path):
                 broken.append(f"File {path} with the repositories content does not exist")
-            repositories = utils.read_external(path)
-            for repo in repositories.split('\n'):
-                repository_url = next(filter(lambda x: x[:4] == 'http' and '://' in x[4:8], repo.split(' ')), None)
-                if repository_url is not None:
-                    repository_urls.add(repository_url)
-            if not repository_urls:
-                broken.append(f"Failed to detect repository URLs in file {path}")
+            else:
+                repositories = utils.read_external(path)
+                for repo in repositories.split('\n'):
+                    repository_url = next(filter(lambda x: x[:4] == 'http' and '://' in x[4:8], repo.split(' ')), None)
+                    if repository_url is not None:
+                        repository_urls.add(repository_url)
+                if not repository_urls:
+                    broken.append(f"Failed to detect repository URLs in file {path}")
 
         repository_urls = list(repository_urls)
         cluster.log.debug(f"Repositories to check: {repository_urls}")

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -33,7 +33,7 @@ from kubemarine import system, kubernetes, etcd
 def missing_or_empty(file):
     if not os.path.exists(file):
         return True
-    content = open(file, 'r').read()
+    content = utils.read_external(file)
     if re.search(r'^\s*$', content):
         return True
 
@@ -41,7 +41,7 @@ def missing_or_empty(file):
 def replace_config_from_backup_if_needed(procedure_inventory_filepath, config):
     if missing_or_empty(config):
         print('Config is missing or empty - retrieving config from backup archive...')
-        with open(utils.get_resource_absolute_path(procedure_inventory_filepath), 'r') as stream:
+        with utils.open_external(procedure_inventory_filepath, 'r') as stream:
             procedure = yaml.safe_load(stream)
         backup_location = procedure.get("backup_location")
         if not backup_location:
@@ -61,7 +61,7 @@ def unpack_data(cluster):
     if not backup_file_source:
         raise Exception('Backup source not specified in procedure')
 
-    backup_file_source = utils.get_resource_absolute_path(backup_file_source)
+    backup_file_source = utils.get_external_resource_path(backup_file_source)
     if not os.path.isfile(backup_file_source):
         raise FileNotFoundError('Backup file "%s" not found' % backup_file_source)
 
@@ -84,7 +84,7 @@ def unpack_data(cluster):
     if not os.path.isfile(descriptor_filepath):
         raise FileNotFoundError('Descriptor not found in backup file')
 
-    with open(descriptor_filepath, 'r') as stream:
+    with utils.open_external(descriptor_filepath, 'r') as stream:
         cluster.context['backup_descriptor'] = yaml.safe_load(stream)
 
 

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -84,7 +84,6 @@ services:
     /usr/bin/etcdctl:
       source: 'resources/scripts/etcdctl.sh'
       group: control-plane
-      binary: false
     /usr/bin/kubeadm:
       source: 'https://storage.googleapis.com/kubernetes-release/release/{{ services.kubeadm.kubernetesVersion }}/bin/linux/amd64/kubeadm'
     /usr/bin/kubelet:

--- a/kubemarine/resources/schemas/definitions/services/packages.json
+++ b/kubemarine/resources/schemas/definitions/services/packages.json
@@ -14,7 +14,7 @@
           "description": "Deletes old repositories on hosts and installs new ones instead"
         },
         "repositories": {
-          "description": "List of new repositories. Can be specified as string with all repositories content, or as list for apt repositories, or as dictionary for yum repositories.",
+          "description": "List of new repositories. Can be specified as path to the file containing repositories, or as list for apt repositories, or as dictionary for yum repositories.",
           "oneOf": [
             {"type": "string"},
             {"$ref": "#/definitions/YumRepositories"},

--- a/kubemarine/resources/schemas/definitions/services/thirdparties.json
+++ b/kubemarine/resources/schemas/definitions/services/thirdparties.json
@@ -66,18 +66,13 @@
             "nodes": {
               "$ref": "../common/node_ref.json#/definitions/Names",
               "description": "The list of node names where the file should be uploaded"
-            },
-            "binary": {
-              "type": "boolean",
-              "default": true,
-              "description": "Specifies whether to treat the file as binary or as text"
             }
           },
           "required": ["source"],
           "propertyNames": {
             "anyOf": [
               {"$ref": "#/definitions/MinimalThirdPartyPropertyNames"},
-              {"enum": ["owner", "mode", "unpack", "group", "groups", "node", "nodes", "binary"]}
+              {"enum": ["owner", "mode", "unpack", "group", "groups", "node", "nodes"]}
             ]
           }
         }

--- a/kubemarine/testsuite.py
+++ b/kubemarine/testsuite.py
@@ -259,7 +259,7 @@ class TestSuite:
         return results
 
     def save_csv(self, destination_file_path, delimiter=';'):
-        with open(destination_file_path, mode='w') as stream:
+        with utils.open_external(destination_file_path, mode='w') as stream:
             csv_writer = csv.writer(stream, delimiter=delimiter, quotechar='"', quoting=csv.QUOTE_MINIMAL)
             csv_writer.writerow(['group', 'status', 'test_id', 'test_name', 'current_result', 'minimal_result', 'recommended_result'])
             for tc in self.tcs:
@@ -274,7 +274,7 @@ class TestSuite:
                 ])
 
     def save_html(self, destination_file_path, check_type, append_styles=True):
-        with open(destination_file_path, mode='w') as stream:
+        with utils.open_external(destination_file_path, mode='w') as stream:
             stream.write('<!DOCTYPE html><html><head><meta charset="utf-8"><title>%s Check Report</title></head><body><div id="date">%s</div><div id="stats">' % (check_type, datetime.utcnow()))
             for key, value in sorted(self.get_stats_data().items(), key=lambda _key: badges_weights[_key[0]]):
                 stream.write('<div class="%s">%s %s</div>' % (key, value, key))
@@ -299,8 +299,7 @@ class TestSuite:
                               ))
             stream.write('</tbody></table>')
             if append_styles:
-                with open(utils.get_resource_absolute_path('resources/reports/check_report.css',
-                                                           script_relative=True)) as css_stream:
-                    stream.write('<style>\n%s\n</style>' % css_stream.read())
+                css = utils.read_internal('resources/reports/check_report.css')
+                stream.write('<style>\n%s\n</style>' % css)
 
             stream.write('</body></html>')

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import io
 from copy import deepcopy
 
 from kubemarine.core import utils, static
@@ -183,9 +183,8 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
         cluster.log.debug(common_group.sudo(remote_commands))
         remote_commands = ''
         # TODO: Possible use SHA1 from inventory instead of calculating if provided?
-        local_path = utils.get_resource_absolute_path(config['source'], script_relative=True)
-        binary = bool(config.get('binary', True))
-        common_group.put(local_path, destination, sudo=True, binary=binary)
+        script = utils.read_internal(config['source'])
+        common_group.put(io.StringIO(script), destination, sudo=True)
 
         # TODO: Do not upload local files if they already exists on remote machines
 
@@ -207,7 +206,7 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
             cluster.log.verbose('Tar will be used for unpacking')
             remote_commands += ' && sudo tar -zxf %s -C %s' % (destination, config['unpack'])
 
-        # TODO acсess rights do not work for zip
+        # TODO access rights do not work for zip
         remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chmod %s %s/FILE' \
                            % (destination, config['mode'], config['unpack'])
         remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chown %s %s/FILE' \

--- a/kubemarine/yum.py
+++ b/kubemarine/yum.py
@@ -17,6 +17,7 @@ import io
 
 import fabric
 
+from kubemarine.core import utils
 from kubemarine.core.group import NodeGroupResult, NodeGroup
 
 
@@ -51,6 +52,8 @@ def create_repo_file(group, repo_data, repo_file):
             config[repo_id] = data
         repo_data = io.StringIO()
         config.write(repo_data)
+    else:
+        repo_data = io.StringIO(utils.read_external(repo_data))
     group.put(repo_data, repo_file, sudo=True)
 
 

--- a/test/unit/core/test_schema.py
+++ b/test/unit/core/test_schema.py
@@ -73,7 +73,7 @@ class FinalizedInventoryValidation(unittest.TestCase):
 
 class TestValidExamples(unittest.TestCase):
     def test_cluster_examples_valid(self):
-        inventories_dir = Path(utils.get_resource_absolute_path("../examples/cluster.yaml", script_relative=True))
+        inventories_dir = Path(utils.get_internal_resource_path("../examples/cluster.yaml"))
         self.assertTrue(inventories_dir.is_dir(), "Examples not found")
         for inventory_filepath in inventories_dir.glob('**/*'):
             if inventory_filepath.is_dir() or 'cluster' not in inventory_filepath.name:
@@ -91,7 +91,7 @@ class TestValidExamples(unittest.TestCase):
                 self.fail(f"Enrichment of {inventory_filepath.relative_to(inventories_dir)} failed: {e}")
 
     def test_procedure_examples_valid(self):
-        inventories_dir = Path(utils.get_resource_absolute_path("../examples/procedure.yaml", script_relative=True))
+        inventories_dir = Path(utils.get_internal_resource_path("../examples/procedure.yaml"))
         if not inventories_dir.is_dir():
             self.skipTest("Examples not found")
         for inventory_filepath in inventories_dir.glob('**/*'):

--- a/test/unit/test_demo.py
+++ b/test/unit/test_demo.py
@@ -89,14 +89,14 @@ class TestFakeFS(unittest.TestCase):
 
         self.assertEqual(expected_data, actual_data, msg="Written and read data are not equal")
 
-    def test_put_stringio(self):
+    def test_put_bytesio(self):
         self.cluster.fake_fs.reset()
 
-        expected_data = io.StringIO('hello\nworld')
+        expected_data = io.BytesIO(b'hello\nworld')
         node_hostname = list(self.cluster.nodes['master'].nodes.keys())[0]
 
         self.cluster.fake_fs.write(node_hostname, '/tmp/test/file.txt', expected_data)
-        actual_data = self.cluster.fake_fs.read(node_hostname, '/tmp/test/file.txt')
+        actual_data = self.cluster.fake_fs.read(node_hostname, '/tmp/test/file.txt').encode('utf-8')
 
         self.assertEqual(expected_data.getvalue(), actual_data, msg="Written and read data are not equal")
 


### PR DESCRIPTION
### Description
There are many places in KubeMarine where there can be an attempt to upload non-ASCII characters. This does not work because of issue https://github.com/paramiko/paramiko/issues/1133
The problem is especially relevant for custom template plugins.

Fixes #342

### Solution
* `NodeGroup.put` now uploads data only as stream of bytes, not characters.
* New requirement for all input text files to be strictly in utf-8 encoding.
    * This is reflected in new utils.py methods which now always open in utf-8.
    * Any internal or external text file should be opened using new methods.
* New approach automatically leads to CRLF -> LF transformation of line endings on Windows deployer for any input text file (internal or external) except external `config` files for plugins with `do_render=False`.
* Removed `binary` parameter for thirdparties as uploading from filesystem is not supported for external thirdparties.
* Minor fix in `services.packages.package_manager.repositories`: now it allows input as path to file for both apt and yum package managers.

### Breaking changes
If `services.packages.package_manager.repositories` for Debian-based cluster was passed as string, it will stop working as the string is now considered as path to file. No longer working configuration:
```yaml
services:
  packages:
    package_manager:
      repositories: |
        deb http://archive.ubuntu.com/ubuntu focal main restricted
        deb http://archive.ubuntu.com/ubuntu focal-updates main restricted
```
New working configuration:
```yaml
services:
  packages:
    package_manager:
      repositories: files/predefined.list
```
where files/predefined.list contains the repositories.

### Test Cases

See https://github.com/Netcracker/KubeMarine/issues/342

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_demo.py and demo.py to adopt to new upload behaviour.
