### PR TITLE
MANOPD-87827 Ensure thirdparties management approach

### DIFF
--- a/kubemarine/__main__.py
+++ b/kubemarine/__main__.py
@@ -159,11 +159,7 @@ Usage: kubemarine <procedure> <arguments>
 ''' % '\n'.join(descriptions_print_list))
         sys.exit(1)
 
-    result = import_procedure(arguments[0]).main(arguments[1:])
-    if result is not None:
-        from kubemarine.testsuite import TestSuite
-        if isinstance(result, TestSuite) and result.is_any_test_failed():
-            sys.exit(1)
+    import_procedure(arguments[0]).main(arguments[1:])
 
 
 def import_procedure(name):

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -147,6 +147,7 @@ class KubernetesCluster(Environment):
         return [
             "kubemarine.core.schema.verify_inventory",
             "kubemarine.core.defaults.merge_defaults",
+            "kubemarine.kubernetes.verify_initial_version",
             "kubemarine.kubernetes.add_node_enrichment",
             "kubemarine.kubernetes.remove_node_enrichment",
             "kubemarine.controlplane.controlplane_node_enrichment",

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -199,11 +199,7 @@ def apply_registry(inventory, cluster):
             containerd_config[path] = {}
         if not containerd_config[path].get('sandbox_image'):
             kubernetes_version = inventory['services']['kubeadm']['kubernetesVersion']
-            pause_mapping = cluster.globals['compatibility_map']['software']['pause']
-            if kubernetes_version not in pause_mapping:
-                raise Exception(f"Failed to detect pause version for Kubernetes {kubernetes_version}. "
-                                f"Please explicitly specify services.cri.containerdConfig.{path}.sandbox_image section.")
-            pause_version = pause_mapping[kubernetes_version]['version']
+            pause_version = cluster.globals['compatibility_map']['software']['pause'][kubernetes_version]['version']
             containerd_config[path]['sandbox_image'] = \
                 f"{inventory['services']['kubeadm']['imageRepository']}/pause:{pause_version}"
 

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -29,6 +29,7 @@ from kubemarine.core.yaml_merger import default_merger
 DEFAULT_ENRICHMENT_FNS = [
     "kubemarine.core.schema.verify_inventory",
     "kubemarine.core.defaults.merge_defaults",
+    "kubemarine.kubernetes.verify_initial_version",
     "kubemarine.admission.enrich_default_admission",
     "kubemarine.kubernetes.add_node_enrichment",
     "kubemarine.kubernetes.remove_node_enrichment",

--- a/kubemarine/core/errors.py
+++ b/kubemarine/core/errors.py
@@ -36,6 +36,9 @@ KME_DICTIONARY = {
     "KME0007": {
         "name": "Docker CRI can not be used with endpoints registry definition."
     },
+    "KME0008": {
+        "name": "Specified Kubernetes version '{version}' - cannot be used! Allowed versions are: {allowed_versions}."
+    }
 }
 
 

--- a/kubemarine/core/flow.py
+++ b/kubemarine/core/flow.py
@@ -17,10 +17,11 @@ import os
 import shlex
 import sys
 import time
+from abc import abstractmethod, ABC
 from copy import deepcopy
 from typing import Type, Optional, List, Union
 
-from kubemarine.core import utils, cluster as c, action, resources as res, errors, summary
+from kubemarine.core import utils, cluster as c, action, resources as res, errors, summary, log
 
 DEFAULT_CLUSTER_OBJ: Optional[Type[c.KubernetesCluster]] = None
 TASK_DESCRIPTION_TEMPLATE = """
@@ -31,33 +32,75 @@ tasks list:
 END_OF_TASKS = object()
 
 
-def run_actions(context: Union[dict, res.DynamicResources], actions: List[action.Action],
-                print_summary: bool = True) -> Optional[c.KubernetesCluster]:
+class FlowResult:
+    def __init__(self, context: dict, logger: log.EnhancedLogger):
+        self.context = context
+        self.logger = logger
+
+
+class Flow(ABC):
+    def run_flow(self, context: Union[dict, res.DynamicResources], print_summary: bool = True) -> FlowResult:
+        time_start = time.time()
+
+        resources: res.DynamicResources = context
+        if isinstance(context, dict):
+            resources = res.DynamicResources(context)
+
+        context = resources.context
+        args: dict = context['execution_arguments']
+
+        try:
+            if not args.get('disable_dump', True):
+                utils.prepare_dump_directory(args.get('dump_location'),
+                                             reset_directory=not args.get('disable_dump_cleanup', False))
+            logger = resources.logger()
+            self._run(resources)
+        except Exception as exc:
+            logger = resources.logger_if_initialized()
+            if isinstance(exc, errors.FailException):
+                utils.do_fail(exc.message, exc.reason, exc.hint, log=logger)
+            else:
+                utils.do_fail(f"'{context['initial_procedure'] or 'undefined'}' procedure failed.", exc,
+                              log=logger)
+
+        time_end = time.time()
+
+        if print_summary:
+            summary.schedule_report(resources.working_context, summary.SummaryItem.EXECUTION_TIME,
+                                    utils.get_elapsed_string(time_start, time_end))
+            summary.print_summary(resources.working_context, logger)
+            logger.info("SUCCESSFULLY FINISHED")
+
+        return FlowResult(resources.working_context, logger)
+
+    @abstractmethod
+    def _run(self, resources: res.DynamicResources):
+        pass
+
+
+class ActionsFlow(Flow):
+    def __init__(self, actions: List[action.Action]):
+        self._actions = actions
+
+    def _run(self, resources: res.DynamicResources):
+        run_actions(resources, self._actions)
+
+
+def run_actions(resources: res.DynamicResources, actions: List[action.Action]) -> None:
     """
     Runs actions one by one, recreates inventory when necessary,
     managing such resources as cluster object and raw inventory.
 
     For each initialized cluster object, preserves inventory if any action is succeeded.
     """
-    time_start = time.time()
-
-    resources: res.DynamicResources = context
-    if isinstance(context, dict):
-        resources = res.DynamicResources(context)
 
     context = resources.context
-
-    args: dict = context['execution_arguments']
-    if not args.get('disable_dump', True):
-        utils.prepare_dump_directory(args.get('dump_location'),
-                                     reset_directory=not args.get('disable_dump_cleanup', False))
-
-    log = resources.logger()
+    logger = resources.logger()
 
     successfully_performed = []
     last_cluster = None
     for act in actions:
-        act.prepare_context(resources.context)
+        act.prepare_context(context)
 
         if not successfully_performed:
             # first action in group
@@ -69,18 +112,14 @@ def run_actions(context: Union[dict, res.DynamicResources], actions: List[action
                 with utils.open_external(resources.procedure_inventory_filepath, "r") as stream:
                     utils.dump_file(context, stream, "procedure.yaml")
         try:
-            log.info(f"Running action '{act.identifier}'")
+            logger.info(f"Running action '{act.identifier}'")
             act.run(resources)
             successfully_performed.append(act.identifier)
-        except Exception as exc:
+        except Exception:
             if successfully_performed:
                 _post_process_actions_group(last_cluster, context, successfully_performed, failed=True)
 
-            if isinstance(exc, errors.FailException):
-                utils.do_fail(exc.message, exc.reason, exc.hint, log=log)
-            else:
-                utils.do_fail(f"'{context['initial_procedure'] or 'undefined'}' procedure failed.", exc,
-                              log=log)
+            raise
 
         last_cluster = resources.cluster_if_initialized()
 
@@ -100,18 +139,8 @@ def run_actions(context: Union[dict, res.DynamicResources], actions: List[action
     if successfully_performed:
         _post_process_actions_group(last_cluster, context, successfully_performed)
 
-    time_end = time.time()
 
-    if print_summary:
-        summary.schedule_report(resources.working_context, summary.SummaryItem.EXECUTION_TIME,
-                                utils.get_elapsed_string(time_start, time_end))
-        summary.print_summary(resources.working_context, log)
-        log.info("SUCCESSFULLY FINISHED")
-
-    return last_cluster
-
-
-def _post_process_actions_group(last_cluster: c.KubernetesCluster, context: dict,
+def _post_process_actions_group(last_cluster: Optional[c.KubernetesCluster], context: dict,
                                 successfully_performed: list, failed=False):
     if last_cluster is None:
         return
@@ -159,7 +188,7 @@ def run_tasks(resources: res.DynamicResources, tasks, cumulative_points=None, ta
         return
 
     init_tasks_flow(cluster)
-    run_flow(tasks, final_list, cluster, cumulative_points, [])
+    run_tasks_recursive(tasks, final_list, cluster, cumulative_points, [])
     proceed_cumulative_point(cluster, cumulative_points, END_OF_TASKS,
                              force=args.get('force_cumulative_points', False))
 
@@ -246,8 +275,8 @@ def _filter_flow_internal(tasks, tasks_filter: List[List[str]], excluded_tasks: 
     return filtered, final_list
 
 
-def run_flow(tasks: dict, final_task_names: List[str], cluster: c.KubernetesCluster,
-             cumulative_points: dict, _task_path: List[str]):
+def run_tasks_recursive(tasks: dict, final_task_names: List[str], cluster: c.KubernetesCluster,
+                        cumulative_points: dict, _task_path: List[str]):
     for task_name, task in tasks.items():
         __task_path = _task_path + [task_name]
         __task_name = ".".join(__task_path)
@@ -271,7 +300,7 @@ def run_flow(tasks: dict, final_task_names: List[str], cluster: c.KubernetesClus
                     hint=cluster.globals['error_handling']['failure_message'] % (sys.argv[0], __task_name)
                 )
         else:
-            run_flow(task, final_task_names, cluster, cumulative_points, __task_path)
+            run_tasks_recursive(task, final_task_names, cluster, cumulative_points, __task_path)
 
 
 def new_common_parser(cli_help):

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -53,6 +53,9 @@ class DynamicResources:
         self.inventory_filepath = args['config']
         self.procedure_inventory_filepath = args.get('procedure_config')
 
+    def logger_if_initialized(self):
+        return self._logger
+
     def logger(self):
         if self._logger is None:
             self._logger = self._create_logger()

--- a/kubemarine/core/static.py
+++ b/kubemarine/core/static.py
@@ -24,14 +24,21 @@ def reload():
     DEFAULTS.clear()
     DEFAULTS.update(_load_defaults())
 
-    global SUPPORTED_VERSIONS
-    SUPPORTED_VERSIONS.clear()
-    SUPPORTED_VERSIONS.update(_load_supported_versions())
+    global KUBERNETES_VERSIONS
+    KUBERNETES_VERSIONS.clear()
+    KUBERNETES_VERSIONS.update(load_kubernetes_versions())
 
 
 def load_compatibility_map(filename: str) -> dict:
     return utils.load_yaml(utils.get_internal_resource_path(
         f"resources/configurations/compatibility/internal/{filename}"))
+
+
+def load_kubernetes_versions() -> dict:
+    kubernetes_versions = utils.load_yaml(
+        utils.get_internal_resource_path('resources/configurations/compatibility/kubernetes_versions.yaml'))
+
+    return kubernetes_versions
 
 
 def _load_globals() -> dict:
@@ -56,15 +63,8 @@ def _load_defaults() -> dict:
         utils.get_internal_resource_path('resources/configurations/defaults.yaml'))
 
 
-def _load_supported_versions() -> dict:
-    kubernetes_versions = utils.load_yaml(
-        utils.get_internal_resource_path('resources/configurations/compatibility/kubernetes_versions.yaml'))
-
-    return kubernetes_versions['kubernetes_versions']
-
-
 GLOBALS = {}
 DEFAULTS = {}
-SUPPORTED_VERSIONS = {}
+KUBERNETES_VERSIONS = {}
 
 reload()

--- a/kubemarine/k8s_certs.py
+++ b/kubemarine/k8s_certs.py
@@ -14,19 +14,11 @@
 
 from kubemarine import kubernetes
 
-version_kubectl_alpha_removed = "v1.21.0"
-
 
 def k8s_certs_overview(control_planes):
-    if kubernetes.version_higher_or_equal(control_planes.cluster.inventory['services']['kubeadm']['kubernetesVersion'],
-                                          version_kubectl_alpha_removed):
-        for control_plane in control_planes.get_ordered_members_list(provide_node_configs=True):
-            control_planes.cluster.log.debug(f"Checking certs expiration for control_plane {control_plane['name']}")
-            control_plane['connection'].sudo("kubeadm certs check-expiration", hide=False)
-    else:
-        for control_plane in control_planes.get_ordered_members_list(provide_node_configs=True):
-            control_planes.cluster.log.debug(f"Checking certs expiration for control_plane {control_plane['name']}")
-            control_plane['connection'].sudo("kubeadm alpha certs check-expiration", hide=False)
+    for control_plane in control_planes.get_ordered_members_list(provide_node_configs=True):
+        control_planes.cluster.log.debug(f"Checking certs expiration for control_plane {control_plane['name']}")
+        control_plane['connection'].sudo("kubeadm certs check-expiration", hide=False)
 
 
 def renew_verify(inventory, cluster):
@@ -45,13 +37,8 @@ def renew_apply(control_planes):
     procedure = control_planes.cluster.procedure_inventory["kubernetes"]
     cert_list = procedure["cert-list"]
 
-    if kubernetes.version_higher_or_equal(control_planes.cluster.inventory['services']['kubeadm']['kubernetesVersion'],
-                                          version_kubectl_alpha_removed):
-        for cert in cert_list:
-            control_planes.sudo(f"kubeadm certs renew {cert}")
-    else:
-        for cert in cert_list:
-            control_planes.sudo(f"kubeadm alpha certs renew {cert}")
+    for cert in cert_list:
+        control_planes.sudo(f"kubeadm certs renew {cert}")
 
     if "all" in cert_list or "admin.conf" in cert_list:
         # need to update cluster-admin config

--- a/kubemarine/procedures/add_node.py
+++ b/kubemarine/procedures/add_node.py
@@ -128,7 +128,7 @@ def main(cli_arguments=None):
     parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure='add_node')
 
-    flow.run_actions(context, [AddNodeAction()])
+    flow.ActionsFlow([AddNodeAction()]).run_flow(context)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -468,7 +468,7 @@ def main(cli_arguments=None):
         }
     }
 
-    flow.run_actions(context, [BackupAction()])
+    flow.ActionsFlow([BackupAction()]).run_flow(context)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/cert_renew.py
+++ b/kubemarine/procedures/cert_renew.py
@@ -74,7 +74,7 @@ def main(cli_arguments=None):
     parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure='cert_renew')
 
-    flow.run_actions(context, [CertRenewAction()])
+    flow.ActionsFlow([CertRenewAction()]).run_flow(context)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -877,11 +877,11 @@ def check_tcp_ports(cluster):
                                        f"Ports that should be opened: {tcp_ports}")
 
 
-def make_reports(cluster):
-    if not cluster.context['execution_arguments'].get('disable_csv_report', False):
-        cluster.context['testsuite'].save_csv(cluster.context['execution_arguments']['csv_report'], cluster.context['execution_arguments']['csv_report_delimiter'])
-    if not cluster.context['execution_arguments'].get('disable_html_report', False):
-        cluster.context['testsuite'].save_html(cluster.context['execution_arguments']['html_report'], cluster.context['initial_procedure'].upper())
+def make_reports(context: dict):
+    if not context['execution_arguments'].get('disable_csv_report', False):
+        context['testsuite'].save_csv(context['execution_arguments']['csv_report'], context['execution_arguments']['csv_report_delimiter'])
+    if not context['execution_arguments'].get('disable_html_report', False):
+        context['testsuite'].save_html(context['execution_arguments']['html_report'], context['initial_procedure'].upper())
 
 
 tasks = OrderedDict({
@@ -978,17 +978,20 @@ def main(cli_arguments=None):
     context['testsuite'] = TestSuite()
     context['preserve_inventory'] = False
 
-    cluster = flow.run_actions(context, [IaasAction()], print_summary=False)
+    flow_ = flow.ActionsFlow([IaasAction()])
+    result = flow_.run_flow(context, print_summary=False)
+
+    context = result.context
+    testsuite: TestSuite = context['testsuite']
 
     # Final summary should be printed only to stdout with custom formatting
     # If test results are required for parsing, they can be found in the test results files
-    print(cluster.context['testsuite'].get_final_summary())
-    cluster.context['testsuite'].print_final_status(cluster.log)
-    make_reports(cluster)
-    return cluster.context['testsuite']
+    print(testsuite.get_final_summary())
+    testsuite.print_final_status(result.logger)
+    make_reports(context)
+    if testsuite.is_any_test_failed():
+        sys.exit(1)
 
 
 if __name__ == '__main__':
-    testsuite = main()
-    if testsuite.is_any_test_failed():
-        sys.exit(1)
+    main()

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1420,17 +1420,20 @@ def main(cli_arguments=None):
     context['testsuite'] = TestSuite()
     context['preserve_inventory'] = False
 
-    cluster = flow.run_actions(context, [PaasAction()], print_summary=False)
+    flow_ = flow.ActionsFlow([PaasAction()])
+    result = flow_.run_flow(context, print_summary=False)
+
+    context = result.context
+    testsuite: TestSuite = context['testsuite']
 
     # Final summary should be printed only to stdout with custom formatting
     # If tests results required for parsing, they can be found in test results files
-    print(cluster.context['testsuite'].get_final_summary(show_minimal=False, show_recommended=False))
-    cluster.context['testsuite'].print_final_status(cluster.log)
-    check_iaas.make_reports(cluster)
-    return cluster.context['testsuite']
+    print(testsuite.get_final_summary(show_minimal=False, show_recommended=False))
+    testsuite.print_final_status(result.logger)
+    check_iaas.make_reports(context)
+    if testsuite.is_any_test_failed():
+        sys.exit(1)
 
 
 if __name__ == '__main__':
-    testsuite = main()
-    if testsuite.is_any_test_failed():
-        sys.exit(1)
+    main()

--- a/kubemarine/procedures/do.py
+++ b/kubemarine/procedures/do.py
@@ -124,8 +124,9 @@ def main(cli_arguments=None):
             return cluster.nodes['control-plane'].get_any_member()
 
     no_stream = arguments.get('no_stream')
-    res = resources.DynamicResources(context, silent=False)
-    flow.run_actions(res, [CLIAction(node_group_provider, remote_args, no_stream)], print_summary=False)
+    action = CLIAction(node_group_provider, remote_args, no_stream)
+    res = resources.DynamicResources(context, silent=True)
+    flow.ActionsFlow([action]).run_flow(res, print_summary=False)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -31,7 +31,7 @@ from kubemarine.core import flow, utils, summary
 from kubemarine.core.executor import RemoteExecutor
 from kubemarine.core.group import NodeGroup
 from kubemarine.core.resources import DynamicResources
-from kubemarine import kubernetes
+
 
 def _applicable_for_new_nodes_with_roles(*roles):
     """
@@ -681,7 +681,7 @@ def main(cli_arguments=None):
     flow.run_actions(context, [install])
 
     if install.verification_version_result:
-        print(install.verification_version_result)
+        utils.warning(install.verification_version_result)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -653,15 +653,11 @@ cumulative_points = {
 class InstallAction(Action):
     def __init__(self):
         super().__init__('install')
-        self.verification_version_result = ""
+        self.target_version = None
 
     def run(self, res: DynamicResources):
-        cluster_yml = res.raw_inventory()
-        if (cluster_yml.get("services", {})
-                and cluster_yml["services"].get("kubeadm", {})
-                and cluster_yml["services"]["kubeadm"].get("kubernetesVersion")):
-            target_version = cluster_yml["services"]["kubeadm"].get("kubernetesVersion")
-            self.verification_version_result = kubernetes.verify_target_version(target_version, res.logger())
+        self.target_version = kubernetes.get_initial_kubernetes_version(res.raw_inventory())
+        kubernetes.verify_supported_version(self.target_version, res.logger())
 
         flow.run_tasks(res, tasks, cumulative_points=cumulative_points)
 
@@ -681,8 +677,7 @@ def main(cli_arguments=None):
     flow_ = flow.ActionsFlow([install])
     result = flow_.run_flow(context)
 
-    if install.verification_version_result:
-        result.logger.warning(install.verification_version_result)
+    kubernetes.verify_supported_version(install.target_version, result.logger)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -661,7 +661,7 @@ class InstallAction(Action):
                 and cluster_yml["services"].get("kubeadm", {})
                 and cluster_yml["services"]["kubeadm"].get("kubernetesVersion")):
             target_version = cluster_yml["services"]["kubeadm"].get("kubernetesVersion")
-            self.verification_version_result = kubernetes.verify_target_version(target_version)
+            self.verification_version_result = kubernetes.verify_target_version(target_version, res.logger())
 
         flow.run_tasks(res, tasks, cumulative_points=cumulative_points)
 
@@ -678,10 +678,11 @@ def main(cli_arguments=None):
     context = flow.create_context(parser, cli_arguments, procedure='install')
 
     install = InstallAction()
-    flow.run_actions(context, [install])
+    flow_ = flow.ActionsFlow([install])
+    result = flow_.run_flow(context)
 
     if install.verification_version_result:
-        utils.warning(install.verification_version_result)
+        result.logger.warning(install.verification_version_result)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/manage_psp.py
+++ b/kubemarine/procedures/manage_psp.py
@@ -52,7 +52,7 @@ def main(cli_arguments=None):
     parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure='manage_psp')
 
-    flow.run_actions(context, [PSPAction()])
+    flow.ActionsFlow([PSPAction()]).run_flow(context)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/manage_pss.py
+++ b/kubemarine/procedures/manage_pss.py
@@ -50,7 +50,7 @@ def main(cli_arguments=None):
     parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure='manage_pss')
 
-    flow.run_actions(context, [PSSAction()])
+    flow.ActionsFlow([PSSAction()]).run_flow(context)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/migrate_cri.py
+++ b/kubemarine/procedures/migrate_cri.py
@@ -327,7 +327,7 @@ def main(cli_arguments=None):
     parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure="migrate_cri")
 
-    flow.run_actions(context, [MigrateCRIAction()])
+    flow.ActionsFlow([MigrateCRIAction()]).run_flow(context)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/migrate_kubemarine.py
+++ b/kubemarine/procedures/migrate_kubemarine.py
@@ -94,7 +94,7 @@ def main(cli_arguments=None):
     if not actions:
         print("No patches to apply")
         exit(0)
-    flow.run_actions(context, actions)
+    flow.ActionsFlow(actions).run_flow(context)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/reboot.py
+++ b/kubemarine/procedures/reboot.py
@@ -69,7 +69,7 @@ def main(cli_arguments=None):
 
     context = flow.create_context(parser, cli_arguments, procedure='reboot')
 
-    flow.run_actions(context, [RebootAction()])
+    flow.ActionsFlow([RebootAction()]).run_flow(context)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/remove_node.py
+++ b/kubemarine/procedures/remove_node.py
@@ -172,7 +172,7 @@ def main(cli_arguments=None):
     parser = flow.new_procedure_parser(cli_help, tasks=tasks)
     context = flow.create_context(parser, cli_arguments, procedure='remove_node')
 
-    flow.run_actions(context, [RemoveNodeAction()])
+    flow.ActionsFlow([RemoveNodeAction()]).run_flow(context)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -290,7 +290,7 @@ def main(cli_arguments=None):
 
     replace_config_from_backup_if_needed(args['procedure_config'], args['config'])
 
-    flow.run_actions(context, [RestoreAction()])
+    flow.ActionsFlow([RestoreAction()]).run_flow(context)
 
 
 if __name__ == '__main__':

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -116,10 +116,7 @@ def upgrade_containerd(cluster: KubernetesCluster):
     if cri == 'containerd':
         path = 'plugins."io.containerd.grpc.v1.cri"'
         target_kubernetes_version = cluster.context["upgrade_version"]
-        pause_mapping = cluster.globals['compatibility_map']['software']['pause']
-        if target_kubernetes_version not in pause_mapping:
-            raise Exception(f"Upgrade to {target_kubernetes_version} is not supported")
-        pause_version = pause_mapping[target_kubernetes_version]['version']
+        pause_version = cluster.globals['compatibility_map']['software']['pause'][target_kubernetes_version]['version']
         if not cluster.inventory["services"]["cri"]['containerdConfig'].get(path, False):
             return
         last_pause_version = cluster.inventory["services"]["cri"]['containerdConfig'][path]["sandbox_image"].split(":")[

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -19,6 +19,7 @@ from copy import deepcopy
 from distutils.util import strtobool
 from io import StringIO
 from itertools import chain
+from typing import List
 
 import toml
 
@@ -252,17 +253,13 @@ def main(cli_arguments=None):
         print(verification_version_result)
 
 
-def verify_upgrade_plan(upgrade_plan):
-    if not upgrade_plan:
-        raise Exception('Upgrade plan is not specified or empty')
-
-    upgrade_plan.sort()
+def verify_upgrade_plan(upgrade_plan: List[str]):
+    for version in upgrade_plan:
+        kubernetes.verify_allowed_version(version)
+    upgrade_plan.sort(key=utils.version_key)
 
     previous_version = None
-    for i in range(0, len(upgrade_plan)):
-        version = upgrade_plan[i]
-        if version == 'v1.24.0':
-            raise Exception('Attempt to upgrade to an unstable version of kubernetes')
+    for version in upgrade_plan:
         if previous_version is not None:
             kubernetes.test_version_upgrade_possible(previous_version, version)
         previous_version = version

--- a/kubemarine/resources/configurations/compatibility/internal/packages.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/packages.yaml
@@ -1,6 +1,7 @@
 # This configuration is partially generated and maintained by "scripts/thirdparties/sync.py"
-# If new Kubernetes version is added, the compatibility mapping is inserted with fake "0.0.0" versions.
-# The developer should manually choose the required package versions.
+#
+# If new Kubernetes version is added, the compatibility mapping is taken from the previous Kubernetes versions.
+# The developer should manually change the required package versions if necessary.
 docker:
   v1.21.2:
     version_rhel: 19.03*

--- a/kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
+++ b/kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
@@ -109,3 +109,9 @@ compatibility_map:
 
 
 # After any change, please run scripts/thirdparties/sync.py
+
+# The following optional keys are supported in addition to the 5 required software keys:
+#<Kubernetes version>:
+#  webhook: <version>
+#  metrics-scraper: <version>
+#  busybox: <version>

--- a/scripts/thirdparties/src/compatibility.py
+++ b/scripts/thirdparties/src/compatibility.py
@@ -36,7 +36,7 @@ class KubernetesVersions:
 
     def sync(self):
         k8s_versions = self._kubernetes_versions['kubernetes_versions']
-        k8s_versions = utils.map_sorted(k8s_versions, key=utils.version_key)
+        k8s_versions = utils.map_sorted(k8s_versions, key=utils.minor_version_key)
         self._kubernetes_versions['kubernetes_versions'] = k8s_versions
 
         minor_versions = set()
@@ -45,7 +45,7 @@ class KubernetesVersions:
             minor_versions.add(minor_version)
             if minor_version not in k8s_versions:
                 utils.insert_map_sorted(k8s_versions, minor_version, CommentedMap({'supported': True}),
-                                        key=utils.version_key)
+                                        key=utils.minor_version_key)
 
         for key in list(k8s_versions):
             if key not in minor_versions:

--- a/scripts/thirdparties/src/compatibility.py
+++ b/scripts/thirdparties/src/compatibility.py
@@ -63,7 +63,10 @@ class KubernetesVersions:
     def _validate_mapping(self):
         mandatory_fields = set(static.GLOBALS['plugins'])
         mandatory_fields.update(['crictl'])
-        optional_fields = {'pause', 'webhook', 'metrics-scraper', 'busybox'}
+        optional_fields = {
+            'webhook', 'metrics-scraper', 'busybox',
+            # 'pause',
+        }
 
         compatibility_map = self._kubernetes_versions['compatibility_map']
         for k8s_version, software in compatibility_map.items():

--- a/scripts/thirdparties/src/compatibility.py
+++ b/scripts/thirdparties/src/compatibility.py
@@ -65,6 +65,8 @@ class KubernetesVersions:
         mandatory_fields.update(['crictl'])
         optional_fields = {
             'webhook', 'metrics-scraper', 'busybox',
+            # Although we are able to operate with pause image, custom version is not fully supported,
+            # because pause image version is not enriched when installing in public.
             # 'pause',
         }
 

--- a/scripts/thirdparties/src/software/kubernetes_images.py
+++ b/scripts/thirdparties/src/software/kubernetes_images.py
@@ -36,7 +36,6 @@ class KubernetesImages(SoftwareType):
     def sync(self, tracker: ChangesTracker):
         """
         Fetch all kubernetes images from 'kubeadm' executable and actualize the compatibility_map.
-        # TODO if pause version is changed, it is necessary to write patch that will reconfigure containerd.
         """
         k8s_versions = tracker.all_k8s_versions
         k8s_images_mapping = get_k8s_images_mapping(self.images_resolver, k8s_versions)

--- a/scripts/thirdparties/src/software/thirdparties.py
+++ b/scripts/thirdparties/src/software/thirdparties.py
@@ -21,9 +21,10 @@ from ..shell import curl, TEMP_FILE, SYNC_CACHE
 from ..tracker import ChangesTracker
 from . import SoftwareType, InternalCompatibility
 
-ERROR_ASCENDING_VERSIONS = "Third-parties should have non-decreasing versions. " \
-                           "Third-party '{thirdparty}' has version {older_version} for Kubernetes {older_k8s_version}, " \
-                           "and has lower version {newer_version} for newer Kubernetes {newer_k8s_version}"
+ERROR_ASCENDING_VERSIONS = \
+    "Third-parties should have non-decreasing versions. " \
+    "Third-party '{thirdparty}' has version {older_version} for Kubernetes {older_k8s_version}, " \
+    "and has lower version {newer_version} for newer Kubernetes {newer_k8s_version}"
 
 
 class ThirdpartyResolver:

--- a/test/unit/core/test_flow.py
+++ b/test/unit/core/test_flow.py
@@ -202,7 +202,7 @@ class FlowTest(unittest.TestCase):
         flow.init_tasks_flow(cluster)
         final_task_names = ["deploy.loadbalancer.haproxy", "deploy.loadbalancer.keepalived",
                             "deploy.accounts", "overview"]
-        flow.run_flow(tasks, final_task_names, cluster, {}, [])
+        flow.run_tasks_recursive(tasks, final_task_names, cluster, {}, [])
 
         self.assertEqual(4, cluster.context["test_info"], f"Here should be 4 calls of test_func for: {final_task_names}")
 
@@ -371,12 +371,10 @@ class FlowTest(unittest.TestCase):
         context = demo.create_silent_context([], parser=flow.new_tasks_flow_parser("Help text"))
         res = demo.FakeResources(context, inventory, fake_shell=self.light_fake_shell)
 
-        with self.assertRaisesRegex(Exception,
-                                    kubernetes.ERROR_NOT_ALLOWED % (re.escape(not_allowed_version), ".*")):
-            try:
-                flow.run_tasks(res, tasks)
-            except errors.FailException as e:
-                raise e.reason
+        with test_utils.assert_raises_kme(self, "KME0008",
+                                          version=re.escape(not_allowed_version),
+                                          allowed_versions='.*'):
+            flow.run_tasks(res, tasks)
 
     def _stub_detect_nodes_context(self, inventory: dict, online_nodes: list, sudoer_nodes: list):
         hosts = [node["address"] for node in inventory["nodes"]]

--- a/test/unit/core/test_flow.py
+++ b/test/unit/core/test_flow.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import os
 import random
+import re
 import socket
 import unittest
 import ast
@@ -22,8 +23,10 @@ from typing import Optional
 
 import invoke
 
-from kubemarine.core import flow, static, errors
-from kubemarine import demo
+from kubemarine.core import flow, static, errors, utils
+from kubemarine import demo, kubernetes
+from test.unit import utils as test_utils
+
 
 test_msg = "test_function_return_result"
 
@@ -354,6 +357,26 @@ class FlowTest(unittest.TestCase):
 
         # no exception should occur
         flow.run_tasks(res, tasks)
+
+    def test_kubernetes_version_not_allowed(self):
+        k8s_versions = list(sorted(static.KUBERNETES_VERSIONS["compatibility_map"], key=utils.version_key))
+        k8s_latest = k8s_versions[-1]
+        not_allowed_version =  test_utils.increment_version(k8s_latest)
+
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['services'].setdefault('kubeadm', {})['kubernetesVersion'] = not_allowed_version
+
+        hosts = [node["address"] for node in inventory["nodes"]]
+        self._stub_detect_nodes_context(inventory, hosts, hosts)
+        context = demo.create_silent_context([], parser=flow.new_tasks_flow_parser("Help text"))
+        res = demo.FakeResources(context, inventory, fake_shell=self.light_fake_shell)
+
+        with self.assertRaisesRegex(Exception,
+                                    kubernetes.ERROR_NOT_ALLOWED % (re.escape(not_allowed_version), ".*")):
+            try:
+                flow.run_tasks(res, tasks)
+            except errors.FailException as e:
+                raise e.reason
 
     def _stub_detect_nodes_context(self, inventory: dict, online_nodes: list, sudoer_nodes: list):
         hosts = [node["address"] for node in inventory["nodes"]]

--- a/test/unit/core/test_run_actions.py
+++ b/test/unit/core/test_run_actions.py
@@ -45,7 +45,7 @@ class RunActionsTest(unittest.TestCase):
                 super().__init__('test', recreate_inventory=True)
 
         res = FakeResources(self.context, {"p1": "v1"})
-        flow.run_actions(res, [TheAction()], print_summary=False)
+        flow.ActionsFlow([TheAction()]).run_flow(res, print_summary=False)
         self.assertEqual(res.recreated_inventory, {"p1": "v1", "p2": "v2"})
 
     def test_patch_cluster(self):
@@ -64,7 +64,7 @@ class RunActionsTest(unittest.TestCase):
         self.assertFalse('successfully_performed' in self.cluster.context)
 
         res = FakeResources(self.context, self.inventory, cluster=self.cluster)
-        flow.run_actions(res, [TheAction()], print_summary=False)
+        flow.ActionsFlow([TheAction()]).run_flow(res, print_summary=False)
         for host in nodes.get_hosts():
             history = fake_shell.history_find(host, 'sudo', ['whoami'])
             self.assertTrue(len(history) == 1 and history[0]["used_times"] == 1)

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -43,8 +43,9 @@ class UpgradeVerifyUpgradePlan(unittest.TestCase):
     def test_upgrade_plan_not_supported_version(self):
         k8s_latest = self.k8s_versions()[-1]
         not_allowed_version = utils.increment_version(k8s_latest)
-        with self.assertRaisesRegex(Exception, kubernetes.ERROR_NOT_ALLOWED
-                                               % (re.escape(not_allowed_version), '.*')):
+        with utils.assert_raises_kme(self, "KME0008",
+                                     version=re.escape(not_allowed_version),
+                                     allowed_versions='.*'):
             upgrade.verify_upgrade_plan([
                 k8s_latest,
                 not_allowed_version

--- a/test/unit/tools/thirdparties/stub.py
+++ b/test/unit/tools/thirdparties/stub.py
@@ -42,7 +42,7 @@ class FakeInternalCompatibility(InternalCompatibility):
 class FakeKubernetesVersions(KubernetesVersions):
     def __init__(self):
         super().__init__()
-        self.stored: Optional[dict] = None
+        self.stored: Optional[CommentedMap] = None
 
     @property
     def kubernetes_versions(self) -> CommentedMap:

--- a/test/unit/tools/thirdparties/test_sync.py
+++ b/test/unit/tools/thirdparties/test_sync.py
@@ -384,7 +384,7 @@ class SynchronizationTest(unittest.TestCase):
 
     def test_manifests_enrichment_update_plugin_versions(self):
         plugin = None
-        plugin_versions = []
+        plugin_versions = set()
         for plugin in ('calico', 'nginx-ingress-controller', 'kubernetes-dashboard', 'local-path-provisioner'):
             plugin_versions = set(v[plugin] for v in self.compatibility_map().values())
             if len(plugin_versions) > 1:
@@ -395,6 +395,7 @@ class SynchronizationTest(unittest.TestCase):
 
         k8s_oldest = self.k8s_versions()[0]
         plugin_oldest = self.compatibility_map()[k8s_oldest][plugin]
+        plugin_versions = sorted(plugin_versions, key=utils.version_key)
         plugin_versions.remove(plugin_oldest)
         new_plugin_version = list(plugin_versions)[0]
 

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import unittest
+from contextlib import contextmanager
 from typing import Dict
 
 from kubemarine import demo, packages
-from kubemarine.core import utils
+from kubemarine.core import utils, errors
 
 
 def make_finalized_inventory(cluster: demo.FakeKubernetesCluster):
@@ -63,3 +64,13 @@ def increment_version(version: str, minor=False):
     else:
         new_version[2] += 1
     return f"v{'.'.join(map(str, new_version))}"
+
+
+@contextmanager
+def assert_raises_kme(test: unittest.TestCase, code: str, **kwargs):
+    expected = errors.KME(code, **kwargs)
+    with test.assertRaisesRegex(errors.KME, str(expected)):
+        try:
+            yield
+        except errors.FailException as e:
+            raise e.reason

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -54,3 +54,12 @@ def stub_associations_packages(cluster: demo.FakeKubernetesCluster, packages_hos
         packages_hosts_stub.setdefault(package, {})
 
     stub_detect_packages(cluster, packages_hosts_stub)
+
+
+def increment_version(version: str, minor=False):
+    new_version = list(utils.version_key(version))
+    if minor:
+        new_version[1] += 1
+    else:
+        new_version[2] += 1
+    return f"v{'.'.join(map(str, new_version))}"


### PR DESCRIPTION
### Description
* It is necessary to restrict usages of not supported Kubernetes patch versions.
* Introduce rules to manage third-parties and add validation of them to the management tool.

### Solution
* Added exception if attempt to install/use/upgrade not supported Kubernetes patch versions.
* Added the following rules to the third-parties management tool:
    * It is allowed to remove Kubernetes version only with all previous versions having the same or lower minor version.
    * Downgrade of plugins is not allowed during upgrade of Kubernetes.
* Improve exception handling process.

### Test Cases

**TestCase 1**

Steps:

1. Remove intermediate Kubernetes version from `kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml`
2. Run `scripts/thirdparties/sync.py`

Results:

| Before | After |
| ------ | ------ |
| Success  | Exception should be raised |

**TestCase 2**

Steps:

1. Upgrade any plugin for intermediate Kubernetes version in `kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml`, but leave higher versions of Kubernetes having the same plugin versions as-is.
2. Run `scripts/thirdparties/sync.py`

Results:

| Before | After |
| ------ | ------ |
| Success  | Exception should be raised |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
* Fixed test_upgrade.py to support new validation and removed obsolete validation.
* Fixed and added tests in test_sync.py.
