### PR TITLE
MANOPD-84442 Fix Blowfish deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,9 @@ dependencies = [
     "toml==0.10.*",
     "python-dateutil==2.8.*",
     "deepdiff==5.7.*",
-    "paramiko==2.9.*",
+    # cryptography is a transitive dependency of paramiko. Fix version to avoid unexpected deprecation warnings.
+    "cryptography==39.0.*",
+    "paramiko==2.11.*",
     "jsonschema==4.17.*",
 ]
 requires-python = ">=3.7"


### PR DESCRIPTION
### Description
* `CryptographyDeprecationWarning: Blowfish has been deprecated` is printed in any Kubemarine procedure.

### Solution
* Increase version of paramiko and freeze version of cryptography.

### Test Cases

1. Run any procedure.

AR: `CryptographyDeprecationWarning: Blowfish has been deprecated` is printed in console logs.

ER: No warnings.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
