### PR TITLE
MANOPD-84124 Fix unnecessary reboot when nothing to remove / upgrade

### DIFF
--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -14,6 +14,8 @@
 
 import io
 
+import fabric
+
 from kubemarine.core.group import NodeGroupResult, NodeGroup
 
 DEBIAN_HEADERS = 'DEBIAN_FRONTEND=noninteractive '
@@ -111,6 +113,12 @@ def upgrade(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
         command += ' --exclude=%s' % exclude
 
     return group.sudo(command, **kwargs)
+
+
+def no_changes_found(action: callable, result: fabric.runners.Result) -> bool:
+    if action not in (install, upgrade, remove):
+        raise Exception(f"Unknown action {action}")
+    return "0 upgraded, 0 newly installed, 0 to remove" in result.stdout
 
 
 def search(group: NodeGroup, package: str, **kwargs) -> NodeGroupResult:

--- a/kubemarine/packages.py
+++ b/kubemarine/packages.py
@@ -326,6 +326,17 @@ def upgrade(group: NodeGroup, include=None, exclude=None, **kwargs) -> NodeGroup
     return get_package_manager(group).upgrade(group, include, exclude, **kwargs)
 
 
+def no_changes_found(group: NodeGroup, action: callable, result: fabric.runners.Result) -> bool:
+    pkg_mgr = get_package_manager(group)
+    if action is install:
+        action = pkg_mgr.install
+    elif action is upgrade:
+        action = pkg_mgr.upgrade
+    elif action is remove:
+        action = pkg_mgr.remove
+    return pkg_mgr.no_changes_found(action, result)
+
+
 def get_detect_package_version_cmd(os_family: str, package_name: str) -> str:
     if os_family in ["rhel", "rhel8"]:
         cmd = r"rpm -q %s" % package_name

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -341,8 +341,8 @@ def manage_custom_packages(group: NodeGroup):
     for action, results in batch_results.items():
         cluster.log.verbose('Verifying packages changes after \'%s\' action...' % action)
         for conn, result in results.items():
-            if "Nothing to do" not in result.stdout \
-                    and "0 upgraded, 0 newly installed, 0 to remove" not in result.stdout:
+            node = cluster.make_group([conn])
+            if not packages.no_changes_found(node, action, result):
                 cluster.log.verbose('Packages changed at %s' % conn.host)
                 any_changes_found = True
 

--- a/kubemarine/yum.py
+++ b/kubemarine/yum.py
@@ -15,6 +15,8 @@
 import configparser
 import io
 
+import fabric
+
 from kubemarine.core.group import NodeGroupResult, NodeGroup
 
 
@@ -111,6 +113,17 @@ def upgrade(group, include=None, exclude=None, **kwargs):
         command += ' --exclude=%s' % exclude
 
     return group.sudo(command, **kwargs)
+
+
+def no_changes_found(action: callable, result: fabric.runners.Result) -> bool:
+    if action is install:
+        return "Nothing to do" in result.stdout
+    elif action is upgrade:
+        return "No packages marked for update" in result.stdout
+    elif action is remove:
+        return "No Packages marked for removal" in result.stdout
+    else:
+        raise Exception(f"Unknown action {action}")
 
 
 def search(group: NodeGroup, package: str, **kwargs) -> NodeGroupResult:


### PR DESCRIPTION
### Description
* If attempt to remove already removed package on RHEL nodes, the reboot is scheduled.

### Solution
* Added check of stdout output to skip reboot of RHEL nodes if nothing to remove or upgrade.

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: RHEL OS family
- Inventory: contains `services.packages.remove` or `services.packages.upgrade`

Steps:

1. Run `install --tasks prepare.package_manager.manage_packages` twice.

Results:

| Before | After |
| ------ | ------ |
| Both runs causes nodes to be rebooted | The second run does not reboot the nodes |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
