### PR TITLE
MANOPD-81998_fix-unattended-updates

### DIFF
--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -79,6 +79,7 @@ def install(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
     command = get_install_cmd(include, exclude)
 
     return group.sudo(command, **kwargs)
+    
     # apt fails to install (downgrade) package if it is already present and has higher version,
     # thus we do not need additional checks here (in contrast to yum)
 

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -58,8 +58,8 @@ def clean(group, **kwargs) -> NodeGroupResult:
     return group.sudo(DEBIAN_HEADERS + "apt clean", **kwargs)
 
 
-def check_unattended_upgrade(group, **kwargs) -> NodeGroupResult:
-    return group.sudo(DEBIAN_HEADERS + "ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300", **kwargs)
+#def check_unattended_upgrade(group, **kwargs) -> NodeGroupResult:
+#    return group.sudo(DEBIAN_HEADERS + "ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300", **kwargs)
 
 
 def get_install_cmd(include: str or list, exclude=None) -> str:
@@ -79,10 +79,8 @@ def get_install_cmd(include: str or list, exclude=None) -> str:
 def install(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
     if include is None:
         raise Exception('You must specify included packages to install')
-        
-    check_unattended_upgrade(group, **kwargs)
                 
-    command = get_install_cmd(include, exclude)
+    command = DEBIAN_HEADERS + "ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300 ;" + get_install_cmd(include, exclude)
 
     return group.sudo(command, **kwargs)
     

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -79,7 +79,9 @@ def get_install_cmd(include: str or list, exclude=None) -> str:
 def install(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
     if include is None:
         raise Exception('You must specify included packages to install')
-
+    else:
+        group.sudo(check_unattended_upgrade)
+                
     command = get_install_cmd(include, exclude)
 
     return group.sudo(command, **kwargs)

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -58,10 +58,6 @@ def clean(group, **kwargs) -> NodeGroupResult:
     return group.sudo(DEBIAN_HEADERS + "apt clean", **kwargs)
 
 
-#def check_unattended_upgrade(group, **kwargs) -> NodeGroupResult:
-#    return group.sudo(DEBIAN_HEADERS + "ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300", **kwargs)
-
-
 def get_install_cmd(include: str or list, exclude=None) -> str:
     if isinstance(include, list):
         include = ' '.join(include)

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -107,7 +107,8 @@ def upgrade(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
     if isinstance(include, list):
         include = ' '.join(include)
     command = DEBIAN_HEADERS + 'apt update && ' + \
-              DEBIAN_HEADERS + 'sudo apt upgrade -y %s' % include
+              DEBIAN_HEADERS + 'sudo apt upgrade -y %s' % include ';' + \
+              DEBIAN_HEADERS + '(($? != 0)) && sleep 666 && sudo apt install -y %s' % include
 
     if exclude is not None:
         if isinstance(exclude, list):

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -66,7 +66,7 @@ def get_install_cmd(include: str or list, exclude=None) -> str:
     if isinstance(include, list):
         include = ' '.join(include)
     command = DEBIAN_HEADERS + 'ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300 ;' + \
-              DEBIAN_HEADERS + 'apt update && ' + \
+              DEBIAN_HEADERS + 'sudo apt update && ' + \
               DEBIAN_HEADERS + 'sudo apt install -y %s' % include
 
     if exclude is not None:

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -77,7 +77,7 @@ def install(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
     if include is None:
         raise Exception('You must specify included packages to install')
                 
-    command = DEBIAN_HEADERS + get_install_cmd(include, exclude)
+    command = get_install_cmd(include, exclude)
 
     return group.sudo(command, **kwargs)
     

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -61,7 +61,7 @@ def clean(group, **kwargs) -> NodeGroupResult:
 def get_install_cmd(include: str or list, exclude=None) -> str:
     if isinstance(include, list):
         include = ' '.join(include)
-    command = DEBIAN_HEADERS + 'ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300 ;' + \
+    command = DEBIAN_HEADERS + 'ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300; ' + \
               DEBIAN_HEADERS + 'sudo apt update && ' + \
               DEBIAN_HEADERS + 'sudo apt install -y %s' % include
 

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -91,7 +91,8 @@ def remove(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
 
     if isinstance(include, list):
         include = ' '.join(include)
-    command = DEBIAN_HEADERS + 'apt purge -y %s' % include
+    command = DEBIAN_HEADERS + 'ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300; ' + \
+              DEBIAN_HEADERS + 'apt purge -y %s' % include
 
     if exclude is not None:
         if isinstance(exclude, list):
@@ -107,7 +108,8 @@ def upgrade(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
 
     if isinstance(include, list):
         include = ' '.join(include)
-    command = DEBIAN_HEADERS + 'apt update && ' + \
+    command = DEBIAN_HEADERS + 'ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300; ' + \
+              DEBIAN_HEADERS + 'apt update && ' + \
               DEBIAN_HEADERS + 'sudo apt upgrade -y %s' % include
     
     if exclude is not None:

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -80,7 +80,7 @@ def install(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
     if include is None:
         raise Exception('You must specify included packages to install')
                 
-    command = DEBIAN_HEADERS + "ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300 ;" + get_install_cmd(include, exclude)
+    command = DEBIAN_HEADERS + "ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300; " + get_install_cmd(include, exclude)
 
     return group.sudo(command, **kwargs)
     

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -65,7 +65,8 @@ def clean(group, **kwargs) -> NodeGroupResult:
 def get_install_cmd(include: str or list, exclude=None) -> str:
     if isinstance(include, list):
         include = ' '.join(include)
-    command = DEBIAN_HEADERS + 'apt update && ' + \
+    command = DEBIAN_HEADERS + 'ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300 ;' + \
+              DEBIAN_HEADERS + 'apt update && ' + \
               DEBIAN_HEADERS + 'sudo apt install -y %s' % include
 
     if exclude is not None:
@@ -80,7 +81,7 @@ def install(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
     if include is None:
         raise Exception('You must specify included packages to install')
                 
-    command = DEBIAN_HEADERS + "ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300; " + get_install_cmd(include, exclude)
+    command = DEBIAN_HEADERS + get_install_cmd(include, exclude)
 
     return group.sudo(command, **kwargs)
     

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -79,8 +79,8 @@ def get_install_cmd(include: str or list, exclude=None) -> str:
 def install(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
     if include is None:
         raise Exception('You must specify included packages to install')
-    else:
-        group.sudo(check_unattended_upgrade)
+        
+    check_unattended_upgrade(group, **kwargs)
                 
     command = get_install_cmd(include, exclude)
 

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -58,6 +58,10 @@ def clean(group, **kwargs) -> NodeGroupResult:
     return group.sudo(DEBIAN_HEADERS + "apt clean", **kwargs)
 
 
+def check_unattended_upgrade(group, **kwargs) -> NodeGroupResult:
+    return group.sudo(DEBIAN_HEADERS + "ps aux | grep -v grep | grep -v unattended-upgrade-shutdown | grep unattended-upgrade && sleep 300", **kwargs)
+
+
 def get_install_cmd(include: str or list, exclude=None) -> str:
     if isinstance(include, list):
         include = ' '.join(include)
@@ -107,9 +111,8 @@ def upgrade(group, include=None, exclude=None, **kwargs) -> NodeGroupResult:
     if isinstance(include, list):
         include = ' '.join(include)
     command = DEBIAN_HEADERS + 'apt update && ' + \
-              DEBIAN_HEADERS + 'sudo apt upgrade -y %s' % include ';' + \
-              DEBIAN_HEADERS + '(($? != 0)) && sleep 666 && sudo apt install -y %s' % include
-
+              DEBIAN_HEADERS + 'sudo apt upgrade -y %s' % include
+    
     if exclude is not None:
         if isinstance(exclude, list):
             exclude = ','.join(exclude)

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -148,7 +148,7 @@ class RemoteExecutor:
                 if action[0] == 'sudo':
                     precommand = 'sudo '
                 previous_action = merged_actions[-1][0]
-                merged_action_command = str(previous_action[1][0] + separator + precommand + action[1][0])
+                merged_action_command = previous_action[1][0] + separator + precommand + action[1][0]
                 merged_actions[-1][0] = (previous_action[0], tuple([merged_action_command]), previous_action[2])
                 merged_actions[-1][1].append(callback)
                 merged_actions[-1][2].append(token)

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -148,7 +148,7 @@ class RemoteExecutor:
                 if action[0] == 'sudo':
                     precommand = 'sudo '
                 previous_action = merged_actions[-1][0]
-                merged_action_command = previous_action[1][0] + separator + precommand + action[1][0]
+                merged_action_command = str(previous_action[1][0] + separator + precommand + action[1][0])
                 merged_actions[-1][0] = (previous_action[0], tuple([merged_action_command]), previous_action[2])
                 merged_actions[-1][1].append(callback)
                 merged_actions[-1][2].append(token)

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -148,7 +148,7 @@ class RemoteExecutor:
                 if action[0] == 'sudo':
                     precommand = 'sudo '
                 previous_action = merged_actions[-1][0]
-                merged_action_command = str(previous_action[1][0]) + separator + precommand + str(action[1][0])
+                merged_action_command = previous_action[1][0] + separator + precommand + action[1][0]
                 merged_actions[-1][0] = (previous_action[0], tuple([merged_action_command]), previous_action[2])
                 merged_actions[-1][1].append(callback)
                 merged_actions[-1][2].append(token)

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -148,7 +148,7 @@ class RemoteExecutor:
                 if action[0] == 'sudo':
                     precommand = 'sudo '
                 previous_action = merged_actions[-1][0]
-                merged_action_command = previous_action[1][0] + separator + precommand + str(action[1][0])
+                merged_action_command = previous_action[1][0] + separator + precommand + action[1][0]
                 merged_actions[-1][0] = (previous_action[0], tuple([merged_action_command]), previous_action[2])
                 merged_actions[-1][1].append(callback)
                 merged_actions[-1][2].append(token)

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -148,7 +148,7 @@ class RemoteExecutor:
                 if action[0] == 'sudo':
                     precommand = 'sudo '
                 previous_action = merged_actions[-1][0]
-                merged_action_command = previous_action[1][0] + separator + precommand + action[1][0]
+                merged_action_command = previous_action[1][0] + separator + precommand + str(action[1][0])
                 merged_actions[-1][0] = (previous_action[0], tuple([merged_action_command]), previous_action[2])
                 merged_actions[-1][1].append(callback)
                 merged_actions[-1][2].append(token)

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -148,7 +148,7 @@ class RemoteExecutor:
                 if action[0] == 'sudo':
                     precommand = 'sudo '
                 previous_action = merged_actions[-1][0]
-                merged_action_command = previous_action[1][0] + str(separator) + precommand + action[1][0]
+                merged_action_command = previous_action[1][0] + separator + precommand + action[1][0]
                 merged_actions[-1][0] = (previous_action[0], tuple([merged_action_command]), previous_action[2])
                 merged_actions[-1][1].append(callback)
                 merged_actions[-1][2].append(token)

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -148,7 +148,7 @@ class RemoteExecutor:
                 if action[0] == 'sudo':
                     precommand = 'sudo '
                 previous_action = merged_actions[-1][0]
-                merged_action_command = previous_action[1][0] + separator + precommand + action[1][0]
+                merged_action_command = str(previous_action[1][0]) + separator + precommand + str(action[1][0])
                 merged_actions[-1][0] = (previous_action[0], tuple([merged_action_command]), previous_action[2])
                 merged_actions[-1][1].append(callback)
                 merged_actions[-1][2].append(token)

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -148,7 +148,7 @@ class RemoteExecutor:
                 if action[0] == 'sudo':
                     precommand = 'sudo '
                 previous_action = merged_actions[-1][0]
-                merged_action_command = previous_action[1][0] + separator + precommand + action[1][0]
+                merged_action_command = previous_action[1][0] + str(separator) + precommand + action[1][0]
                 merged_actions[-1][0] = (previous_action[0], tuple([merged_action_command]), previous_action[2])
                 merged_actions[-1][1].append(callback)
                 merged_actions[-1][2].append(token)


### PR DESCRIPTION
### Description
* Need to check that unattended-updates process is running at the moment because it affect to another procedures with apt package manager.

Fixes # (issue)
MANOPD-81998

### Solution
* A one-line command was added to the **"get_install_cmd"** function in **apt.py** to check the running unattended-upgrades process before starting "apt upgrade/install/purge"


- Hardware: 
- OS: Ubuntu 20.04, 22.04
- Inventory: 


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


