### PR TITLE
PSUPCLPL-11975 -Update thirdparties.py

### DIFF
--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -201,16 +201,23 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
         if extension == 'zip':
             cluster.log.verbose('Unzip will be used for unpacking')
             remote_commands += ' && sudo unzip -o %s -d %s' % (destination, config['unpack'])
+            
+            remote_commands += ' && sudo chmod  %s %s' \
+                   % (config['mode'], config['unpack'])
+            remote_commands += ' && sudo chown -R %s %s' \
+                   % (config['owner'], config['unpack'])
+            remote_commands += ' && sudo ls -la %s' % (config['unpack'])
+            
         else:
             cluster.log.verbose('Tar will be used for unpacking')
             remote_commands += ' && sudo tar -zxf %s -C %s' % (destination, config['unpack'])
-
-        # TODO access rights do not work for zip
-        remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chmod %s %s/FILE' \
+            
+            remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chmod %s %s/FILE' \
                            % (destination, config['mode'], config['unpack'])
-        remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chown %s %s/FILE' \
+            remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chown %s %s/FILE' \
                            % (destination, config['owner'], config['unpack'])
-        remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo ls -la %s/FILE' % (destination, config['unpack'])
+            remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo ls -la %s/FILE' % (destination, config['unpack'])
+        
 
     return common_group.sudo(remote_commands)
 

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -200,8 +200,7 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
         extension = destination.split('.')[-1]
         if extension == 'zip':
             cluster.log.verbose('Unzip will be used for unpacking')
-            # TODO re-installation waits forever
-            remote_commands += ' && sudo unzip %s -d %s' % (destination, config['unpack'])
+            remote_commands += ' && sudo unzip -o %s -d %s' % (destination, config['unpack'])
         else:
             cluster.log.verbose('Tar will be used for unpacking')
             remote_commands += ' && sudo tar -zxf %s -C %s' % (destination, config['unpack'])


### PR DESCRIPTION
### Description
Fix the waiting forever while re-installation of third parties.
* 

Fixes # (issue)


### Solution
* Adding parameter to **overwrite** the existing third parties which will prevent the code to go into forever waiting.
* Adding additional code for adding proper file _permission_ and _ownership_ after unpacking of .**zip** archives


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase **

Run the re-installation of thirdparties using below command-
`kubemarine install --tasks prepare.thirdparties`


Results:

| Before | After |
| ------ | ------ |
| Thirdparties re-installation went into infinite waiting loop | Thirdparties re-installation was successful. |
| .zip archives are not getting required ownership and file permissions after unpacking | .zip archives are getting required ownership and file permissions after unpacking|


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


