### PR TITLE
[MANOPD-84029] Status of resources

### DIFF
--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -253,6 +253,7 @@ def expect_replicaset(cluster: KubernetesCluster,
 
     raise Exception('In the expected time, the ReplicaSets did not become ready')
 
+
 def expect_statefulset(cluster: KubernetesCluster,
                        statefulsets_names: List[str] or List[Dict[str, str]],
                        timeout: int = None,

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -199,6 +199,8 @@ def expect_daemonset(cluster: KubernetesCluster,
             cluster.log.debug(f"DaemonSets are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
 
+    raise Exception('In the expected time, the DaemonSets did not become ready')
+
 
 def expect_replicaset(cluster: KubernetesCluster,
                       replicasets_names: List[str] or List[Dict[str, str]],
@@ -249,6 +251,7 @@ def expect_replicaset(cluster: KubernetesCluster,
             cluster.log.debug(f"ReplicaSets are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
 
+    raise Exception('In the expected time, the ReplicaSets did not become ready')
 
 def expect_statefulset(cluster: KubernetesCluster,
                        statefulsets_names: List[str] or List[Dict[str, str]],
@@ -299,6 +302,8 @@ def expect_statefulset(cluster: KubernetesCluster,
             cluster.log.debug(f"StatefulSets are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
 
+    raise Exception('In the expected time, the StatefulSets did not become ready')
+
 
 def expect_deployment(cluster: KubernetesCluster,
                       deployments_names: List[str] or List[Dict[str, str]],
@@ -348,6 +353,8 @@ def expect_deployment(cluster: KubernetesCluster,
             retries -= 1
             cluster.log.debug(f"Deployments are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
+
+    raise Exception('In the expected time, the Deployments did not become ready')
 
 
 def expect_pods(cluster, pods, namespace=None, timeout=None, retries=None,

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -52,7 +52,7 @@ pods:
       retries: 30
     plugins:
       timeout: 5
-      retries: 30
+      retries: 45
   critical_states:
     - Error
     - ErrImagePull

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -52,7 +52,7 @@ pods:
       retries: 30
     plugins:
       timeout: 5
-      retries: 360
+      retries: 30
   critical_states:
     - Error
     - ErrImagePull

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -52,7 +52,7 @@ pods:
       retries: 30
     plugins:
       timeout: 5
-      retries: 45
+      retries: 360
   critical_states:
     - Error
     - ErrImagePull


### PR DESCRIPTION
### Description
Installation/upgrade procedure doesn't fail on `deploy.plugins` task if the retries are exceeded for the following resources:
* `DaemonSet`
* `Deployment`
* `StatefulSet`
* `ReplicaSet`


### Solution
* Add exception in `expect_` methods in `plugins` module


### How to apply
Not applicable


### Test Cases


**TestCase 1**
Check if the fix works

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 20.04
- Inventory: MiniHA

Steps:

1. Run installation procedure. At least one predefined plugin must be enabled and it should not have enough time to run its main resource (one of the following: `DaemonSet`, `Deployment`, `StatefulSet`, `ReplicaSet`)

Results:

| Before | After |
| ------ | ------ |
| Success | Fail with exception |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


