### PR TITLE
[PDSDNREQ-7070] HAproxy running with Root, should move to non-root

### DIFF
--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -23,8 +23,10 @@ from typing import List
 
 from kubemarine.core.patch import Patch
 from kubemarine.patches.p1_fix_nginx_ingress_k8s_1_25_x import FixNginxIngress
+from kubemarine.patches.p2_fix_haproxy_user import FixHaproxy
 
 patches: List[Patch] = [
     FixNginxIngress(),
+    FixHaproxy(),
 ]
 """List of patches which can be executed strictly in the declared order"""

--- a/kubemarine/patches/p2_fix_haproxy_user.py
+++ b/kubemarine/patches/p2_fix_haproxy_user.py
@@ -1,0 +1,54 @@
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from textwrap import dedent
+
+from kubemarine.core import flow
+from kubemarine.core.action import Action
+from kubemarine.core.patch import Patch
+from kubemarine.core.resources import DynamicResources
+from kubemarine.procedures import install
+
+
+class TheAction(Action):
+    def __init__(self):
+        super().__init__("Correct haproxy user")
+
+    def run(self, res: DynamicResources):
+        cluster = res.cluster()
+        if not cluster.nodes.get('balancer'):
+            cluster.log.info("Skip no balancer nodes.")
+            return
+
+        cluster.log.info(f"The following loadbalancer will be configure: haproxy")
+        flow.run_tasks(res, install.tasks, cumulative_points=install.cumulative_points,
+                       tasks_filter=['deploy.loadbalancer.haproxy.configure'])
+
+
+
+class FixHaproxy(Patch):
+    def __init__(self):
+        super().__init__("correct_haproxy_user")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            Reconfigure loadbalancer haproxy for kubernetes clusters using corrected template.
+            """.rstrip()
+        )

--- a/kubemarine/templates/haproxy.cfg.j2
+++ b/kubemarine/templates/haproxy.cfg.j2
@@ -1,5 +1,7 @@
 global
     log                 127.0.0.1 local2 debug
+    user haproxy
+    group haproxy
 
 defaults
     log                 global


### PR DESCRIPTION
### Description
* On the cluster, Haproxy runs from root, you need to make it run not from root, but from the haproxy user

Fixes # (issue)
PDSDNREQ-7070

### Solution
* Add new user and group parameters to `haproxy.cfg`

```
global
    log                 127.0.0.1 local2 debug
    user haproxy
    group haproxy
```
### How to apply
run
```
kubemarine install --tasks="deploy.loadbalancer.haproxy.configure"
```
or 

use patch `p2_fix_haproxy_user.py`

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: Ubuntu 20.04, 22.04, Centos 7
- Inventory: 

Steps:

1. 

Results:

| Before | After |
| ------ | ------ |
| Haproxy running with Root | Haproxy running with non-Root |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts
