### PR TITLE
[MANOPD-87510] Ingress-nginx-controller installation error (IPv6)

### DIFF
--- a/kubemarine/plugins/nginx_ingress.py
+++ b/kubemarine/plugins/nginx_ingress.py
@@ -291,6 +291,7 @@ class IngressNginxManifestProcessor(Processor):
             plugin_service='webhook', container_name='patch', is_init_container=False)
 
     def enrich_service_ingress_nginx_controller(self, manifest: Manifest):
+        # The method needs some rework in case of dual stack support
         key = "Service_ingress-nginx-controller"
         ip = self.inventory['services']['kubeadm']['networking']['serviceSubnet'].split('/')[0]
         if type(ipaddress.ip_address(ip)) is ipaddress.IPv6Address:

--- a/test/unit/plugins/test_nginx_ingress.py
+++ b/test/unit/plugins/test_nginx_ingress.py
@@ -181,6 +181,15 @@ class ManifestEnrichment(_AbstractManifestEnrichmentTest):
                 self.assertEqual(expected_num_resources, webhook_resources,
                                  f"ingress-nginx for {k8s_version} should have {expected_num_resources} webhook resources")
 
+    def test_service_ipv6(self):
+        inventory = self.inventory(self.k8s_latest)
+        inventory['nodes'][0]['internal_address'] = '2001::1'
+        cluster = demo.new_cluster(inventory)
+        manifest = self.enrich_yaml(cluster)
+        data = self.get_obj(manifest, "Service_ingress-nginx-controller")
+        self.assertEqual(['IPv6'], data['spec']['ipFamilies'],
+                        f"ingress-nginx enrichment error for IPv6 family")
+
     def test_v1_2_x_controller_container_difference(self):
         for k8s_version, presence_checker in (
             (self.k8s_1_24_x, self.assertFalse),


### PR DESCRIPTION
### Description
* Kubernetes v1.25+ installation fails on `ingress-nginx-controller` plugin step in case of `IPv6` stack usage. The error message:
```
The Service "ingress-nginx-controller" is invalid: spec.ipFamilies[0]: Invalid value: "IPv4": not configured on this cluster
2023-04-19 13:03:59,633 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL FAILURE!
2023-04-19 13:03:59,638 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL TASK FAILED deploy.plugins
2023-04-19 13:03:59,639 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL KME0002: Remote group exception
2023-04-19 13:03:59,641 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 2*****************f:
2023-04-19 13:03:59,642 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 	Encountered a bad command exit code!
2023-04-19 13:03:59,642 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 	
2023-04-19 13:03:59,642 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 	Command: "sudo -S -p '[sudo] password: ' kubectl apply -f /etc/kubernetes/nginx-ingress-controller-v1.4.0.yaml"
2023-04-19 13:03:59,642 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 	
2023-04-19 13:03:59,642 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 	Exit code: 1
2023-04-19 13:03:59,642 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 	
2023-04-19 13:03:59,642 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 	Stdout: already printed
2023-04-19 13:03:59,642 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 	
2023-04-19 13:03:59,642 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 	Stderr: already printed
2023-04-19 13:03:59,642 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 	
2023-04-19 13:03:59,642 qa-all-in-one-kubernetes.openshift.sdntest.local CRITICAL 	
```

### Solution
* Add enrichment method for `ingress-nginx-controller` `Service` that makes replacement in original YAML for `IPv6` stack installation.


### How to apply
Not applicable


### Test Cases


**TestCase 1**

Check if the Kubernetes v1.25 installation works for `IPv6` stack

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 22.04
- Inventory: AllInOne

Steps:

1. Create `cluster.yaml` with `IPv6` stack and `ingress-nginx-controller` plugin enabled
2. Run Kubernetes installation

Results:

| Before | After |
| ------ | ------ |
| Fail | Success |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts




