### PR TITLE
Fix ci dump location

### DIFF
--- a/.github/workflows/test_install.yaml
+++ b/.github/workflows/test_install.yaml
@@ -44,6 +44,7 @@ jobs:
         id: test_check_paas
         run: ./bin/kubemarine check_paas -c ./ci/default_config.yaml  --dump-location ./results/check_paas_dump/
       - name: Change not-recommended symbols in dump files
+        if: failure()
         run: rename 's/[:]/_/g' ./results/*/*
       - name: Collect dump artifacts
         if: failure()
@@ -95,6 +96,7 @@ jobs:
         id: test_check_paas
         run: ./bin/kubemarine check_paas -c ./ci/extended_config.yaml --dump-location ./results/check_paas_dump/
       - name: Change not-recommended symbols in dump files
+        if: failure()
         run: rename 's/[:]/_/g' ./results/*/*
       - name: Collect dump artifacts
         if: failure()

--- a/.github/workflows/test_install.yaml
+++ b/.github/workflows/test_install.yaml
@@ -44,7 +44,7 @@ jobs:
         id: test_check_paas
         run: ./bin/kubemarine check_paas -c ./ci/default_config.yaml  --dump-location ./results/check_paas_dump/
       - name: Change not-recommended symbols in dump files
-        run: rename 's/[:]/_/g' ./results/*
+        run: rename 's/[:]/_/g' ./results/*/*
       - name: Collect dump artifacts
         if: true
         uses: actions/upload-artifact@v3
@@ -95,7 +95,7 @@ jobs:
         id: test_check_paas
         run: ./bin/kubemarine check_paas -c ./ci/extended_config.yaml --dump-location ./results/check_paas_dump/
       - name: Change not-recommended symbols in dump files
-        run: rename 's/[:]/_/g' ./results/*
+        run: rename 's/[:]/_/g' ./results/*/*
       - name: Collect dump artifacts
         if: true
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test_install.yaml
+++ b/.github/workflows/test_install.yaml
@@ -41,6 +41,8 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: ./bin/kubemarine check_paas -c ./ci/default_config.yaml  --dump-location ./results/check_paas_dump/
+      - name: Change not-recommended symbols in dump files
+        run: rename 's/[:]/_/g' ./results/*
       - name: Collect dump artifacts
         if: true
         uses: actions/upload-artifact@v3
@@ -87,7 +89,9 @@ jobs:
         run: ./bin/kubemarine install -c ./ci/extended_config.yaml --disable-cumulative-points --dump-location ./results/install_dump/
       - name: Check paas
         id: test_check_paas
-        run: ./bin/kubemarine check_paas -c ./ci/extended_config.yaml --dump-location ./rresults/check_paas_dump/
+        run: ./bin/kubemarine check_paas -c ./ci/extended_config.yaml --dump-location ./results/check_paas_dump/
+      - name: Change not-recommended symbols in dump files
+        run: rename 's/[:]/_/g' ./results/*
       - name: Collect dump artifacts
         if: true
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test_install.yaml
+++ b/.github/workflows/test_install.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Change not-recommended symbols in dump files
         run: rename 's/[:]/_/g' ./results/*/*
       - name: Collect dump artifacts
-        if: true
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: default_cluster_procedure_dumps
@@ -97,7 +97,7 @@ jobs:
       - name: Change not-recommended symbols in dump files
         run: rename 's/[:]/_/g' ./results/*/*
       - name: Collect dump artifacts
-        if: true
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: extended_cluster_procedure_dumps

--- a/.github/workflows/test_install.yaml
+++ b/.github/workflows/test_install.yaml
@@ -34,28 +34,19 @@ jobs:
         run: sudo apt remove moby-runc
       - name: Check Iaas
         id: test_check_iaas
-        run: ./bin/kubemarine check_iaas -c ./ci/default_config.yaml
-      - name: Copy check iaas dumps
-        if:  (success() || failure()) && steps.test_check_iaas.outcome != 'skipped'
-        run: mkdir -p results && cp -a dump/. results/check_iaas_dump/
+        run: ./bin/kubemarine check_iaas -c ./ci/default_config.yaml  --dump-location ./results/check_iaas_dump/
       - name: Install
         id: test_install
-        run: ./bin/kubemarine install -c ./ci/default_config.yaml --disable-cumulative-points
-      - name: Copy install dumps
-        if: (success() || failure()) && steps.test_install.outcome != 'skipped'
-        run: mkdir -p results && cp -a dump/. results/install_dump/
+        run: ./bin/kubemarine install -c ./ci/default_config.yaml --disable-cumulative-points --dump-location ./results/install_dump/
       - name: Check paas
         id: test_check_paas
-        run: ./bin/kubemarine check_paas -c ./ci/default_config.yaml
-      - name: Copy check paas dumps
-        if:  (success() || failure()) && steps.test_check_paas.outcome != 'skipped'
-        run: mkdir -p results && cp -a dump/. results/check_paas_dump/
+        run: ./bin/kubemarine check_paas -c ./ci/default_config.yaml  --dump-location ./results/check_paas_dump/
       - name: Collect dump artifacts
-        if: failure()
+        if: true
         uses: actions/upload-artifact@v3
         with:
           name: default_cluster_procedure_dumps
-          path: results/
+          path: ./results/
           retention-days: 7
 
 
@@ -90,26 +81,17 @@ jobs:
         run: sudo apt remove moby-runc
       - name: Check Iaas
         id: test_check_iaas
-        run: ./bin/kubemarine check_iaas -c ./ci/extended_config.yaml
-      - name: Copy check iaas dumps
-        if:  (success() || failure()) && steps.test_check_iaas.outcome != 'skipped'
-        run: mkdir -p results && cp -a dump/. results/check_iaas_dump/
+        run: ./bin/kubemarine check_iaas -c ./ci/extended_config.yaml --dump-location ./results/check_iaas_dump/
       - name: Install
         id: test_install
-        run: ./bin/kubemarine install -c ./ci/extended_config.yaml --disable-cumulative-points
-      - name: Copy install dumps
-        if: (success() || failure()) && steps.test_install.outcome != 'skipped'
-        run: mkdir -p results && cp -a dump/. results/install_dump/
+        run: ./bin/kubemarine install -c ./ci/extended_config.yaml --disable-cumulative-points --dump-location ./results/install_dump/
       - name: Check paas
         id: test_check_paas
-        run: ./bin/kubemarine check_paas -c ./ci/extended_config.yaml
-      - name: Copy check paas dumps
-        if:  (success() || failure()) && steps.test_check_paas.outcome != 'skipped'
-        run: mkdir -p results && cp -a dump/. results/check_paas_dump/
+        run: ./bin/kubemarine check_paas -c ./ci/extended_config.yaml --dump-location ./rresults/check_paas_dump/
       - name: Collect dump artifacts
-        if: failure()
+        if: true
         uses: actions/upload-artifact@v3
         with:
           name: extended_cluster_procedure_dumps
-          path: results/
+          path: ./results/
           retention-days: 7

--- a/.github/workflows/test_install.yaml
+++ b/.github/workflows/test_install.yaml
@@ -32,6 +32,8 @@ jobs:
           pip install -r requirements.txt
       - name: Remove moby-runc to resolve conflicts
         run: sudo apt remove moby-runc
+      - name: Install rename
+        run: sudo apt install rename
       - name: Check Iaas
         id: test_check_iaas
         run: ./bin/kubemarine check_iaas -c ./ci/default_config.yaml  --dump-location ./results/check_iaas_dump/
@@ -81,6 +83,8 @@ jobs:
           pip install -r requirements.txt
       - name: Remove moby-runc to resolve conflicts
         run: sudo apt remove moby-runc
+      - name: Install rename
+        run: sudo apt install rename
       - name: Check Iaas
         id: test_check_iaas
         run: ./bin/kubemarine check_iaas -c ./ci/extended_config.yaml --dump-location ./results/check_iaas_dump/


### PR DESCRIPTION
### Description
In test installation ci we copy dump files to separate directory after any operation. But it's better to use `--dump-location` option to reduce steps count.
At the same time github ci reject some symbols in file names to upload like artifact. For this reason was added additional steps to rename such symbols on `_`

Fixes # (issue)


### Solution
* Use `--dump-location` instead of additional steps;
* Change not valid symbols before uploading;


### How to apply
Provide steps how to apply on top previous Kubemarine version to execute on existing clusters
* [Install task/s](documentation/Installation.md#installation-tasks-description)
* Manual step 
* [Upgrade procedure](documentation/Maintenance.md#upgrade-procedure)


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 

Steps:

1. 

Results:

| Before | After |
| ------ | ------ |
|  |  |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


