### PR TITLE
[MANOPD-86195] K8s 1.26.3 support

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -6323,3 +6323,175 @@ The tables below shows the correspondence of versions that are supported and is 
   </tr>
 </tbody>
 </table>
+
+
+## Default Dependent Components Versions for Kubernetes Versions v1.26.3
+
+<table style="undefined;table-layout: fixed; width: 1167px">
+<colgroup>
+<col style="width: 60px">
+<col style="width: 389px">
+<col style="width: 128px">
+<col style="width: 119px">
+<col style="width: 99px">
+<col style="width: 100px">
+<col style="width: 272px">
+</colgroup>
+<thead>
+  <tr>
+    <th rowspan="2">Type</th>
+    <th rowspan="2">Name</th>
+    <th colspan="5">Versions</th>
+    <th rowspan="2">Note</th>
+  </tr>
+  <tr>
+    <th>CentOS RHEL<br>7.5+</th>
+    <th>CentOS RHEL<br>Oracle Linux 8.4</th>
+    <th>Ubuntu 20.04</th>
+    <th>Ubuntu 22.04</th>
+    <th>Oracle Linux 7.5+</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td rowspan="5">binaries</td>
+    <td>kubeadm</td>
+    <td colspan="5" rowspan="3">v1.26.3</td>
+    <td>SHA1: 86e202f98d22c8fddcadda6656f6698d21eae6ca</td>
+  </tr>
+  <tr>
+    <td>kubelet</td>
+    <td>SHA1: 5fe320fedaabb91d3770da19135412b7454bb28b</td>
+  </tr>
+  <tr>
+    <td>kubectl</td>
+    <td>SHA1: 56916d87c3caef05489db932fd9e48d32ebdf634</td>
+  </tr>
+  <tr>
+    <td>calicoctl</td>
+    <td colspan="5">v3.24.2</td>
+    <td>SHA1: c4de7a203e5a3a942fdf130bc9ec180111fc2ab6<br>Required only if calico is installed.</td>
+  </tr>
+  <tr>
+    <td>crictl</td>
+    <td colspan="5">v1.25.0</td>
+    <td>SHA1: b3a24e549ca3b4dfd105b7f4639014c0c508bea3<br>Required only if containerd is used as a container runtime.</td>
+  </tr>
+  <tr>
+    <td rowspan="5">rpms</td>
+    <td>docker-ce</td>
+    <td colspan="5">20.10</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>containerd.io</td>
+    <td>1.6.*</td>
+    <td>1.6.*</td>
+    <td>1.5.*</td>
+    <td>1.5.*</td>				  
+    <td>1.6.*</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>podman</td>
+    <td>1.6.4</td>
+    <td>latest</td>
+    <td>latest</td>
+    <td>latest</td>				   
+    <td>1.4.4</td>
+    <td>Required only if containerd is used as a container runtime.</td>
+  </tr>
+  <tr>
+    <td>haproxy/rh-haproxy</td>
+    <td>1.8</td>
+    <td>1.8</td>
+    <td>2.*</td>
+    <td>2.*</td>
+    <td>1.8</td>
+    <td>Required only if balancers are presented in the deployment scheme.</td>
+  </tr>
+  <tr>
+    <td>keepalived</td>
+    <td>1.3</td>
+    <td>2.1</td>
+    <td>2.*</td>
+    <td>2.*</td>
+    <td>1.3</td>
+    <td>Required only if VRRP is presented in the deployment scheme.</td>
+  </tr>
+  <tr>
+    <td rowspan="16">images</td>
+    <td>k8s.gcr.io/kube-apiserver</td>
+    <td colspan="5" rowspan="4">v1.26.3</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>k8s.gcr.io/kube-controller-manager</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>k8s.gcr.io/kube-proxy</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>k8s.gcr.io/kube-scheduler</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>k8s.gcr.io/coredns</td>
+    <td colspan="5">v1.9.3</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>k8s.gcr.io/pause</td>
+    <td colspan="5">3.9</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>k8s.gcr.io/etcd</td>
+    <td colspan="5">3.5.6-0</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>calico/typha</td>
+    <td colspan="5" rowspan="5">v3.24.2</td>
+    <td>Required only if Typha is enabled in Calico config.</td>
+  </tr>
+  <tr>
+    <td>calico/cni</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>calico/node</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>calico/kube-controllers</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>calico/pod2daemon-flexvol</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>quay.io/kubernetes-ingress-controller/nginx-ingress-controller</td>
+    <td colspan="5">v1.4.0</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>kubernetesui/dashboard</td>
+    <td colspan="5">v2.7.0</td>
+    <td>Required only if Kubernetes Dashboard plugin is set to be installed.</td>
+  </tr>
+  <tr>
+    <td>kubernetesui/metrics-scraper</td>
+    <td colspan="5">v1.0.8</td>
+    <td>Required only if Kubernetes Dashboard plugin is set to be installed.</td>
+  </tr>
+  <tr>
+    <td>rancher/local-path-provisioner</td>
+    <td colspan="5">v0.0.23</td>
+    <td>Required only if local-path provisioner plugin is set to be installed.</td>
+  </tr>
+</tbody>
+</table>

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -322,7 +322,7 @@ compatibility_map:
       v1.26.3:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.5.*
+        version_debian: 1.6.*
     podman:
       v1.21.2:
         version_rhel: 1.6.4*

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -269,7 +269,7 @@ compatibility_map:
         version_debian: 1.5.*
       v1.26.3:
         version_rhel8: 1.4*
-        version_debian: 1.5.*
+        version_debian: 1.6.*
     containerdio:
       v1.21.2:
         version_rhel: 1.6*

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -9,6 +9,8 @@ kubernetes_versions:
     supported: true
   v1.25:
     supported: true
+  v1.26:
+    supported: true
 
 connection:
   defaults:
@@ -223,7 +225,11 @@ compatibility_map:
       v1.25.7:
         version_rhel: 19.03*
         version_rhel8: 19.03*
-        version_debian: 5:20.10.*        
+        version_debian: 5:20.10.*
+      v1.26.3:
+        version_rhel: 19.03*
+        version_rhel8: 19.03*
+        version_debian: 5:20.10.*
     containerd:
       v1.21.2:
         version_rhel: 1.4*
@@ -259,6 +265,9 @@ compatibility_map:
         version_rhel8: 1.4*
         version_debian: 1.5.*
       v1.25.7:
+        version_rhel8: 1.4*
+        version_debian: 1.5.*
+      v1.26.3:
         version_rhel8: 1.4*
         version_debian: 1.5.*
     containerdio:
@@ -307,6 +316,10 @@ compatibility_map:
         version_rhel8: 1.6*
         version_debian: 1.5.*
       v1.25.7:
+        version_rhel: 1.6*
+        version_rhel8: 1.6*
+        version_debian: 1.5.*
+      v1.26.3:
         version_rhel: 1.6*
         version_rhel8: 1.6*
         version_debian: 1.5.*
@@ -359,6 +372,10 @@ compatibility_map:
         version_rhel: 1.6.4*
         version_rhel8: "*"
         version_debian: "*"
+      v1.26.3:
+        version_rhel: 1.6.4*
+        version_rhel8: "*"
+        version_debian: "*"
     haproxy:
       v1.21.2:
         version_rhel: 1.8*
@@ -405,6 +422,10 @@ compatibility_map:
         version_rhel8: 1.8*
         version_debian: 2.*
       v1.25.7:
+        version_rhel: 1.8*
+        version_rhel8: 1.8*
+        version_debian: 2.*
+      v1.26.3:
         version_rhel: 1.8*
         version_rhel8: 1.8*
         version_debian: 2.*
@@ -457,6 +478,10 @@ compatibility_map:
         version_rhel: 1.3*
         version_rhel8: 2.1*
         version_debian: 1:2.*
+      v1.26.3:
+        version_rhel: 1.3*
+        version_rhel8: 2.1*
+        version_debian: 1:2.*
     crictl:
       v1.21.2:
         version: v1.23.0
@@ -494,6 +519,9 @@ compatibility_map:
       v1.25.7:
         version: v1.25.0
         sha1: b3a24e549ca3b4dfd105b7f4639014c0c508bea3
+      v1.26.3:
+        version: v1.25.0
+        sha1: b3a24e549ca3b4dfd105b7f4639014c0c508bea3
     kubeadm:
       v1.21.2:
         sha1: cbb07d380de4ef73d43d594a1055839fa9753138
@@ -519,6 +547,8 @@ compatibility_map:
         sha1: 72b87eedc9701c1143126f4aa7375b91fc9d46fc
       v1.25.7:
         sha1: 4efb3da49a50d137b728f0529bedee458e8c5f86
+      v1.26.3:
+        sha1: 86e202f98d22c8fddcadda6656f6698d21eae6ca
     kubelet:
       v1.21.2:
         sha1: 024e458aa0f74cba6b773401b779590437812fc6
@@ -543,7 +573,9 @@ compatibility_map:
       v1.25.2:
         sha1: afdc009cd59759626ecce007667f42bf42e7c1be 
       v1.25.7:
-        sha1: ace8ce244896aca5d38c8184c44226660a09269a 
+        sha1: ace8ce244896aca5d38c8184c44226660a09269a
+      v1.26.3:
+        sha1: 5fe320fedaabb91d3770da19135412b7454bb28b
     kubectl:
       v1.21.2:
         sha1: 2c7a7de9fff41ac49f7c2546a9b1aff2c1d9c468
@@ -569,6 +601,8 @@ compatibility_map:
         sha1: b12c0e102df89cd0579c8a3c769988aaf5dbe4ba
       v1.25.7:
         sha1: a5b32c173670ee6fa7710d7158ea4a0d198c8af5
+      v1.26.3:
+        sha1: 56916d87c3caef05489db932fd9e48d32ebdf634
     calico:
       v1.21:
         version: v3.22.2
@@ -584,7 +618,10 @@ compatibility_map:
         sha1: c4de7a203e5a3a942fdf130bc9ec180111fc2ab6 
       v1.25:
         version: v3.24.2
-        sha1: c4de7a203e5a3a942fdf130bc9ec180111fc2ab6 
+        sha1: c4de7a203e5a3a942fdf130bc9ec180111fc2ab6
+      v1.26:
+        version: v3.24.2
+        sha1: c4de7a203e5a3a942fdf130bc9ec180111fc2ab6
     nginx-ingress-controller:
       v1.21:
         image-name: ingress-nginx/controller
@@ -608,6 +645,12 @@ compatibility_map:
         pod-name: ingress-nginx-controller
         webhook-image-name: ingress-nginx/kube-webhook-certgen
         webhook-version: v20220916-gd32f8c343
+      v1.26:
+        image-name: ingress-nginx/controller
+        version: v1.4.0
+        pod-name: ingress-nginx-controller
+        webhook-image-name: ingress-nginx/kube-webhook-certgen
+        webhook-version: v20220916-gd32f8c343
     kubernetes-dashboard:
       v1.21:
         version: v2.5.1
@@ -624,6 +667,9 @@ compatibility_map:
       v1.25:
         version: v2.7.0
         metrics-scraper-version: v1.0.8
+      v1.26:
+        version: v2.7.0
+        metrics-scraper-version: v1.0.8
     local-path-provisioner:
       v1.21:
         version: v0.0.22
@@ -634,6 +680,8 @@ compatibility_map:
       v1.24:
         version: v0.0.22
       v1.25:
+        version: v0.0.23
+      v1.26:
         version: v0.0.23
     busybox:
       v1.21:
@@ -646,6 +694,8 @@ compatibility_map:
         version: 1.34.1
       v1.25:
         version: 1.34.1
+      v1.26:
+        version: 1.34.1
     pause:
       v1.21:
         version: 3.4.1
@@ -657,6 +707,8 @@ compatibility_map:
         version: 3.7
       v1.25:
         version: 3.8
+      v1.26:
+        version: 3.9
 
   hardware:
     minimal:


### PR DESCRIPTION
### Description
* It is necessary to add support for the new version of kubernetes in kubemarine
* Kubernetes 1.26.3 support

### Solution
* Added support for kubernetes version 1.26 in kubemarine
* Updated global.yaml
* Update Installation.md


### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: All-one
- OS: Centos,Ubuntu
- Inventory: Default 

Steps:

1. Install

Results:

| Before | After |
| ------ | ------ |
| Not supported new version |  Supported new version |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


