### PR TITLE
[MANOPD-84427] : No busybox version 1.31.2

### DIFF
--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -605,15 +605,15 @@ compatibility_map:
         version: v0.0.23
     busybox:
       v1.21:
-        version: 1.31.2
+        version: 1.34.1
       v1.22:
-        version: 1.31.2
+        version: 1.34.1
       v1.23:
-        version: 1.31.2
+        version: 1.34.1
       v1.24:
-        version: 1.31.2
+        version: 1.34.1
       v1.25:
-        version: 1.31.2
+        version: 1.34.1
     pause:
       v1.21:
         version: 3.4.1

--- a/kubemarine/resources/schemas/definitions/plugins/local-path-provisioner.json
+++ b/kubemarine/resources/schemas/definitions/plugins/local-path-provisioner.json
@@ -35,7 +35,7 @@
     },
     "helper-pod-image": {
       "type": "string",
-      "default": "library/busybox:latest"
+      "default": "busybox:latest"
     }
   },
   "propertyNames": {

--- a/kubemarine/resources/schemas/definitions/plugins/local-path-provisioner.json
+++ b/kubemarine/resources/schemas/definitions/plugins/local-path-provisioner.json
@@ -5,8 +5,7 @@
   "allOf": [{"$ref": "generic_plugin.json#/definitions/Properties"}],
   "properties": {
     "image": {
-      "type": "string",
-      "default": "rancher/local-path-provisioner:v0.0.23"
+      "type": "string"
     },
     "storage-class": {
       "type": "object",
@@ -34,8 +33,7 @@
       "$ref": "generic_plugin.json#/definitions/CustomTolerations"
     },
     "helper-pod-image": {
-      "type": "string",
-      "default": "busybox:latest"
+      "type": "string"
     }
   },
   "propertyNames": {

--- a/kubemarine/resources/schemas/definitions/plugins/local-path-provisioner.json
+++ b/kubemarine/resources/schemas/definitions/plugins/local-path-provisioner.json
@@ -35,7 +35,7 @@
     },
     "helper-pod-image": {
       "type": "string",
-      "default": "library/busybox:1.35.0"
+      "default": "library/busybox:latest"
     }
   },
   "propertyNames": {


### PR DESCRIPTION
### Description
* Need update busybox in globals.yaml. Because there is no previous version on Docker HUB 
* Local-path-provisioner PVC stuck is not working correctly
* Need update json schemas

WA:
* Must be added to `cluster.yaml`. In the `plugins->local-path-provider` section, add the `helper-pod-image` parameter with the value `library/busybox:1.34.1`
* Restart pod local-path-provider

```yaml
plugins:
  local-path-provisioner:
    install: true
    storage-class:
      is-default: 'true'
    helper-pod-image: library/busybox:1.34.1
```

### Solution
* Update busybox in globals.yaml and json schema
### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


