### PR TITLE
[MANOPD-87367] Check_iaas procedure doesn't check tcp ports 9091, 9094 and 10254

### DIFF
--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -863,7 +863,8 @@ def install_tcp_listener(cluster: KubernetesCluster, nodes: dict, tcp_ports):
 def check_tcp_ports(cluster):
     with TestCase(cluster.context['testsuite'], '011', 'Network', 'TCPPorts', default_results='Connected'),\
             suspend_firewalld(cluster):
-        tcp_ports = ["80", "443", "179", "5473", "6443", "8443", "2379", "2380", "10250", "10257", "10259", "30001", "30002"]
+        tcp_ports = ["80", "443", "179", "5473", "6443", "8443", "2379", "2380", "9091", "9094", "10250", "10254",
+                     "10257", "10259", "30001", "30002"]
         nodes = {node["connect_to"]: node
                  for node in cluster.nodes['all'].get_ordered_members_list(provide_node_configs=True)}
         host_to_ip = {host: node['internal_address'] for host, node in nodes.items()}


### PR DESCRIPTION
### Description
* It is necessary to add ports for checking in check_iaas for `calico metrics` and `prometheus` to work

Fixes # (issue)
[MANOPD-87367]

### Solution
* Ports for `calico metrics` and `prometheus` have been added to the `check_iaas.py` check

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


