### PR TITLE
Manopd 85857 the restore procedure fails on the unpacking backup step

### DIFF
--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -37,7 +37,6 @@ def get_default_backup_files_list(cluster: KubernetesCluster):
     keepalived_service = cluster.get_package_association('keepalived', 'service_name')
 
     backup_files_list = [
-        "/etc/resolv.conf",
         "/etc/hosts",
         "/etc/chrony.conf",
         "/etc/selinux/config",
@@ -54,6 +53,9 @@ def get_default_backup_files_list(cluster: KubernetesCluster):
         "/etc/systemd/system/kubelet.service"
     ]
 
+    if cluster.inventory["services"].get("resolv.conf") is not None:
+        backup_files_list.append("/etc/resolv.conf")
+
     cri_impl = cluster.inventory['services']['cri']['containerRuntime']
     if cri_impl == "docker":
         backup_files_list.append("/etc/docker/daemon.json")
@@ -62,6 +64,7 @@ def get_default_backup_files_list(cluster: KubernetesCluster):
         backup_files_list.append("/etc/crictl.yaml")
 
     return backup_files_list
+
 
 
 def prepare_backup_tmpdir(cluster):


### PR DESCRIPTION
### Description
If resolve.conf is not specified in the cluster.yaml file then restore procedure was failing as chattr function is not supported on synbolic link
* 

### Solution
if we do not install resolv.conf, then backup & restore should leave resolv.conf on the nodes without changes so it should not take backup of resolv.conf and not restore it
* 

### How to apply
Provide steps how to apply on top previous Kubemarine version to execute on existing clusters
* [Install task/s](documentation/Installation.md#installation-tasks-description)
* Manual step 
* [Upgrade procedure](documentation/Maintenance.md#upgrade-procedure)


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 

Steps:

1. 

Results:

| Before | After |
| ------ | ------ |
|  |  |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


