### PR TITLE
[MANOPD-86862] - add TG for vrrp in calico

### DIFF
--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -553,7 +553,8 @@ Nov 28 14:02:06 node01 kubelet[308309]: E1128 14:02:06.631719  308309 kubelet.go
 
 **Root cause**: Not all Calico BGP sessions between nodes are established due to incorrect network interface choice.
 
-**Solution**: By default, Calico uses a `first-found` network interface to route the traffic between nodes. This is fine for nodes with only one Ethernet interface, but it can work improperly in case of multiple interfaces. To avoid issues with routing between different network segments, it is necessary to set a proper interface in Calico's `IP_AUTODETECTION_METHOD` variable, for example:
+**Solution**: By default, Calico uses a `first-found` method, that takes the first valid IP address on the first interface 
+to route the traffic between nodes. This is fine for nodes with only one Ethernet interface, but it can work improperly in case of multiple interfaces. To avoid issues with routing between different network segments, it is necessary to set a proper interface in Calico's `IP_AUTODETECTION_METHOD` variable, for example:
 ```
 plugins:
   calico:
@@ -578,8 +579,9 @@ k8s-control-plane-2   (64512)   192.168.0.2/24
 k8s-control-plane-3   (64512)   192.168.0.3/24
 ```
 
-**Solution**: By default, Calico uses a `first-found` network interface to route the traffic between nodes. This is fine  
-for nodes that don't have more than one different ips, but it can work improperly in case of multiple ips. 
+**Solution**: By default, Calico uses a `first-found` method, that takes the first valid IP address on the first interface 
+to route the traffic between nodes. This is fine for nodes that don't have more than one different ips, but it can work 
+improperly in case of multiple ips. 
 To avoid such issues, you should change Calico's `IP_AUTODETECTION_METHOD` variable on `kubernetes-internal-ip` or another method,
 that is suitable in your situation:
 ```

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -23,7 +23,8 @@ This section provides troubleshooting information for KubeMarine and Kubernetes 
   - [Pods Stuck in "terminating" Status During Deletion](#pods-stuck-in-terminating-status-during-deletion)
   - [Random 504 Error on Ingresses](#random-504-error-on-ingresses)
   - [Nodes Have `NotReady` Status Periodically](#nodes-have-notready-status-periodically)
-  - [No Pod-to-Pod Traffic for Some Nodes](#no-pod-to-pod-traffic-for-some-nodes)
+  - [No Pod-to-Pod Traffic for Some Nodes with more than one network interface](#no-pod-to-pod-traffic-for-some-nodes-with-more-than-one-network-interface)
+  - [No Pod-to-Pod Traffic for Some Nodes with more than one ips with different CIDR notation](#no-pod-to-pod-traffic-for-some-nodes-with-more-than-one-ips-with-different-cidr-notation)
 - [Troubleshooting KubeMarine](#troubleshooting-kubemarine)
   - [Failures During Kubernetes Upgrade Procedure](#failures-during-kubernetes-upgrade-procedure)
   - [Numerous Generation of Auditd System Messages ](#numerous-generation-of-auditd-system)
@@ -546,7 +547,7 @@ Nov 28 14:02:06 node01 kubelet[308309]: E1128 14:02:06.631719  308309 kubelet.go
 
 **Solution**: Upgrade Linux kernel to `5.4.0-135-generic`
 
-## No Pod-to-Pod Traffic for Some Nodes
+## No Pod-to-Pod Traffic for Some Nodes with more than one network interface
 
 **Symptoms**: There is no traffic between pods located at different nodes. There is more than 1 permanent network interface at the nodes.
 
@@ -560,6 +561,37 @@ plugins:
       IP_AUTODETECTION_METHOD: interface=ens160
 ```
 More details on IP autodetection methods are [here](https://docs.tigera.io/calico/3.25/reference/configure-calico-node#ip-autodetection-methods).
+
+## No Pod-to-Pod Traffic for Some Nodes with more than one ips with different CIDR notation
+
+**Symptoms**: There is no traffic between pods located at different nodes. There is more than 1 ips on used network interface with different CIDR notations.
+
+**Root cause**: Not all Calico BGP sessions between nodes are established due to different CIDR notations on chosen ips for nodes.
+Typically, such situation can appear in minha scheme with vrrp, where balancer role is combined with other roles. In that case 
+calico can autodetect vrrp for some node instead of its internal ip.
+You can use `calicoctl` to check such situation, e.g. for [example minha cluster.yaml](../examples/cluster.yaml/miniha-cluster.yaml):
+```sh
+sudo calicoctl get nodes --output=wide
+NAME                  ASN       IPV4                IPV6
+k8s-control-plane-1   (64512)   192.168.0.250/32
+k8s-control-plane-2   (64512)   192.168.0.2/24
+k8s-control-plane-3   (64512)   192.168.0.3/24
+```
+
+**Solution**: By default, Calico uses a `first-found` network interface to route the traffic between nodes. This is fine  
+for nodes that don't have more than one different ips, but it can work improperly in case of multiple ips. 
+To avoid such issues, you should change Calico's `IP_AUTODETECTION_METHOD` variable on `kubernetes-internal-ip` or another method,
+that is suitable in your situation:
+```
+plugins:
+  calico:
+    install: true
+    env:
+      IP_AUTODETECTION_METHOD: kubernetes-internal-ip
+```
+More details on IP autodetection methods are [here](https://docs.tigera.io/calico/3.25/reference/configure-calico-node#ip-autodetection-methods).
+
+
 
 # Troubleshooting KubeMarine
 


### PR DESCRIPTION
### Description
In minha scheme Calico can detect vrrp for one of the nodes, if it uses default 'first-found' autodetect method. In that case pod-to-pod traffic from that node will lost.

Fixes # (issue)


### Solution
Added new TG section, that describes possible way to resolve such situation.


### How to apply
Provide steps how to apply on top previous Kubemarine version to execute on existing clusters
* [Install task/s](documentation/Installation.md#installation-tasks-description)
* Manual step 
* [Upgrade procedure](documentation/Maintenance.md#upgrade-procedure)


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration: 

- Hardware: 
- OS: ubuntu
- Inventory: minha scheme

Steps:

Before:
1. run `kubemarine install` with default configuration for calico;
2. Wait, whan vrrp will be the first ip on interface on node;

After:
1. run `kubemarine install` with overridden `IP_AUTODETECTION_METHOD=kubernetes-internal-ip`;
2. Wait, whan vrrp will be the first ip on interface on node;

Results:

| Before | After |
| ------ | ------ |
| Pod-to-pod connectivity from node with vrrp won't be established. Calico autodetects vrrp for problem node. | Pod-to-pod connectivity from node with vrrp will be established. Calico autodetects internal ips for all nodes. |

**TestCase 2**

Test Configuration: 

- Hardware: 
- OS: ubuntu
- Inventory: more than 2 control-plane/worker nodes

Steps:

Before:
1. Add new ip with another CIDR notation in the begin of used network interface;
2. run `kubemarine install` with default configuration for calico;

After:
1. Add new ip with another CIDR notation in the begin of used network interface;
2. run `kubemarine install` with overridden `IP_AUTODETECTION_METHOD=kubernetes-internal-ip`;

Results:

| Before | After |
| ------ | ------ |
| Pod-to-pod connectivity from node with vrrp won't be established. Calico autodetects created ip for problem node. | Pod-to-pod connectivity from node with vrrp will be established. Calico autodetects internal ips for all nodes. |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


