### PR TITLE
MANOPD-86915 Missed /root/.kube/config in backup & restore

### DIFF
--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -51,6 +51,7 @@ def get_default_backup_files_list(cluster: KubernetesCluster):
         f"/etc/systemd/system/{keepalived_service}.service.d/{keepalived_service}.conf",
         "/usr/local/bin/check_haproxy.sh",
         "/etc/kubernetes",
+        "/root/.kube/config",
         "/etc/systemd/system/kubelet.service"
     ]
 


### PR DESCRIPTION
### Description
* Restore over the newly installed cluster fails in `reboot` task with `kubectl` error: "Unable to connect to the server: x509: certificate signed by unknown authority".
* The reason is in absent /root/.kube/config file in list of files to backup.

### Solution
* Add the missed /root/.kube/config file.

### Test Cases

**TestCase 1**

Steps:

1. Run `install`, `backup`.
2. Rebuild VMs.
3. Run `install`, `restore`.

Results:

| Before | After |
| ------ | ------ |
| Nodes did not become ready in the expected time | Success |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
