### PR TITLE
[PSUPCLPL-11680] adjust plugins and nodes timeouts

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -82,7 +82,7 @@ This section provides information about the inventory, features, and steps for i
         - [template](#template)
         - [config](#config) 
         - [expect pods](#expect-pods)
-        - [expect deployments/daemonsets/replicasets/statefulsets](#expect-deployments-daemonsets-replicasets-statefulsets)
+        - [expect deployments/daemonsets/replicasets/statefulsets](#expect-deploymentsdaemonsetsreplicasetsstatefulsets)
         - [python](#python)
         - [thirdparty](#thirdparty)
         - [shell](#shell)

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -18,6 +18,7 @@ This section provides information about the inventory, features, and steps for i
       - [Full-HA Scheme](#full-ha-scheme)
   - [Taints and Toleration](#taints-and-toleration)
   - [Configuration](#configuration)
+    - [globals](#globals)
     - [node_defaults](#node_defaults)
     - [nodes](#nodes)
     - [cluster_name](#cluster_name)
@@ -491,6 +492,28 @@ The known IDEs that support validation are:
 
 The inventory file consists of the following sections.
 
+### globals
+In the `globals` section you can describe the global parameters that can be overridden. For example:
+
+```
+globals:
+  nodes:
+    ready:
+      timeout: 10
+      retries: 60
+    boot:
+      timeout: 900
+```
+
+The following parameters are supported:
+
+|Name|Type|Mandatory|Default Value|Example|Description|
+|---|---|---|---|---|---|
+|`nodes.ready.timeout`|int|no|5|`10`|Timeout between `nodes.ready.retries` for cluster node readiness waiting|
+|`nodes.ready.retries`|int|no|15|`60`|Number of retries to check a cluster node readiness|
+|`nodes.boot.timeout`|int|no|600|`900`|Timeout for node reboot waiting|
+
+
 ### node_defaults
 
 In the `node_defaults` section, you can describe the parameters to be applied by default to each record in the [nodes](#nodes) section.
@@ -531,7 +554,7 @@ node:
 ```
 
 Following are the parameters allowed to be specified in the `node_defaults` section:
-* keyfile, username, connection_port, connection_timeout, boot_timeout, ready_timeout, ready_retries and gateway.
+* keyfile, username, connection_port, connection_timeout and gateway.
 * labels, and taints - specify at global level only if the [Mini-HA Scheme](#mini-ha-scheme) is used.
 
 For more information about the listed parameters, refer to the following section.
@@ -551,14 +574,9 @@ The following options are supported:
 |internal_address|ip address|**yes**| |`192.168.0.1`|Internal node's IP-address|
 |connection_port|int|no|`22`| |Port for SSH-connection to cluster node|
 |connection_timeout|int|no|10|`60`|Timeout for SSH-connection to cluster node|
-|ready_timeout|int|no|5|`10`|Timeout between `ready_retries` for cluster node readiness waiting|
-|ready_retries|int|no|15|`30`|Number of retries to check a cluster node readiness|
-|boot_timeout|int|no|600|`900`|Timeout for node reboot waiting|
 |roles|list|**yes**| |`["control-plane"]`|Cluster member role. It can be `balancer`, `worker`, or `control-plane`.|
 |labels|map|no| |`netcracker-infra: infra`|Additional labels for node|
 |taints|list|no| |See examples below|Additional taints for node. **Caution**: Use at your own risk. It can cause unexpected behavior. No support is provided for consequences.|
-
-*Warning*: In case of `ready_timeout`, `ready_retries`, `boot_timeout` should be redefined, it must be done in `node_defaults` section of `cluster.yaml`. They can be overridden only for all the nodes at once.
 
 An example with parameters values is as follows:
 

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -630,8 +630,7 @@ class NodeGroup:
     def _await_rebooted_nodes(self, timeout=None, initial_boot_history: NodeGroupResult = None) -> _HostToResult:
 
         if timeout is None:
-            # boot_timeout is set for all nodes, so we can take any node's boot_timeout
-            timeout = self.cluster.inventory['nodes'][0].get('boot_timeout', self.cluster.globals['nodes']['boot']['defaults']['timeout'])
+            timeout = int(self.cluster.inventory['globals']['nodes']['boot']['timeout'])
 
         delay_period = self.cluster.globals['nodes']['boot']['defaults']['delay_period']
 
@@ -680,7 +679,7 @@ class NodeGroup:
                 time.sleep(delay_period - attempt_time)
 
         if left_nodes:
-            self.cluster.log.verbose("Failed to wait for boot of nodes %s. Try to increase boot_timeout parameter in node_defaults: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#node_defaults" % list(left_nodes.keys()))
+            self.cluster.log.verbose("Failed to wait for boot of nodes %s" % list(left_nodes.keys()))
         else:
             self.cluster.log.verbose("All nodes are online now")
 

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -601,9 +601,8 @@ def wait_for_nodes(group):
     else:
         status_cmd = "kubectl get nodes %s -o jsonpath='{.status.conditions[?(@.type==\"%s\")].status}'"
 
-    # timeout should be the same for all the nodes
-    timeout = group.cluster.inventory['nodes'][0].get('ready_timeout', group.cluster.globals['nodes']['ready']['timeout'])
-    retries = group.cluster.inventory['nodes'][0].get('ready_retries', group.cluster.globals['nodes']['ready']['retries'])
+    timeout = int(group.cluster.inventory['globals']['nodes']['ready']['timeout'])
+    retries = int(group.cluster.inventory['globals']['nodes']['ready']['retries'])
     log.debug("Waiting for new kubernetes nodes to become ready, %s retries every %s seconds" % (retries, timeout))
     while retries > 0:
         correct_conditions = 0
@@ -624,7 +623,7 @@ def wait_for_nodes(group):
             log.debug("All nodes are ready!")
             return
 
-    raise Exception("Nodes did not become ready in the expected time, %s retries every %s seconds. Try to increase ready_retries parameter in node_defaults: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#node_defaults" % (retries, timeout))
+    raise Exception("Nodes did not become ready in the expected time, %s retries every %s seconds. Try to increase node.ready.retries parameter in globals: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#globals" % (retries, timeout))
 
 
 def init_workers(group):

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -197,7 +197,7 @@ def expect_daemonset(cluster: KubernetesCluster,
             cluster.log.debug(f"DaemonSets are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
 
-    raise Exception('In the expected time, the DaemonSets did not become ready. Try to increase number of retries in expect.daemonsets: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deployments-daemonsets-replicasets-statefulsets')
+    raise Exception('In the expected time, the DaemonSets did not become ready. Try to increase number of retries in expect.daemonsets: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deploymentsdaemonsetsreplicasetsstatefulsets')
 
 
 def expect_replicaset(cluster: KubernetesCluster,
@@ -249,7 +249,7 @@ def expect_replicaset(cluster: KubernetesCluster,
             cluster.log.debug(f"ReplicaSets are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
 
-    raise Exception('In the expected time, the ReplicaSets did not become ready. Try to increase number of retries in expect.replicasets: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deployments-daemonsets-replicasets-statefulsets')
+    raise Exception('In the expected time, the ReplicaSets did not become ready. Try to increase number of retries in expect.replicasets: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deploymentsdaemonsetsreplicasetsstatefulsets')
 
 
 def expect_statefulset(cluster: KubernetesCluster,
@@ -301,7 +301,7 @@ def expect_statefulset(cluster: KubernetesCluster,
             cluster.log.debug(f"StatefulSets are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
 
-    raise Exception('In the expected time, the StatefulSets did not become ready. Try to increase number of retries in expect.statefulsets: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deployments-daemonsets-replicasets-statefulsets')
+    raise Exception('In the expected time, the StatefulSets did not become ready. Try to increase number of retries in expect.statefulsets: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deploymentsdaemonsetsreplicasetsstatefulsets')
 
 
 def expect_deployment(cluster: KubernetesCluster,
@@ -353,7 +353,7 @@ def expect_deployment(cluster: KubernetesCluster,
             cluster.log.debug(f"Deployments are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
 
-    raise Exception('In the expected time, the Deployments did not become ready. Try to increase number of retries in expect.deployments: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deployments-daemonsets-replicasets-statefulsets')
+    raise Exception('In the expected time, the Deployments did not become ready. Try to increase number of retries in expect.deployments: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deploymentsdaemonsetsreplicasetsstatefulsets')
 
 
 def expect_pods(cluster, pods, namespace=None, timeout=None, retries=None,

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -439,7 +439,7 @@ def expect_pods(cluster, pods, namespace=None, timeout=None, retries=None,
             cluster.log.debug(running_pods_stdout)
             time.sleep(timeout)
 
-    raise Exception('In the expected time, the pods did not become ready. Try to increase number of retries in expect.pods: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-pods')
+    raise Exception('In the expected time, the pods did not become ready')
 
 
 def is_critical_state_in_stdout(cluster, stdout):

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -167,9 +167,9 @@ def expect_daemonset(cluster: KubernetesCluster,
     log = cluster.log
 
     if timeout is None:
-        timeout = cluster.globals['expect']['plugins']['timeout']
+        timeout = cluster.globals['deployments']['expect']['timeout']
     if retries is None:
-        retries = cluster.globals['expect']['plugins']['retries']
+        retries = cluster.globals['deployments']['expect']['retries']
 
     log.debug(f"Expecting the following DaemonSets to be up to date: {daemonsets_names}")
     log.verbose("Max expectation time: %ss" % (timeout * retries))
@@ -197,7 +197,7 @@ def expect_daemonset(cluster: KubernetesCluster,
             cluster.log.debug(f"DaemonSets are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
 
-    raise Exception('In the expected time, the DaemonSets did not become ready')
+    raise Exception('In the expected time, the DaemonSets did not become ready. Try to increase number of retries in expect.daemonsets: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deployments-daemonsets-replicasets-statefulsets')
 
 
 def expect_replicaset(cluster: KubernetesCluster,
@@ -219,9 +219,9 @@ def expect_replicaset(cluster: KubernetesCluster,
     log = cluster.log
 
     if timeout is None:
-        timeout = cluster.globals['expect']['plugins']['timeout']
+        timeout = cluster.globals['deployments']['expect']['timeout']
     if retries is None:
-        retries = cluster.globals['expect']['plugins']['retries']
+        retries = cluster.globals['deployments']['expect']['retries']
 
     log.debug(f"Expecting the following ReplicaSets to be up to date: {replicasets_names}")
     log.verbose("Max expectation time: %ss" % (timeout * retries))
@@ -249,7 +249,7 @@ def expect_replicaset(cluster: KubernetesCluster,
             cluster.log.debug(f"ReplicaSets are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
 
-    raise Exception('In the expected time, the ReplicaSets did not become ready')
+    raise Exception('In the expected time, the ReplicaSets did not become ready. Try to increase number of retries in expect.replicasets: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deployments-daemonsets-replicasets-statefulsets')
 
 
 def expect_statefulset(cluster: KubernetesCluster,
@@ -271,9 +271,9 @@ def expect_statefulset(cluster: KubernetesCluster,
     log = cluster.log
 
     if timeout is None:
-        timeout = cluster.globals['expect']['plugins']['timeout']
+        timeout = cluster.globals['deployments']['expect']['timeout']
     if retries is None:
-        retries = cluster.globals['expect']['plugins']['retries']
+        retries = cluster.globals['deployments']['expect']['retries']
 
     log.debug(f"Expecting the following StatefulSets to be up to date: {statefulsets_names}")
     log.verbose("Max expectation time: %ss" % (timeout * retries))
@@ -301,7 +301,7 @@ def expect_statefulset(cluster: KubernetesCluster,
             cluster.log.debug(f"StatefulSets are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
 
-    raise Exception('In the expected time, the StatefulSets did not become ready')
+    raise Exception('In the expected time, the StatefulSets did not become ready. Try to increase number of retries in expect.statefulsets: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deployments-daemonsets-replicasets-statefulsets')
 
 
 def expect_deployment(cluster: KubernetesCluster,
@@ -323,9 +323,9 @@ def expect_deployment(cluster: KubernetesCluster,
     log = cluster.log
 
     if timeout is None:
-        timeout = cluster.globals['expect']['plugins']['timeout']
+        timeout = cluster.globals['deployments']['expect']['timeout']
     if retries is None:
-        retries = cluster.globals['expect']['plugins']['retries']
+        retries = cluster.globals['deployments']['expect']['retries']
 
     log.debug(f"Expecting the following Deployments to be up to date: {deployments_names}")
     log.verbose("Max expectation time: %ss" % (timeout * retries))
@@ -353,7 +353,7 @@ def expect_deployment(cluster: KubernetesCluster,
             cluster.log.debug(f"Deployments are not up to date yet... ({retries * timeout}s left)")
             time.sleep(timeout)
 
-    raise Exception('In the expected time, the Deployments did not become ready')
+    raise Exception('In the expected time, the Deployments did not become ready. Try to increase number of retries in expect.deployments: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-deployments-daemonsets-replicasets-statefulsets')
 
 
 def expect_pods(cluster, pods, namespace=None, timeout=None, retries=None,
@@ -364,9 +364,9 @@ def expect_pods(cluster, pods, namespace=None, timeout=None, retries=None,
         cluster = cluster.cluster
 
     if timeout is None:
-        timeout = cluster.globals['expect']['plugins']['timeout']
+        timeout = cluster.globals['pods']['expect']['plugins']['timeout']
     if retries is None:
-        retries = cluster.globals['expect']['plugins']['retries']
+        retries = cluster.globals['pods']['expect']['plugins']['retries']
 
     cluster.log.debug("Expecting the following pods to be ready: %s" % pods)
     cluster.log.verbose("Max expectation time: %ss" % (timeout * retries))
@@ -439,7 +439,7 @@ def expect_pods(cluster, pods, namespace=None, timeout=None, retries=None,
             cluster.log.debug(running_pods_stdout)
             time.sleep(timeout)
 
-    raise Exception('In the expected time, the pods did not become ready')
+    raise Exception('In the expected time, the pods did not become ready. Try to increase number of retries in expect.pods: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Installation.md#expect-pods')
 
 
 def is_critical_state_in_stdout(cluster, stdout):
@@ -478,7 +478,7 @@ def convert_expect(cluster, config):
         config['statefulsets'] = {
             'list': config['statefulsets']
         }
-    if config.get('deployments') is not None and isinstance(config['pods'], list):
+    if config.get('deployments') is not None and isinstance(config['deployments'], list):
         config['deployments'] = {
             'list': config['deployments']
         }
@@ -492,35 +492,31 @@ def convert_expect(cluster, config):
 def apply_expect(cluster, config, plugin_name=None):
     # TODO: Add support for expect services and expect nodes
 
-    plugins_timeout = cluster.globals['pods']['expect']['plugins']['timeout']
-    plugins_retries = cluster.globals['pods']['expect']['plugins']['retries']
-
     for expect_type, expect_conf in config.items():
         if expect_type == 'daemonsets':
             expect_daemonset(cluster, config['daemonsets']['list'],
-                             timeout=config['daemonsets'].get('timeout', plugins_timeout),
-                             retries=config['daemonsets'].get('retries', plugins_retries))
+                             timeout=config['daemonsets'].get('timeout'),
+                             retries=config['daemonsets'].get('retries'))
 
         elif expect_type == 'replicasets':
             expect_replicaset(cluster, config['replicasets']['list'],
-                              timeout=config['replicasets'].get('timeout', plugins_timeout),
-                              retries=config['replicasets'].get('retries', plugins_retries))
+                              timeout=config['replicasets'].get('timeout'),
+                              retries=config['replicasets'].get('retries'))
 
         elif expect_type == 'statefulsets':
             expect_statefulset(cluster, config['statefulsets']['list'],
-                               timeout=config['statefulsets'].get('timeout', plugins_timeout),
-                               retries=config['statefulsets'].get('retries', plugins_retries))
+                               timeout=config['statefulsets'].get('timeout'),
+                               retries=config['statefulsets'].get('retries'))
 
         elif expect_type == 'deployments':
             expect_deployment(cluster, config['deployments']['list'],
-                              timeout=config['deployments'].get('timeout', plugins_timeout),
-                              retries=config['deployments'].get('retries', plugins_retries))
+                              timeout=config['deployments'].get('timeout'),
+                              retries=config['deployments'].get('retries'))
 
         elif expect_type == 'pods':
-            expect_pods(cluster, config['pods']['list'],
-                        namespace=config['pods'].get('namespace'),
-                        timeout=config['pods'].get('timeout', plugins_timeout),
-                        retries=config['pods'].get('retries', plugins_retries))
+            expect_pods(cluster, config['pods']['list'], namespace=config['pods'].get('namespace'),
+                        timeout=config['pods'].get('timeout'),
+                        retries=config['pods'].get('retries'))
 
 
 # **** PYTHON ****

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -3,10 +3,10 @@ vrrp_ips: []
 globals: 
   nodes:
     ready:
-      timeout: '{{ globals.nodes.ready.timeout }}'
-      retries: '{{ globals.nodes.ready.retries }}'
+      timeout: 5
+      retries: 15
     boot:
-     timeout: '{{ globals.nodes.boot.defaults.timeout }}'
+     timeout: 600
 
 node_defaults: {}
 

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -1,5 +1,13 @@
 vrrp_ips: []
 
+globals: 
+  nodes:
+    ready:
+      timeout: '{{ globals.nodes.ready.timeout }}'
+      retries: '{{ globals.nodes.ready.retries }}'
+    boot:
+     timeout: '{{ globals.nodes.boot.defaults.timeout }}'
+
 node_defaults: {}
 
 nodes: []

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -417,9 +417,12 @@ plugins:
             deployments:
               - calico-kube-controllers
             pods:
-              - coredns
-              - calico-kube-controllers
-              - calico-node
+              list:
+                - coredns
+                - calico-kube-controllers
+                - calico-node
+              timeout: 5
+              retries: 150
         - thirdparty: /usr/bin/calicoctl
         - shell:
             command: mkdir -p /etc/calico

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -70,13 +70,9 @@ nodes:
     kubernetes_version:
       timeout: 10
       retries: 30
-  ready:
-    retries: 15
-    timeout: 5
   boot:
     reboot_command: 'reboot 2>/dev/null >/dev/null &'
     defaults:
-      timeout: 600
       delay_period: 5
   drain:
     timeout: 10

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -44,6 +44,10 @@ etcd:
 kubernetes:
   temporary_exceptions:
     - has prevented the request from succeeding
+deployments:
+  expect:
+    timeout: 5
+    retries: 30
 pods:
   allowed_failures: 10
   expect:

--- a/kubemarine/resources/schemas/cluster.json
+++ b/kubemarine/resources/schemas/cluster.json
@@ -2,6 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object",
   "properties": {
+    "globals": {
+      "$ref": "definitions/globals.json"
+    },
     "nodes": {
       "type": "array",
       "description": "Describe each node of the cluster.",

--- a/kubemarine/resources/schemas/definitions/globals.json
+++ b/kubemarine/resources/schemas/definitions/globals.json
@@ -11,10 +11,13 @@
   "definitions": {
     "Nodes": {
       "type": "object",
+      "description": "Section to hold mostly timeout-related settings, global for nodes",
       "additionalProperties": false,
       "properties": {
          "ready": {
            "type": "object",
+           "description": "Settings for Kubernetes nodes readiness check",
+           "additionalProperties": false,
            "properties": {
              "retries": {
                "type": "integer",
@@ -32,6 +35,8 @@
          },
          "boot": {
            "type": "object",
+           "description": "Nodes boot settings",
+           "additionalProperties": false,
            "properties": {
              "timeout": {
                "type": "integer",

--- a/kubemarine/resources/schemas/definitions/globals.json
+++ b/kubemarine/resources/schemas/definitions/globals.json
@@ -17,12 +17,14 @@
            "type": "object",
            "properties": {
              "retries": {
-               "type": ["string", "integer"],
-                "default": 30,
-                "description": "Number of retries for node readiness check"
+               "type": "integer",
+               "minimal": 1, 
+               "default": 30,
+               "description": "Number of retries for node readiness check"
              },
              "timeout": {
-               "type": ["string", "integer"],
+               "type": "integer",
+               "minimal": 1,
                "default": 5,
                "description": "Timeout for node readiness check in seconds"
              }
@@ -32,7 +34,8 @@
            "type": "object",
            "properties": {
              "timeout": {
-               "type": ["string", "integer"],
+               "type": "integer",
+               "minimal": 1,
                "default": 600,
                "description": "Timeout for node reboot in seconds"
              }

--- a/kubemarine/resources/schemas/definitions/globals.json
+++ b/kubemarine/resources/schemas/definitions/globals.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "description": "Section to hold the parameters which override global settings",
+  "additionalProperties": false,
+  "properties": {
+    "nodes": {
+      "$ref": "#/definitions/Nodes"
+    }
+  },
+  "definitions": {
+    "Nodes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+         "ready": {
+           "type": "object",
+           "properties": {
+             "retries": {
+               "type": "integer",
+                "minimum": 1,
+                "default": 30,
+                "description": "Number of retries for node readiness check"
+             },
+             "timeout": {
+               "type": "integer",
+               "minimum": 1,
+               "default": 5,
+               "description": "Timeout for node readiness check in seconds"
+             }
+           }
+         },
+         "boot": {
+           "type": "object",
+           "properties": {
+             "timeout": {
+               "type": "integer",
+               "minimum": 1,
+               "default": 600,
+               "description": "Timeout for node reboot in seconds"
+             }
+           }
+         }
+      }
+    }
+  }
+}

--- a/kubemarine/resources/schemas/definitions/globals.json
+++ b/kubemarine/resources/schemas/definitions/globals.json
@@ -17,14 +17,12 @@
            "type": "object",
            "properties": {
              "retries": {
-               "type": "integer",
-                "minimum": 1,
+               "type": ["string", "integer"],
                 "default": 30,
                 "description": "Number of retries for node readiness check"
              },
              "timeout": {
-               "type": "integer",
-               "minimum": 1,
+               "type": ["string", "integer"],
                "default": 5,
                "description": "Timeout for node readiness check in seconds"
              }
@@ -34,8 +32,7 @@
            "type": "object",
            "properties": {
              "timeout": {
-               "type": "integer",
-               "minimum": 1,
+               "type": ["string", "integer"],
                "default": 600,
                "description": "Timeout for node reboot in seconds"
              }

--- a/kubemarine/resources/schemas/definitions/node_defaults.json
+++ b/kubemarine/resources/schemas/definitions/node_defaults.json
@@ -53,31 +53,13 @@
         "gateway": {
           "type": "string",
           "description": "Gateway that should be used to connect to node(s)"
-        },
-        "ready_timeout": {
-          "type": "integer",
-          "minimum": 1,
-          "default": 5,
-          "description": "Timeout for node readiness check in seconds"
-        },
-        "ready_retries": {
-          "type": "integer",
-          "minimum": 1,
-          "default": 30,
-          "description": "Number of retries for node readiness check"
-        },
-        "boot_timeout": {
-          "type": "integer",
-          "minimum": 1,
-          "default": 600,
-          "description": "Timeout for node reboot in seconds"
         }
       }
     },
     "CommonNodePropertyNames": {
       "anyOf": [
         {"$ref": "#/definitions/SSHAccessCommonPropertyNames"},
-        {"enum": ["labels", "taints", "gateway", "ready_timeout", "ready_retries", "boot_timeout"]}
+        {"enum": ["labels", "taints", "gateway"]}
       ]
     }
   }

--- a/kubemarine/resources/schemas/definitions/node_defaults.json
+++ b/kubemarine/resources/schemas/definitions/node_defaults.json
@@ -53,13 +53,31 @@
         "gateway": {
           "type": "string",
           "description": "Gateway that should be used to connect to node(s)"
+        },
+        "ready_timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 5,
+          "description": "Timeout for node readiness check in seconds"
+        },
+        "ready_retries": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 30,
+          "description": "Number of retries for node readiness check"
+        },
+        "boot_timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 600,
+          "description": "Timeout for node reboot in seconds"
         }
       }
     },
     "CommonNodePropertyNames": {
       "anyOf": [
         {"$ref": "#/definitions/SSHAccessCommonPropertyNames"},
-        {"enum": ["labels", "taints", "gateway"]}
+        {"enum": ["labels", "taints", "gateway", "ready_timeout", "ready_retries", "boot_timeout"]}
       ]
     }
   }


### PR DESCRIPTION
### Description
Need to do the following improvements:
1. Add a separate timeout for expectation of daemonsets/deployments/replicasets/statefulsets readyness (now we have only one timeout pods.expect.plugins which is used for all of them and for pods).
2. Set higher default timeout for expectation of calico-node pods.
3. Add more sense in exception messages when daemonsets/deployments/replicasets/statefulsets/pods have not got ready within given timeouts (how to override default values of timeouts/retries).
4. Make some global timeouts configurable (nodes.ready, nodes.boot.defaults.timeout).

Fixes # (issue)
PSUPCLPL-11680
PSUPCLPL-11836
PSUPCLPL-11876

### Solution
1. New global parameter is introduced:
```
deployments:
  expect:
    timeout: 5
    retries: 30
```
which defines default values for `timeout` and `retries` in expectation of deployments/daemonsets/replicasets/statefulsets.

2. Increased number of retries in `expect.pods` for calico-node in defaults.yaml.

3. Exception messages in expect_* are updated.

4. New section `globals: {}` in cluster.yaml is introduced. It has the similar structure to `globals.yaml`, but user can override only these parameters. Now these are allowed:
```
globals:
  nodes:
    ready:
      timeout: 10
      retries: 50
    boot:
      timeout: 1000
```
Other parameters (for example, deployment or pods timeouts) can also be allowed if necessary.

Log messages in corresponding procedures are also updated with information about timeouts.

### How to apply
-

### Test Cases
1. Deploy k8s cluster with new parameters in cluster.yaml, for example:
```
node_defaults:
  username: "ubuntu"
  keyfile: "/home/nat/.ssh/shift-test.key"
  ready_timeout: 3
  ready_retries: 57
  boot_timeout: 876
```
ER: cluster is deployed successfully.

2. Try to add a node to the cluster from step 1.
ER: the node is added successfully, in debug.log there is a message like:
```
DEBUG [__init__.wait_for_nodes] Waiting for new kubernetes nodes to become ready, 57 retries every 3 seconds
```

3. Try to reboot nodes in the cluster.
ER: the nodes rebooted successfully, in debug log there is a message like:
```
VERBOSE [group._await_rebooted_nodes] Trying to connect to nodes, timeout is 876 seconds...
```

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


