### PR TITLE
increase deployments.expect.retries

### DIFF
--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -47,7 +47,7 @@ kubernetes:
 deployments:
   expect:
     timeout: 5
-    retries: 30
+    retries: 45
 pods:
   allowed_failures: 10
   expect:


### PR DESCRIPTION
### Description
Old value of  `deployments.expect.retries` (30) is not enough to calico daemonset get up.

Fixes # (issue)


### Solution
change `deployments.expect.retries` to 45 as it were for `pods.expect.plugins.retries`.

### How to apply
-

### Test Cases
Run install job with `tasks=deploy.plugins`.
ER: plugins are installed successfully, timeout for daemonsets, deployments, statefulsets is 5*45=220s.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


