### PR TITLE
[MANOPD-87644] Logs from pods are unavailable in kubernetes

### DIFF
--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -32,7 +32,7 @@ services:
     apiVersion: kubelet.config.k8s.io/v1beta1
     kind: KubeletConfiguration
     readOnlyPort: 0
-    enableDebuggingHandlers: false
+    enableDebuggingHandlers: true
     protectKernelDefaults: true
     podPidsLimit: 4096
     cgroupDriver: systemd


### PR DESCRIPTION
### Description
* If the `enableDebuggingHandlers` parameter is enabled, the kube-apiserver logs will not be available.
* It is necessary to make the default parameter enabled, with the ability to disable it via cluster.yaml

Fixes # (issue)
[MANOPD-87644]

### Solution
* The parameter is enabled by default in default.yaml

### How to apply
If you need an enabled parameter `enableDebuggingHandlers`
Then follow the steps

1 - You need to add a parameter `enableDebuggingHandlers: false` to kubeadm-flags.env
Path /var/lib/kubelet/kubeadm-flags.env
Example:
```
apiVersion: kubelet.config.k8s.io/v1beta1
...
enableDebuggingHandlers: false
...
```
2 - You need to restart kubelet with the command: 
`systemctl restart kubelet`


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


