### PR TITLE
Doc update: add new parameters in globals section of IN

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -508,6 +508,10 @@ In the `globals` section you can describe the global parameters that can be over
 
 ```
 globals:
+  expect:
+    pods:
+      plugins:
+        retries: 300
   nodes:
     ready:
       timeout: 10
@@ -518,11 +522,17 @@ globals:
 
 The following parameters are supported:
 
-|Name|Type|Mandatory|Default Value|Example|Description|
-|---|---|---|---|---|---|
-|`nodes.ready.timeout`|int|no|5|`10`|Timeout between `nodes.ready.retries` for cluster node readiness waiting|
-|`nodes.ready.retries`|int|no|15|`60`|Number of retries to check a cluster node readiness|
-|`nodes.boot.timeout`|int|no|600|`900`|Timeout for node reboot waiting|
+| Name                             | Type | Mandatory | Default Value | Example | Description                                                                                                        |
+|----------------------------------|------|-----------|---------------|---------|--------------------------------------------------------------------------------------------------------------------|
+| `expect.deployments.timeout`     | int  | no        | 5             | `10`    | Timeout between `expect.deployments.retries` for daemonsets/deployments/replicasets/statefulsets readiness waiting |
+| `expect.deployments.retries`     | int  | no        | 45            | `100`   | Number of retires to check daemonsets/deployments/replicasets/statefulsets readiness                               |
+| `expect.pods.kubernetes.timeout` | int  | no        | 5             | `10`    | Timeout between `expect.pods.kubernetes.retries` for control-plane pods readiness waiting                          |
+| `expect.pods.kubernetes.retries` | int  | no        | 30            | `50`    | Number of retires to check control-plane pods readiness                                                            |
+| `expect.pods.plugins.timeout`    | int  | no        | 5             | `10`    | Timeout between `expect.pods.plugins.retries` for pods readiness waiting in `plugins`                              |
+| `expect.pods.plugins.retries`    | int  | no        | 150           | `300`   | Number of retires to check pods readiness in `plugins`                                                             |
+| `nodes.ready.timeout`            | int  | no        | 5             | `10`    | Timeout between `nodes.ready.retries` for cluster node readiness waiting                                           |
+| `nodes.ready.retries`            | int  | no        | 15            | `60`    | Number of retries to check a cluster node readiness                                                                |
+| `nodes.boot.timeout`             | int  | no        | 600           | `900`   | Timeout for node reboot waiting                                                                                    |
 
 
 ### node_defaults


### PR DESCRIPTION
### Description
In the documentation there is no description of supported parameters in `globals` section of cluster.yaml added in https://github.com/Netcracker/KubeMarine/pull/410.

Fixes # (issue)

### Solution
Installation.md updated.

### How to apply

### Test Cases

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


