### PR TITLE
[MANOPD-86649] Installation on IPv6 env fails

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2386,7 +2386,7 @@ For more information about Docker daemon parameters, refer to the official docke
 
 *Overwrite files*: Yes, only when a list of kernel modules changes, `/etc/modules-load.d/predefined.conf`, backup is created
 
-*OS specific*: No
+*OS specific*: Yes
 
 The `services.modprobe` section manages Linux Kernel modules to be loaded in the host operating system. By default, the following modules are loaded(according to the IP version):
 
@@ -2429,7 +2429,7 @@ services:
     - nf_defrag_ipv6
 ```
 
-If necessary, you can redefine or add [List Merge Strategy](#list-merge-strategy) to the standard list of Kernel modules to load. For example:
+If necessary, you can redefine or add [List Merge Strategy](#list-merge-strategy) to the standard list of Kernel modules to load. For example (Debian OS family):
 
 ```yaml
 services:

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2388,7 +2388,7 @@ For more information about Docker daemon parameters, refer to the official docke
 
 *OS specific*: Yes
 
-The `services.modprobe` section manages Linux Kernel modules to be loaded in the host operating system. By default, the following modules are loaded(according to the IP version):
+The `services.modprobe` section manages Linux Kernel modules to be loaded in the host operating system. By default, the following modules are loaded(according to the IP version and OS family):
 
 IPv4:
 ```yaml

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2388,24 +2388,55 @@ For more information about Docker daemon parameters, refer to the official docke
 
 *OS specific*: No
 
-The `services.modprobe` section manages Linux Kernel modules to be loaded in the host operating system. By default, the following modules are loaded:
+The `services.modprobe` section manages Linux Kernel modules to be loaded in the host operating system. By default, the following modules are loaded(according to the IP version):
 
-|Key|Note|
-|---|---|
-|br_netfilter| |
-|ip6table_filter|Only when IPv6 detected in node IP|
-|nf_conntrack_ipv6|Only when IPv6 detected in node IP|
-|nf_nat_masquerade_ipv6|Only when IPv6 detected in node IP|
-|nf_reject_ipv6|Only when IPv6 detected in node IP|
-|nf_defrag_ipv6|Only when IPv6 detected in node IP|
+IPv4:
+```yaml
+services:
+  modprobe:
+    rhel:
+    - br_netfilter
+    rhel8:
+    - br_netfilter
+    debian:
+    - br_netfilter
+```
+
+IPv6:
+```yaml
+services:
+  modprobe:
+    rhel:
+    - br_netfilter
+    - ip6table_filter
+    - nf_conntrack_ipv6
+    - nf_nat_masquerade_ipv6
+    - nf_reject_ipv6
+    - nf_defrag_ipv6
+    rhel8:
+    - br_netfilter
+    - ip6table_filter
+    - nf_conntrack
+    - nf_nat
+    - nf_reject_ipv6
+    - nf_defrag_ipv6
+    debian:
+    - br_netfilter
+    - ip6table_filter
+    - nf_conntrack
+    - nf_nat
+    - nf_reject_ipv6
+    - nf_defrag_ipv6
+```
 
 If necessary, you can redefine or add [List Merge Strategy](#list-merge-strategy) to the standard list of Kernel modules to load. For example:
 
 ```yaml
 services:
   modprobe:
-    - my_own_module1
-    - my_own_module2
+    debian:
+      - my_own_module1
+      - my_own_module2
 ```
 
 **Warning**: Be careful with these settings, they directly affect the hosts operating system.

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -608,6 +608,14 @@ plugins:
 ```
 More details on IP autodetection methods are [here](https://docs.tigera.io/calico/3.25/reference/configure-calico-node#ip-autodetection-methods).
 
+## IPv6 `services` are unreachable
+
+**Symptoms**: After the Kubernetes installation on IPv6 environment `services` are unreachable
+
+**Root cause**: IPv6 NAT rules don't work properly in case of IPv4 address existing in system
+
+**Solution**: Exclude IPv4 addresses and routes from network settings
+
 
 # Troubleshooting KubeMarine
 

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -608,6 +608,7 @@ plugins:
 ```
 More details on IP autodetection methods are [here](https://docs.tigera.io/calico/3.25/reference/configure-calico-node#ip-autodetection-methods).
 
+
 # Troubleshooting KubeMarine
 
 This section provides troubleshooting information for KubeMarine-specific or installation-specific issues.

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -608,15 +608,6 @@ plugins:
 ```
 More details on IP autodetection methods are [here](https://docs.tigera.io/calico/3.25/reference/configure-calico-node#ip-autodetection-methods).
 
-## IPv6 `services` are unreachable
-
-**Symptoms**: After the Kubernetes installation on IPv6 environment `services` are unreachable
-
-**Root cause**: IPv6 NAT rules don't work properly in case of IPv4 address existing in system
-
-**Solution**: Exclude IPv4 addresses and routes from network settings
-
-
 # Troubleshooting KubeMarine
 
 This section provides troubleshooting information for KubeMarine-specific or installation-specific issues.

--- a/examples/cluster.yaml/full-cluster.yaml
+++ b/examples/cluster.yaml/full-cluster.yaml
@@ -179,6 +179,8 @@ services:
         - man_groff
 
   modprobe:
+    # For RHEL OS:
+    rhel:
     - br_netfilter
     - ip_vs
     - ip_vs_rr
@@ -187,6 +189,18 @@ services:
     - ip6table_filter
     - nf_conntrack_ipv6
     - nf_nat_masquerade_ipv6
+    - nf_reject_ipv6
+    - nf_defrag_ipv6
+    # For Debian OS:
+    debian:
+    - br_netfilter
+    - ip_vs
+    - ip_vs_rr
+    - ip_vs_wrr
+    - ip_vs_sh
+    - ip6table_filter
+    - nf_conntrack
+    - nf_nat
     - nf_reject_ipv6
     - nf_defrag_ipv6
 

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -66,7 +66,8 @@ DEFAULT_ENRICHMENT_FNS = [
     "kubemarine.plugins.builtin.verify_inventory",
     "kubemarine.coredns.enrich_add_hosts_config",
     "kubemarine.k8s_certs.renew_verify",
-    "kubemarine.cri.enrich_inventory"
+    "kubemarine.cri.enrich_inventory",
+    "kubemarine.system.enrich_kernel_modules"
 ]
 
 supported_defaults = {

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -142,12 +142,27 @@ services:
       userland-proxy: False
 
   modprobe:
-    - br_netfilter
-    - '{% if not nodes[0]["internal_address"]|isipv4 %}ip6table_filter{% endif %}'
-    - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_conntrack_ipv6{% endif %}'
-    - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_nat_masquerade_ipv6{% endif %}'
-    - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_reject_ipv6{% endif %}'
-    - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_defrag_ipv6{% endif %}'
+    rhel:
+      - br_netfilter
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}ip6table_filter{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_conntrack_ipv6{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_nat_masquerade_ipv6{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_reject_ipv6{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_defrag_ipv6{% endif %}'
+    rhel8:
+      - br_netfilter
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}ip6table_filter{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_conntrack{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_nat{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_reject_ipv6{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_defrag_ipv6{% endif %}'
+    debian:
+      - br_netfilter
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}ip6table_filter{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_conntrack{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_nat{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_reject_ipv6{% endif %}'
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_defrag_ipv6{% endif %}'
 
   sysctl:
     net.bridge.bridge-nf-call-iptables: 1

--- a/kubemarine/resources/schemas/definitions/services/modprobe.json
+++ b/kubemarine/resources/schemas/definitions/services/modprobe.json
@@ -1,16 +1,31 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "type": "array",
-  "description": "Manage Linux Kernel modules to be loaded in the host operating system",
-  "items": {
+  "type": "object",
+  "properties": {
+    "debian": {"$ref": "#/definitions/OSFamilyModules"},
+    "rhel": {"$ref": "#/definitions/OSFamilyModules"},
+    "rhel8": {"$ref": "#/definitions/OSFamilyModules"}
+  },
+  "propertyNames": {
     "anyOf": [
-      {
-        "type": "string",
-        "enum": ["br_netfilter", "ip6table_filter", "nf_conntrack_ipv6", "nf_nat_masquerade_ipv6", "nf_reject_ipv6", "nf_defrag_ipv6"]
-      },
-      {"type": "string"},
-      {"$ref": "../common/utils.json#/definitions/ListMergingSymbol"}
+      {"enum": ["debian", "rhel", "rhel8"]}
     ]
   },
-  "uniqueItems": true
+  "definitions": {
+    "OSFamilyModules": {
+      "type": "array",
+      "description": "Manage Linux Kernel modules to be loaded in the host operating system",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": ["br_netfilter", "ip6table_filter", "nf_conntrack_ipv6", "nf_nat_masquerade_ipv6", "nf_reject_ipv6", "nf_defrag_ipv6", "nf_nat", "nf_conntrack"]
+          },
+          {"type": "string"},
+          {"$ref": "../common/utils.json#/definitions/ListMergingSymbol"}
+        ]
+      },
+      "uniqueItems": true
+    }
+  }
 }

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -127,6 +127,16 @@ def enrich_upgrade_inventory(inventory: dict, cluster: KubernetesCluster):
 
     return inventory
 
+def enrich_kernel_modules(inventory: dict, cluster: KubernetesCluster):
+    """
+    The method enrich the list of kernel modules ('services.modprobe') according to OS family
+    """
+    os_family = cluster.get_os_family()
+    if os_family in ('unknown', 'unsupported', 'multiple'):
+        raise Exception("Kernel modules are not available for the current OS family")
+    inventory['services']['modprobe'] = cluster.inventory['services']['modprobe'][os_family]
+
+    return inventory
 
 def get_system_packages_for_upgrade(cluster):
     upgrade_ver = cluster.context["upgrade_version"]

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -34,6 +34,8 @@ from kubemarine.core.group import NodeGroupResult, NodeGroup
 from kubemarine.core.yaml_merger import default_merger
 from kubemarine.core.annotations import restrict_empty_group
 
+ERROR_UNSUPPORTED_KERNEL_MODULES_VERSIONS_DETECTED = \
+        "Kernel modules are not available for the current OS family"
 
 def verify_inventory(inventory, cluster):
 
@@ -131,10 +133,22 @@ def enrich_kernel_modules(inventory: dict, cluster: KubernetesCluster):
     """
     The method enrich the list of kernel modules ('services.modprobe') according to OS family
     """
+    
     os_family = cluster.get_os_family()
-    if os_family in ('unknown', 'unsupported', 'multiple'):
-        raise Exception("Kernel modules are not available for the current OS family")
-    inventory['services']['modprobe'] = cluster.inventory['services']['modprobe'][os_family]
+    if os_family in ["unknown", "unsupported"]:
+        raise Exception(ERROR_UNSUPPORTED_KERNEL_MODULES_VERSIONS_DETECTED)
+    elif os_family in ["debian", "rhel", "rhel8"]:
+        modprobe = {}
+        modprobe[os_family] = inventory["services"]["modprobe"][os_family]
+        inventory["services"]["modprobe"] = modprobe
+    elif os_family == "multiple":
+        modprobe = {}
+        os_families = set()
+        for node in cluster.nodes['all'].get_final_nodes().get_hosts():
+            os_families.add(cluster.get_os_family_for_node(node))
+        for item in os_families:
+            modprobe[item] = inventory["services"]["modprobe"][item]
+        inventory["services"]["modprobe"] = modprobe
 
     return inventory
 
@@ -565,6 +579,7 @@ def configure_timesyncd(group, retries=120):
 def setup_modprobe(group):
     log = group.cluster.log
 
+    os_family = group.cluster.get_os_family()
     if group.cluster.inventory['services'].get('modprobe') is None \
             or not group.cluster.inventory['services']['modprobe']:
         log.debug('Skipped - no modprobe configs in inventory')
@@ -578,7 +593,7 @@ def setup_modprobe(group):
 
     config = ''
     raw_config = ''
-    for module_name in group.cluster.inventory['services']['modprobe']:
+    for module_name in group.cluster.inventory['services']['modprobe'][os_family]:
         module_name = module_name.strip()
         if module_name is not None and module_name != '':
             config += module_name + "\n"
@@ -599,7 +614,8 @@ def is_modprobe_valid(group):
     verify_results = group.sudo("lsmod", warn=True)
     is_valid = True
 
-    for module_name in group.cluster.inventory['services']['modprobe']:
+    os_family = group.cluster.get_os_family()
+    for module_name in group.cluster.inventory['services']['modprobe'][os_family]:
         for conn, result in verify_results.items():
             if module_name not in result.stdout:
                 log.debug('Kernel module %s not found at %s' % (module_name, conn.host))

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -579,7 +579,7 @@ def configure_timesyncd(group, retries=120):
 def setup_modprobe(group):
     log = group.cluster.log
 
-    os_family = group.cluster.get_os_family()
+    os_family = group.get_nodes_os()
     if group.cluster.inventory['services'].get('modprobe') is None \
             or not group.cluster.inventory['services']['modprobe']:
         log.debug('Skipped - no modprobe configs in inventory')
@@ -614,7 +614,7 @@ def is_modprobe_valid(group):
     verify_results = group.sudo("lsmod", warn=True)
     is_valid = True
 
-    os_family = group.cluster.get_os_family()
+    os_family = group.get_nodes_os()
     for module_name in group.cluster.inventory['services']['modprobe'][os_family]:
         for conn, result in verify_results.items():
             if module_name not in result.stdout:


### PR DESCRIPTION
### Description
Kubernetes installation on Ubuntu 22.04/20.04 fails if nodes have IPv6 network whereas installation on CentOS 7 works.
The error message is the following:
```
2023-03-28 08:31:40,903 47597 140540068624192 qa-fullha-kubernetes.openshift.sdntest.local VERBOSE [log.verbose] modprobe: WARNING: Module nf_conntrack_ipv6 not found in directory /lib/modules/5.4.0-146-generic
```
The reason is:
* Ubuntu 20.04/22.04 and CentOS 7 have different sets of kernel modules that should be applied during the installation in case of IPv6 usage


### Solution
* Expand `defaults.yaml` for several sets of kernel modules that are stored in `services.modprobe`
* Add `services.modprobe` enrichment that must assume the OS family dependent procedure
* Change validation schema
* Update documentation


### How to apply
Add the OS family name into the 'cluster.yaml' in case of using custom kernel modules. For instance, the following notation:
```yaml
services:
  modprobe:
    - my_own_module1
    - my_own_module2
```
must be changed to:
```yaml
services:
  modprobe:
    debian:
      - my_own_module1
      - my_own_module2
```


### Test Cases

**TestCase 1**

Ubuntu 20.04/22.04 installation works

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 22.04
- Inventory: AllInOne

Steps:

1. Create 'cluster.yaml' with nodes that have IPv6 adsresses
2. Run Kubernetes installation with --tasks="prepare"

Results:

| Before | After |
| ------ | ------ |
| Fail | Success |

**TestCase 2**

OS migration procedure works in case of using IPv4

Test Configuration:

- Hardware: 4CPU/4GB
- OS: CentOS7 -> Ubuntu 20.04
- Inventory: MiniHA

Steps:

1. Run node migration procedure on existing Kubernetes cluster.

Results:

| Before | After |
| ------ | ------ |
| Not applicable | Success |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests



