### PR TITLE
Fix replacement of package README links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Management tool for Kubernetes cluster deployment and maintenance
 authors = [
     {name = "Kubemarine Group", email = "kubemarinegroup@netcracker.com"},
 ]
-license = {file = "LICENSE"}
+license = {text = "Apache-2.0"}
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,15 @@ def read(path):
 VERSION = read("kubemarine/version").strip()
 
 README = read("README.md")
+# Special case to refer to anchor within the current README page should be translated to explicit README referring.
+README = re.sub(
+    r'\[(.*?)]\((#.*?)\)',
+    rf'[\1](https://github.com/Netcracker/KubeMarine/blob/{VERSION}/README.md\2)',
+    README
+)
 # Replace all relative links (not starting with http[s]://) to absolute referring to specific version on GitHub
 README = re.sub(
-    r'\[(.*)]\((?!https?://)(.*)\)',
+    r'\[(.*?)]\((?!https?://)(.*?)\)',
     rf'[\1](https://github.com/Netcracker/KubeMarine/blob/{VERSION}/\2)',
     README
 )


### PR DESCRIPTION
### Description
* Une non-greedy '*?' to replace more than one link in the line.
* Specially process links within the current README page.
* Use short license identifier instead of full license text.

### Test Cases

**TestCase 1**

1. Deploy package to PyPI.
2. Check that all links in README work.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
