### PR TITLE
[MANOPD-87506] Wrong format for ipv6 address and port in kubeconfig

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -474,6 +474,8 @@ def fetch_admin_config(cluster: KubernetesCluster) -> str:
     # Replace cluster FQDN with ip
     public_cluster_ip = cluster.inventory.get('public_cluster_ip')
     if public_cluster_ip:
+        if type(ipaddress.ip_address(public_cluster_ip)) is ipaddress.IPv6Address:
+            public_cluster_ip = f"[{public_cluster_ip}]"
         cluster_name = cluster.inventory['cluster_name']
         kubeconfig = kubeconfig.replace(cluster_name, public_cluster_ip)
 


### PR DESCRIPTION
### Description
* Local `kubeconfig` has unreachable cluster URL in case of using IPv6. For instance:
```yaml
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: <...data...>
    server: https://2a03:7900:6:0:a00:27ff:fefb:e20f:6443
...
```

### Solution
* Implement code changes that wrap IPv6 address in local version of `kubeconfig` into brackets


### How to apply
Not applicable since we do not have a lot of IPv6 installations


### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 22.04
- Inventory: AllInOne

Steps:

1. Run Kubernetes installation from IPv6 environment
2. Check the content of `kubeconfig` file that is allocated in `KubeMarine` running folder 

Results:

| Before | After |
| ------ | ------ |
| wrong IPv6 URL format | correct IPv6 URL format  |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts



