### PR TITLE
PSUPCLPL-11975 - Fix for issue #365

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2190,7 +2190,7 @@ This is configured in the `services.thirdparties` section. The contents of this 
 |**sha1**|no|`None`|SHA1 hash of the file. It is necessary in order to check with an existing file on the hosts and decide whether to download the file or not.|
 |**owner**|no|`root`|The owner who needs to be assigned to the file after downloading it.|
 |**mode**|no|`700`|The mode which needs to be assigned to the file after downloading it.|
-|**unpack**|no|`None`|Absolute path on hosts where to unpack the downloaded file. Unpacking is supported only for the following file extensions: `.tar`, `.gz` and `.zip`.|
+|**unpack**|no|`None`|Absolute path on hosts where to unpack the downloaded file. Unpacking is supported only for the following file extensions: `.tar.gz` and `.zip`.|
 |**group**|no|`None`|The name of the group to whose hosts the file should be uploaded.|
 |**groups**|no|`None`|The list of group names to whose hosts the file should be uploaded.|
 |**node**|no|`None`|The name of node where the file should be uploaded.|

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -387,7 +387,7 @@ def thirdparties_hashes(cluster):
                 unpack_dir = config['unpack']
                 extension = path.split('.')[-1]
                 if extension == 'zip': 
-                    res = group.sudo(' unzip -l %s | grep -v /$ | grep -vw -e Name -e "----" | awk \'NF > 3 { print $4 }\' | while read file_name; do '  # for each file in archive
+                    res = group.sudo(' unzip -qq -l %s | awk \'NF > 3 { print $4 }\' | while read file_name; do '  # for each file in archive
                                  '  echo ${file_name} '  # print   1) filename
                                  '    $(sudo unzip -p %s ${file_name} | openssl sha1 | cut -d\\  -f2) '  # 2) sha archive
                                  '    $(sudo openssl sha1 %s/${file_name} | cut -d\\  -f2); '  # 3) sha unpacked

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -385,12 +385,20 @@ def thirdparties_hashes(cluster):
             # SHA is correct, now check if it is an archive and if it does, then also check SHA for archive content
             if 'unpack' in config:
                 unpack_dir = config['unpack']
-                # TODO support zip
-                res = group.sudo('tar tf %s | grep -vw "./" | while read file_name; do '  # for each file in archive
+                arr = path.split(".") 
+                if len(arr) == 2: 
+                    res = group.sudo(' unzip -l %s | grep -v /$ | grep -vw -e Name -e "----" | awk \'NF > 3 { print $4 }\' | while read file_name; do '  # for each file in archive
+                                 '  echo ${file_name} '  # print   1) filename
+                                 '    $(sudo unzip -p %s ${file_name} | openssl sha1 | cut -d\\  -f2) '  # 2) sha archive
+                                 '    $(sudo openssl sha1 %s/${file_name} | cut -d\\  -f2); '  # 3) sha unpacked
+                                 'done' % (path, path, unpack_dir)) 
+                else :
+                    res = group.sudo('tar tf %s | grep -vw "./" | while read file_name; do '  # for each file in archive
                                  '  echo ${file_name} '  # print   1) filename
                                  '    $(sudo tar xfO %s ${file_name} | openssl sha1 | cut -d\\  -f2) '  # 2) sha archive
                                  '    $(sudo openssl sha1 %s/${file_name} | cut -d\\  -f2); '  # 3) sha unpacked
                                  'done' % (path, path, unpack_dir))
+                
                 # for each file on each host, verify that SHA in archive is equal to SHA for unpacked
                 for host, result in res.items():
                     if result.failed:

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -385,8 +385,8 @@ def thirdparties_hashes(cluster):
             # SHA is correct, now check if it is an archive and if it does, then also check SHA for archive content
             if 'unpack' in config:
                 unpack_dir = config['unpack']
-                arr = path.split(".") 
-                if len(arr) == 2: 
+                extension = path.split('.')[-1]
+                if extension == 'zip': 
                     res = group.sudo(' unzip -l %s | grep -v /$ | grep -vw -e Name -e "----" | awk \'NF > 3 { print $4 }\' | while read file_name; do '  # for each file in archive
                                  '  echo ${file_name} '  # print   1) filename
                                  '    $(sudo unzip -p %s ${file_name} | openssl sha1 | cut -d\\  -f2) '  # 2) sha archive

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -202,9 +202,9 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
             cluster.log.verbose('Unzip will be used for unpacking')
             remote_commands += ' && sudo unzip -o %s -d %s' % (destination, config['unpack'])
             
-            remote_commands += ' && sudo unzip -l %s | grep -v /$ | grep -vw -e Name -e "----" | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo chmod -R %s %s/FILE' \
+            remote_commands += ' && sudo unzip -qq -l %s | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo chmod -R %s %s/FILE' \
                    % (destination, config['mode'], config['unpack'])
-            remote_commands += ' && sudo unzip -l %s | grep -v /$ | grep -vw -e Name -e "----" | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo chown -R %s %s/FILE' \
+            remote_commands += ' && sudo unzip -qq -l %s | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo chown -R %s %s/FILE' \
                    % (destination, config['owner'], config['unpack'])
             remote_commands += ' && sudo ls -la %s' % (config['unpack'])
             

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -202,10 +202,10 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
             cluster.log.verbose('Unzip will be used for unpacking')
             remote_commands += ' && sudo unzip -o %s -d %s' % (destination, config['unpack'])
             
-            remote_commands += ' && sudo chmod -R %s %s/*' \
-                   % (config['mode'], config['unpack'])
-            remote_commands += ' && sudo chown -R %s %s/*' \
-                   % (config['owner'], config['unpack'])
+            remote_commands += ' && sudo unzip -l %s | grep -v /$ | grep -vw -e Name -e "----" | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo chmod -R %s %s/FILE' \
+                   % (destination, config['mode'], config['unpack'])
+            remote_commands += ' && sudo unzip -l %s | grep -v /$ | grep -vw -e Name -e "----" | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo chown -R %s %s/FILE' \
+                   % (destination, config['owner'], config['unpack'])
             remote_commands += ' && sudo ls -la %s' % (config['unpack'])
             
         else:

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -206,7 +206,7 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
                    % (destination, config['mode'], config['unpack'])
             remote_commands += ' && sudo unzip -qq -l %s | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo chown -R %s %s/FILE' \
                    % (destination, config['owner'], config['unpack'])
-            remote_commands += ' && sudo unzip -qq -l %s | awk \'NF > 3 { print $4 }'\| xargs -I FILE sudo ls -la %s/FILE' % (destination, config['unpack'])
+            remote_commands += ' && sudo unzip -qq -l %s | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo ls -la %s/FILE' % (destination, config['unpack'])
             
         else:
             cluster.log.verbose('Tar will be used for unpacking')

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -206,7 +206,7 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
                    % (destination, config['mode'], config['unpack'])
             remote_commands += ' && sudo unzip -qq -l %s | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo chown -R %s %s/FILE' \
                    % (destination, config['owner'], config['unpack'])
-            remote_commands += ' && sudo ls -la %s' % (config['unpack'])
+            remote_commands += ' && sudo unzip -qq -l %s | awk \'NF > 3 { print $4 }'\| xargs -I FILE sudo ls -la %s/FILE' % (destination, config['unpack'])
             
         else:
             cluster.log.verbose('Tar will be used for unpacking')

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -202,9 +202,9 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
             cluster.log.verbose('Unzip will be used for unpacking')
             remote_commands += ' && sudo unzip -o %s -d %s' % (destination, config['unpack'])
             
-            remote_commands += ' && sudo chmod -R %s %s/' \
+            remote_commands += ' && sudo chmod -R %s %s/*' \
                    % (config['mode'], config['unpack'])
-            remote_commands += ' && sudo chown -R %s %s/' \
+            remote_commands += ' && sudo chown -R %s %s/*' \
                    % (config['owner'], config['unpack'])
             remote_commands += ' && sudo ls -la %s' % (config['unpack'])
             

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -202,7 +202,7 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
             cluster.log.verbose('Unzip will be used for unpacking')
             remote_commands += ' && sudo unzip -o %s -d %s' % (destination, config['unpack'])
             
-            remote_commands += ' && sudo unzip -qq -l %s | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo chmod -R %s %s/FILE' \
+            remote_commands += ' && sudo unzip -qq -l %s | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo chmod %s %s/FILE' \
                    % (destination, config['mode'], config['unpack'])
             remote_commands += ' && sudo unzip -qq -l %s | awk \'NF > 3 { print $4 }\'| xargs -I FILE sudo chown -R %s %s/FILE' \
                    % (destination, config['owner'], config['unpack'])

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -202,9 +202,9 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
             cluster.log.verbose('Unzip will be used for unpacking')
             remote_commands += ' && sudo unzip -o %s -d %s' % (destination, config['unpack'])
             
-            remote_commands += ' && sudo chmod  %s %s' \
+            remote_commands += ' && sudo chmod -R %s %s/' \
                    % (config['mode'], config['unpack'])
-            remote_commands += ' && sudo chown -R %s %s' \
+            remote_commands += ' && sudo chown -R %s %s/' \
                    % (config['owner'], config['unpack'])
             remote_commands += ' && sudo ls -la %s' % (config['unpack'])
             

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -200,18 +200,24 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> NodeGroupRe
         extension = destination.split('.')[-1]
         if extension == 'zip':
             cluster.log.verbose('Unzip will be used for unpacking')
-            # TODO re-installation waits forever
-            remote_commands += ' && sudo unzip %s -d %s' % (destination, config['unpack'])
+            remote_commands += ' && sudo unzip -o %s -d %s' % (destination, config['unpack'])
+            
+            remote_commands += ' && sudo chmod  %s %s' \
+                   % (config['mode'], config['unpack'])
+            remote_commands += ' && sudo chown -R %s %s' \
+                   % (config['owner'], config['unpack'])
+            remote_commands += ' && sudo ls -la %s' % (config['unpack'])
+            
         else:
             cluster.log.verbose('Tar will be used for unpacking')
             remote_commands += ' && sudo tar -zxf %s -C %s' % (destination, config['unpack'])
-
-        # TODO access rights do not work for zip
-        remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chmod %s %s/FILE' \
+            
+            remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chmod %s %s/FILE' \
                            % (destination, config['mode'], config['unpack'])
-        remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chown %s %s/FILE' \
+            remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo chown %s %s/FILE' \
                            % (destination, config['owner'], config['unpack'])
-        remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo ls -la %s/FILE' % (destination, config['unpack'])
+            remote_commands += ' && sudo tar -tf %s | xargs -I FILE sudo ls -la %s/FILE' % (destination, config['unpack'])
+
 
     return common_group.sudo(remote_commands)
 


### PR DESCRIPTION
### Description
* Fix the waiting forever while re-installation of third parties.
* Fix the `owner` and `mode` option for .zip thirdparties 
* Add check SHA of zip archive content.

Fixes # (issue)
https://github.com/Netcracker/KubeMarine/issues/365

### Solution
* Adding parameter to **overwrite** the existing third parties which will prevent the code to go into forever waiting.
* Adding additional code for adding proper file _permission_ and _ownership_ after unpacking of .**zip** archives
* Adding additional code for verifying the **hash (SHA1)** for **zip archive** contents before and after unpacking.


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase **

1. Run the re-installation of thirdparties using below command-
`kubemarine install --tasks prepare.thirdparties`
2. Verify SHA1 hash for zip thirdpaties arcvhies using below command-
`kubemarine check_paas --task thirdparties`


Results:

| Before | After |
| ------ | ------ |
| Thirdparties re-installation went into infinite waiting loop | Thirdparties re-installation was successful. |
| .zip archives are not getting required ownership and file permissions after unpacking | .zip archives are getting required ownership and file permissions after unpacking|
| SHA1 for zip archive content is failed to verify with error as "_can not verify files SHA for archive_" | SHA1 for zip archive content is successfully verified |
