### PR TITLE
[MANOPD-86838] Resolve conflict of archive names in add_node and restore procedures

### DIFF
--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -444,17 +444,21 @@ class ClusterStorage:
         if new_control_planes.is_empty():
             return
 
+        archive_name = 'dump_log_cluster.tar.gz'
+        archive_dump_path = get_dump_filepath(self.cluster.context, archive_name)
+        archive_remote_path = f"/tmp/{archive_name}"
+        log = self.cluster.log
+
         node = self.cluster.nodes['control-plane'].get_initial_nodes().get_first_member(provide_node_configs=True)
         control_plane = self.cluster.make_group([node['connect_to']])
-        data_copy_res = control_plane.sudo(f'tar -czvf /tmp/kubemarine-backup.tar.gz {self.dir_path}')
-        self.cluster.log.verbose('Backup created:\n%s' % data_copy_res)
-        control_plane.get('/tmp/kubemarine-backup.tar.gz',
-                          get_dump_filepath(self.cluster.context, "dump_log_cluster.tar.gz"), 'dump_log_cluster.tar.gz')
+        data_copy_res = control_plane.sudo(f'tar -czvf {archive_remote_path} {self.dir_path}')
+        log.verbose("Archive with procedures history is created:\n%s" % data_copy_res)
+        control_plane.get(archive_remote_path, archive_dump_path)
 
-        self.cluster.log.debug('Backup downloaded')
+        log.debug("Archive with procedures history is downloaded")
 
         for new_node in new_control_planes.get_ordered_members_list(provide_node_configs=True):
             group = self.cluster.make_group([new_node['connect_to']])
-            group.put(get_dump_filepath(self.cluster.context, "dump_log_cluster.tar.gz"),
-                      "/tmp/dump_log_cluster.tar.gz", sudo=True)
-            group.sudo(f'tar -C / -xzvf /tmp/dump_log_cluster.tar.gz')
+            group.put(archive_dump_path, archive_remote_path, sudo=True)
+            group.sudo(f'tar -C / -xzvf {archive_remote_path}')
+            log.debug(f"Archive with procedures history is uploaded to {new_node['name']!r}")


### PR DESCRIPTION
### Description
* `restore` after `add_node` fails with "[Errno 13] Permission denied"
* The reason is in '/tmp/kubemarine-backup.tar.gz' archive that is left after `add_node` procedure, belongs to root, and prevents uploading of different archive with the same name during `restore`.

### Solution
* Use archives with different names for different purposes.

### Test Cases

**TestCase 1**

Steps:

1. Run `install`, then `backup`, then `remove_node` & `add_node`, then `restore`.

Results:

| Before | After |
| ------ | ------ |
| "[Errno 13] Permission denied" | Successful |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
