### PR TITLE
[PDSDNREQ-7285] Kubelet to have enable-debugging-handlers flag

### DIFF
--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -21,6 +21,7 @@ services:
     apiVersion: kubelet.config.k8s.io/v1beta1
     kind: KubeletConfiguration
     readOnlyPort: 0
+    enableDebuggingHandlers: false
     protectKernelDefaults: true
     podPidsLimit: 4096
     cgroupDriver: systemd


### PR DESCRIPTION
### Description
* Flag `enableDebuggingHandlers` enables server endpoints for log access and local running of containers and commands, including the exec, attach, logs, and portforward features. 
* By default, this option is enabled
* It is necessary to add the ability to disable server endpoints for kubelet

Fixes # (issue)
PDSDNREQ-7285

### Solution
* Flag has been added to default.yaml responsible for disabling server endpoints


### How to apply
1 - You need to add a parameter `enableDebuggingHandlers: false` to kubeadm-flags.env
Path /var/lib/kubelet/kubeadm-flags.env
Example:
```
apiVersion: kubelet.config.k8s.io/v1beta1
...
enableDebuggingHandlers: false
...
```
2 - You need to restart kubelet with the command: 
`systemctl restart kubelet'

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


