### PR TITLE
[MANOPD-85605][MANOPD-85606] Fix template nginx-ingress-controller-v1.4.yaml.j2

### DIFF
--- a/kubemarine/templates/plugins/nginx-ingress-controller-v1.4.yaml.j2
+++ b/kubemarine/templates/plugins/nginx-ingress-controller-v1.4.yaml.j2
@@ -51,6 +51,7 @@ data:
 ---
 apiVersion: v1
 data:
+  allow-snippet-annotations: "true"
 {% if plugins['nginx-ingress-controller']['config_map'] is defined -%}
   {{ plugins['nginx-ingress-controller']['config_map'] | toyaml | indent(width=2, first=True) -}}
 {%- endif %}
@@ -61,7 +62,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.2.0
+    app.kubernetes.io/version: 1.4.0
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -368,20 +369,6 @@ subjects:
   namespace: ingress-nginx
 ---
 apiVersion: v1
-data:
-  allow-snippet-annotations: "true"
-kind: ConfigMap
-metadata:
-  labels:
-    app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.4.0
-  name: ingress-nginx-controller
-  namespace: ingress-nginx
----
-apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -471,6 +458,7 @@ spec:
         - --controller-class=k8s.io/ingress-nginx
         - --ingress-class=nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
+        - --watch-ingress-without-class=true
         {% if plugins['nginx-ingress-controller']['controller']['ssl']['enableSslPassthrough'] is true -%}
         - --enable-ssl-passthrough
         {%- endif %}
@@ -585,8 +573,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: {% if plugins['nginx-ingress-controller']['installation']['registry'] is defined and plugins['nginx-ingress-controller']['installation']['registry']|length %}{{
-        plugins['nginx-ingress-controller']['installation']['registry'] }}/{% endif %}{{ plugins['nginx-ingress-controller']['webhook']['image'] }}
+        image: {% if plugins['nginx-ingress-controller']['installation']['registry'] is defined and plugins['nginx-ingress-controller']['installation']['registry']|length %}{{ plugins['nginx-ingress-controller']['installation']['registry'] }}/{% endif %}{{ plugins['nginx-ingress-controller']['webhook']['image'] }}
         imagePullPolicy: IfNotPresent
         name: create
         securityContext:
@@ -660,6 +647,8 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/version: 1.4.0
   name: nginx
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
 spec:
   controller: k8s.io/ingress-nginx
 ---


### PR DESCRIPTION
### Description
There is no annotation `ingressclass.kubernetes.io/is-default-class: "true"` in IngressClass nginx.
Custom values form `config_map` are not configured in ConfigMap `ingress-nginx-controller`
There is no flag `--watch-ingress-without-class=true` in DaemonSet ingress-nginx-controller.

Fixes # (issue)
MANOPD-85605
MANOPD-85606

### Solution
Adjust template nginx-ingress-controller-v1.4.yaml.j2

### How to apply
Run `deploy.plugins` task.

### Test Cases
Add `config_map` part to cluster.yaml, for example:
```
plugins:
  nginx-ingress-controller:
    install: true
    config_map:
      proxy-buffer-size: 64k
      client-max-body-size: 200m
...
```
Run `deploy.plugins` task at a cluster with k8s v1.25.* with nginx-ingress-controller plugin `install: true`.

ER: ingress-nginx-controller plugin is deployed successfully. 
There is annotation `ingressclass.kubernetes.io/is-default-class: "true"` in IngressClass nginx.
Custom values form `config_map` are added to ConfigMap `ingress-nginx-controller`.
There is a flag `--watch-ingress-without-class=true` in DaemonSet ingress-nginx-controller.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


