### PR TITLE
MANOPD-85270 Fixes of reboot after restore

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -225,6 +225,7 @@ dnf -y install 'dnf-command(copr)'
 curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8/devel:kubic:libcontainers:stable.repo
 dnf -y --refresh install containerd
 dnf -y --refresh install podman
+systemctl enable containerd
 ```
 After the successful execution of the commands, it is necessary to complete the installation by excluding the **prepare.cri.install** task.
 

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -360,10 +360,10 @@ class NodeGroup:
 
         return group_result
 
-    def run(self, *args, **kwargs) -> NodeGroupResult or int:
+    def run(self, *args, **kwargs) -> Union[NodeGroupResult, int]:
         return self.do("run", *args, **kwargs)
 
-    def sudo(self, *args, **kwargs) -> NodeGroupResult or int:
+    def sudo(self, *args, **kwargs) -> Union[NodeGroupResult, int]:
         return self.do("sudo", *args, **kwargs)
 
     def put(self, local_file: Union[io.StringIO, str], remote_file: str, **kwargs):
@@ -474,7 +474,7 @@ class NodeGroup:
     def get(self, *args, **kwargs):
         return self.do("get", *args, **kwargs)
 
-    def do(self, do_type, *args, **kwargs) -> NodeGroupResult or int:
+    def do(self, do_type, *args, **kwargs) -> Union[NodeGroupResult, int]:
         raw_results = self._do_with_wa(do_type, *args, **kwargs)
         if isinstance(raw_results, int):
             return raw_results
@@ -485,7 +485,7 @@ class NodeGroup:
 
         return group_results
 
-    def _do_with_wa(self, do_type, *args, **kwargs) -> _HostToResult or int:
+    def _do_with_wa(self, do_type, *args, **kwargs) -> Union[_HostToResult, int]:
         # by default all code is async, but can be set False forcibly
         is_async = kwargs.pop("is_async", True) is not False
 
@@ -540,7 +540,7 @@ class NodeGroup:
 
         return True
 
-    def _do(self, do_type: str, nodes: Connections, is_async, *args, **kwargs) -> _HostToResult:
+    def _do(self, do_type: str, nodes: Connections, is_async, *args, **kwargs) -> Union[_HostToResult, int]:
 
         if do_type in ["run", "sudo"]:
             # by default fabric will print all output from nodes


### PR DESCRIPTION
### Description
* Restore fails with different connection errors during `reboot` task.
    * For RHEL8 on containerd, containerd is not started after reboot.
    * kube-apiserver / Haproxy / Keepalived might be not yet started just after reboot.

### Solution
* Check non-zero exit code in `kubernetes.wait_for_nodes`.
* Add manual step for RHEL8 to enable containerd.

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Any
- OS: RHEL8
- Inventory: Based on containerd

Steps:

1. Install taking into account manual prerequisites for RHEL8 nodes.
2. backup
3. restore

Results:

| Before | After |
| ------ | ------ |
| `kubectl` fails just after reboot in `restore` procedure | Success |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
