### PR TITLE
[MANOPD-85375] CentOS kernel and Calico compatibility

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3445,6 +3445,8 @@ Before proceeding, refer to the [Official Documentation of the Kubernetes Cluste
 
 Calico plugin is installed by default and does not require any special enablement or configuration. However it is possible to explicitly enable or disable the installation of this plugin through the `install` plugin parameter.
 
+**Warning:** According to the Calico kernel requirements, CentOS7 with kernel lower than `3.10.0-940.el7.x86_64` is not compatible with Calico 3.24 and higher. More information: [Kubernetes requirements](https://docs.tigera.io/calico/3.24/getting-started/kubernetes/requirements#kubernetes-requirements)
+
 The following is an example to enable the calico plugin:
 
 ```yaml

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3445,7 +3445,7 @@ Before proceeding, refer to the [Official Documentation of the Kubernetes Cluste
 
 Calico plugin is installed by default and does not require any special enablement or configuration. However it is possible to explicitly enable or disable the installation of this plugin through the `install` plugin parameter.
 
-**Warning:** According to the Calico kernel requirements, CentOS 7 with kernel lower than `3.10.0-940.el7.x86_64` is not compatible with Calico 3.24 and higher. More information: [Kubernetes requirements](https://docs.tigera.io/calico/3.24/getting-started/kubernetes/requirements#kubernetes-requirements)
+**Warning**: According to the Calico kernel requirements, CentOS 7 with a kernel lower than `3.10.0-940.el7.x86_64` is not compatible with Calico 3.24 and higher. For more information, refer to [Kubernetes requirements](https://docs.tigera.io/calico/3.24/getting-started/kubernetes/requirements#kubernetes-requirements).
 
 The following is an example to enable the calico plugin:
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3445,7 +3445,7 @@ Before proceeding, refer to the [Official Documentation of the Kubernetes Cluste
 
 Calico plugin is installed by default and does not require any special enablement or configuration. However it is possible to explicitly enable or disable the installation of this plugin through the `install` plugin parameter.
 
-**Warning:** According to the Calico kernel requirements, CentOS7 with kernel lower than `3.10.0-940.el7.x86_64` is not compatible with Calico 3.24 and higher. More information: [Kubernetes requirements](https://docs.tigera.io/calico/3.24/getting-started/kubernetes/requirements#kubernetes-requirements)
+**Warning:** According to the Calico kernel requirements, CentOS 7 with kernel lower than `3.10.0-940.el7.x86_64` is not compatible with Calico 3.24 and higher. More information: [Kubernetes requirements](https://docs.tigera.io/calico/3.24/getting-started/kubernetes/requirements#kubernetes-requirements)
 
 The following is an example to enable the calico plugin:
 


### PR DESCRIPTION
### Description
* Kubernetes cluster installation on `CentOS` images (with kernel <= `3.10.0-940.el7.x86_64`) fails on `Calico` (version `v3.24+`) plugin installation due to the `eBPF` feature absence.


### Solution
* Update documentation


### How to apply
Not applicable


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


