### PR TITLE
[MANOPD-87294] - fix version check

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -849,8 +849,8 @@ def control_plane_configuration_status(cluster):
 
             for static_pod in static_pods_content:
                 result[static_pod['metadata']['name']] = dict()
-                if version in static_pod["spec"]["containers"][0].get("image", ""):
-                    result[static_pod['metadata']['name']]['correct_version'] = True
+                result[static_pod['metadata']['name']]['correct_version'] = \
+                    version in static_pod["spec"]["containers"][0].get("image", "")
                 result[static_pod['metadata']['name']]['correct_properties'] = \
                     check_extra_args(cluster, static_pod, control_plane)
                 result[static_pod['metadata']['name']]['correct_volumes'] = check_extra_volumes(cluster, static_pod)


### PR DESCRIPTION
### Description
If we change kuber version in cluster.yaml and run `check_paas` procedure, `control_plane.configuration_status` fails with exception:
```
2023-04-11 10:26:53.064 +0300 Traceback (most recent call last):
2023-04-11 10:26:53.064 +0300   File "/usr/local/lib/python3.11/site-packages/kubemarine/procedures/check_paas.py", line 854, in control_plane_configuration_status
2023-04-11 10:26:53.064 +0300     if result[static_pod_name]['correct_version'] and \
2023-04-11 10:26:53.064 +0300        ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
2023-04-11 10:26:53.064 +0300 KeyError: 'correct_version'
2023-04-11 10:26:53.064 +0300   Control plane    ERROR?   220  configuration status ................................................................ 'correct_version'
```

Fixes # (issue)


### Solution
We save only True value in case of similar versions, but in other case this value will be undefined and follows an exception in next lines.
Fixed

### How to apply
Provide steps how to apply on top previous Kubemarine version to execute on existing clusters
* [Install task/s](documentation/Installation.md#installation-tasks-description)
* Manual step 
* [Upgrade procedure](documentation/Maintenance.md#upgrade-procedure)


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 

Steps:

1. Run `kubemarne install`
2. Change kubernetes version in cluster.yaml
3. Run `check_paas`

Results:

| Before | After |
| ------ | ------ |
| `control_plane.configuration_status` fails with exception | `control_plane.configuration_status` fails as expected |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


