### PR TITLE
[PSUPCLPL-12085] Added missing security headers

### DIFF
--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -647,11 +647,10 @@ plugins:
         namespace: kubernetes-dashboard
         annotations:
           nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-          nginx.ingress.kubernetes.io/configuration-snippet: |   
+          nginx.ingress.kubernetes.io/configuration-snippet: |
             add_header X-Frame-Options "sameorigin";
             add_header X-Content-Type-Options "nosniff";
-            more_set_headers "Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; frame-ancestors 'self'; form-action 'self'";
-            more_set_headers "Cross-Origin-Resource-Policy: same-site"; 
+            add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'; form-action 'self' " ; 
       spec:
         ingressClassName: nginx
         tls:


### PR DESCRIPTION
### Description
As per external Pentest performed by the one of client, Kubernetes dashboard is missing some security headers.
We have added below missing security headers to the default configuration of dashboard ingress.
* X-Frame-Options
* X-Content-Type-Options
* Content-Security-Policy

Fixes # (issue)
PSUPCLPL-12085


### Solution
* Adding below mentioned annotations for the dashboard-ingress in default configurations.


### How to apply
Steps how to apply on top previous Kubemarine version to execute on existing clusters
* Edit the configuration for the dashboard-ingress in kubernetes-dashboard namespace
* Add required headers in annotations as _configuration-snippet_. 
```
  nginx.ingress.kubernetes.io/configuration-snippet: |
      add_header X-Frame-Options "sameorigin";
      add_header X-Content-Type-Options "nosniff";
      add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'self'; form-action 'self' " ;
``` 



### Test Cases

**TestCase 1**

Check the http headers for the impacted endpoint using curl command -
` curl -I -L http://dashboard.k8s-prpa.openshift.sdntest.netcracker.com/ ` 

In the response we see list of available headers for the provided endpoint
```
HTTP/1.1 308 Permanent Redirect
Date: Tue, 21 Mar 2023 10:59:56 GMT
Content-Type: text/html
Content-Length: 164
Connection: keep-alive
Location: https://dashboard.k8s-prpa.openshift.sdntest.netcracker.com

curl: (60) schannel: SEC_E_UNTRUSTED_ROOT (0x80090325) - The certificate chain was issued by an authority that is not trusted.
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

**Test Case 2**
Check the http headers for the impacted endpoint using curl command for latest dashboard version (v2.5.1)
` curl -I -L http://dashboard.k8s-prpa.openshift.sdntest.netcracker.com/ ` 


Results:

| Before | After |
| ------ | ------ |
| In the response for curl request to the endpoint as mentioned above, headers are missing | In the response for curl request to the endpoint as mentioned above, headers will be seen in the list |

Once we add the above mentioned security headers, the curl response will look like-
```
HTTP/1.1 308 Permanent Redirect
Date: Mon, 27 Mar 2023 07:00:23 GMT
Content-Type: text/html
Content-Length: 164
Connection: keep-alive
Location: https://dashboard.k8s-prpa.openshift.sdntest.netcracker.com
Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; frame-ancestors 'self'; form-action 'self'
Cross-Origin-Resource-Policy: same-site
X-Frame-Options: sameorigin
X-Content-Type-Options: nosniff

curl: (60) schannel: SEC_E_UNTRUSTED_ROOT (0x80090325) - The certificate chain was issued by an authority that is not trusted.
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
``` 


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts




