### PR TITLE
[MANOPD-85659 ]Update Containerd version for all supported Kubernetes

### DIFF
--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -257,16 +257,16 @@ compatibility_map:
         version_debian: 1.5.*        
       v1.24.2:
         version_rhel8: 1.4*
-        version_debian: 1.5.*
+        version_debian: 1.6.*
       v1.24.11:
         version_rhel8: 1.4*
-        version_debian: 1.5.*
+        version_debian: 1.6.*
       v1.25.2:
-        version_rhel8: 1.4*
-        version_debian: 1.5.*
+        version_rhel8: 1.6*
+        version_debian: 1.6.*
       v1.25.7:
         version_rhel8: 1.4*
-        version_debian: 1.5.*
+        version_debian: 1.6.*
       v1.26.3:
         version_rhel8: 1.4*
         version_debian: 1.6.*
@@ -306,19 +306,19 @@ compatibility_map:
       v1.24.2:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.5.*
+        version_debian: 1.6.*
       v1.24.11:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.5.*
+        version_debian: 1.6.*
       v1.25.2:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.5.*
+        version_debian: 1.6.*
       v1.25.7:
         version_rhel: 1.6*
         version_rhel8: 1.6*
-        version_debian: 1.5.*
+        version_debian: 1.6.*
       v1.26.3:
         version_rhel: 1.6*
         version_rhel8: 1.6*


### PR DESCRIPTION
### Description
Please include a summary of the change and describe issue. Please also include relevant motivation and context.
* It is necessary to update the containerd version, as the support matrix for containerd has been updated [https://containerd.io/releases/#kubernetes-support](url) 

Fixes # (issue)
[MANOPD-85659]

### Solution
* Globals.yaml has been updated

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: All-in-one
- OS: Ubuntu 20.04, Ubuntu 22.04, Centos 7
- Inventory: Default

Steps:

1. Install

Results:

| Before | After |
| ------ | ------ |
| old version containerd| new version containerd  |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


