### PR TITLE
Update integration_tests.yaml

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -59,6 +59,15 @@ jobs:
         run: sudo apt remove moby-runc
       - name: Install rename
         run: sudo apt install rename
+      - name: Install and start journald
+        run: |
+          sudo apt-get update && sudo apt-get install -y systemd
+          sudo systemctl start systemd-journald.service	
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker.io systemd-journal-remote jq			
          # TODO: change to kubemarine runtime values feature
       - name: Set kubernetes version to cluster.yaml
         run: sed -i "s/<KUBERNETES_VERSION>/${{ matrix.kubernetes-version }}/" ${{ env.cluster_yaml_file }}
@@ -71,11 +80,50 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: kubemarine check_paas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_paas_dump/
-      - name: Collect kubelet logs
+      - name: Collect Kubernetes logs
         run: |
-          journalctl -u kubelet --no-pager > ./results/kubelet.log
-          journalctl -u kubelet.service --no-pager > ./results/kubelet_service.log
-          journalctl -u kubelet.service --no-pager -o json > ./results/kubelet_service.json
+          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler > ./results/kube-logs.txt
+          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler -o json > ./results/kube-logs.json
+          sudo journalctl -u etcd > ./results/etcd-logs.txt
+          sudo journalctl -u etcd -o json > ./results/etcd-logs.json
+          sudo journalctl -u coredns > ./results/coredns-logs.txt
+          sudo journalctl -u coredns -o json > ./results/coredns-logs.json
+          sudo journalctl > ./results/all-logs.txt
+          sudo journalctl -o json > ./results/all-logs.json
+          sudo cp /var/log/syslog ./results/syslog.txt
+
+      - name: Collect Docker logs
+        run: |
+          sudo journalctl -u docker > ./results/docker-logs.txt
+          sudo journalctl -u docker -o json > ./results/docker-logs.json
+          sudo cp /var/log/docker.log ./results/docker.log.txt
+
+      - name: Collect network logs
+        run: |
+          sudo tcpdump -i any -w tcpdump.pcap &
+          sudo timeout 30s ping 8.8.8.8
+          sudo killall tcpdump
+          sudo cp tcpdump.pcap ./results/tcpdump.pcap
+
+      - name: Collect system information
+        run: |
+          uname -a > ./results/system-info.txt
+          sudo apt list --installed > ./results/installed-packages.txt
+          sudo df -h > ./results/disk-usage.txt
+          sudo free -m > ./results/memory-usage.txt
+          sudo cp /var/log/messages ./results/messages.txt
+          sudo cp /var/log/auth.log ./results/auth.log.txt
+          sudo systemctl status kubelet > ./results/kubelet-status.txt
+          sudo systemctl status kube-proxy > ./results/kube-proxy-status.txt
+          sudo systemctl status kube-apiserver > ./results/kube-apiserver-status.txt
+          sudo systemctl status kube-controller-manager > ./results/kube-controller-manager-status.txt
+          sudo systemctl status kube-scheduler > ./results/kube-scheduler-status.txt
+          sudo systemctl status etcd > ./results/etcd-status.txt
+          sudo systemctl status coredns > ./results/coredns-status.txt
+          sudo systemctl status docker > ./results/docker-status.txt
+          sudo systemctl status systemd-journald > ./results/journald-status.txt
+          sudo cp /var/log/audit/audit.log ./results/audit.log.txt
+  
       - name: Change not-recommended symbols in dump files
         if: failure()
         run: rename 's/[:]/_/g' ./results/*/dump/*

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -63,11 +63,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y systemd
           sudo systemctl start systemd-journald.service	
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y docker.io systemd-journal-remote jq			
+		
          # TODO: change to kubemarine runtime values feature
       - name: Set kubernetes version to cluster.yaml
         run: sed -i "s/<KUBERNETES_VERSION>/${{ matrix.kubernetes-version }}/" ${{ env.cluster_yaml_file }}

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -75,25 +75,12 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: kubemarine check_paas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_paas_dump/
-      - name: Collect Kubernetes logs
-        run: |
-          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler > ./results/kube-logs.txt
-          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler -o json > ./results/kube-logs.json
-          sudo journalctl -u etcd > ./results/etcd-logs.txt
-          sudo journalctl -u etcd -o json > ./results/etcd-logs.json
-          sudo journalctl -u coredns > ./results/coredns-logs.txt
-          sudo journalctl -u coredns -o json > ./results/coredns-logs.json
-          sudo journalctl > ./results/all-logs.txt
-          sudo journalctl -o json > ./results/all-logs.json
-
-      - name: Collect Docker logs
-        run: |
-          sudo journalctl -u docker > ./results/docker-logs.txt
-          sudo journalctl -u docker -o json > ./results/docker-logs.json
-  
       - name: Change not-recommended symbols in dump files
         if: failure()
-        run: rename 's/[:]/_/g' ./results/*/dump/*
+        run: |
+          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler > ./results/kube-logs.txt
+          sudo journalctl > ./results/all-logs.txt 
+          rename 's/[:]/_/g' ./results/*/dump/*
       - name: Collect dump artifacts
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -91,21 +91,12 @@ jobs:
           sudo journalctl -u docker > ./results/docker-logs.txt
           sudo journalctl -u docker -o json > ./results/docker-logs.json
 
-      - name: Collect network logs
-        run: |
-          sudo tcpdump -i any -w tcpdump.pcap &
-          sudo timeout 30s ping 8.8.8.8
-          sudo killall tcpdump
-          sudo cp tcpdump.pcap ./results/tcpdump.pcap
-
       - name: Collect system information
         run: |
           uname -a > ./results/system-info.txt
           sudo apt list --installed > ./results/installed-packages.txt
           sudo df -h > ./results/disk-usage.txt
           sudo free -m > ./results/memory-usage.txt
-          sudo cp /var/log/messages ./results/messages.txt
-          sudo cp /var/log/auth.log ./results/auth.log.txt
           sudo systemctl status kubelet > ./results/kubelet-status.txt
           sudo systemctl status kube-proxy > ./results/kube-proxy-status.txt
           sudo systemctl status kube-apiserver > ./results/kube-apiserver-status.txt
@@ -115,7 +106,6 @@ jobs:
           sudo systemctl status coredns > ./results/coredns-status.txt
           sudo systemctl status docker > ./results/docker-status.txt
           sudo systemctl status systemd-journald > ./results/journald-status.txt
-          sudo cp /var/log/audit/audit.log ./results/audit.log.txt
   
       - name: Change not-recommended symbols in dump files
         if: failure()

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -121,6 +121,10 @@ jobs:
         run: sudo apt remove moby-runc
       - name: Install rename
         run: sudo apt install rename
+      - name: Install and start journald
+        run: |
+          sudo apt update && sudo apt install -y systemd
+          sudo systemctl start systemd-journald.service	
       - name: Check Iaas
         id: test_check_iaas
         run: kubemarine check_iaas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_iaas_dump/

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -59,6 +59,10 @@ jobs:
         run: sudo apt remove moby-runc
       - name: Install rename
         run: sudo apt install rename
+      - name: Install and start journald
+        run: |
+          sudo apt-get update && sudo apt-get install -y systemd
+          sudo systemctl start systemd-journald.service	
          # TODO: change to kubemarine runtime values feature
       - name: Set kubernetes version to cluster.yaml
         run: sed -i "s/<KUBERNETES_VERSION>/${{ matrix.kubernetes-version }}/" ${{ env.cluster_yaml_file }}
@@ -71,11 +75,22 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: kubemarine check_paas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_paas_dump/
-      - name: Collect kubelet logs
+      - name: Collect Kubernetes logs
         run: |
-          journalctl -u kubelet --no-pager > ./results/kubelet.log
-          journalctl -u kubelet.service --no-pager > ./results/kubelet_service.log
-          journalctl -u kubelet.service --no-pager -o json > ./results/kubelet_service.json
+          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler > ./results/kube-logs.txt
+          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler -o json > ./results/kube-logs.json
+          sudo journalctl -u etcd > ./results/etcd-logs.txt
+          sudo journalctl -u etcd -o json > ./results/etcd-logs.json
+          sudo journalctl -u coredns > ./results/coredns-logs.txt
+          sudo journalctl -u coredns -o json > ./results/coredns-logs.json
+          sudo journalctl > ./results/all-logs.txt
+          sudo journalctl -o json > ./results/all-logs.json
+
+      - name: Collect Docker logs
+        run: |
+          sudo journalctl -u docker > ./results/docker-logs.txt
+          sudo journalctl -u docker -o json > ./results/docker-logs.json
+  
       - name: Change not-recommended symbols in dump files
         if: failure()
         run: rename 's/[:]/_/g' ./results/*/dump/*

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -61,7 +61,7 @@ jobs:
         run: sudo apt install rename
       - name: Install and start journald
         run: |
-          sudo apt-get update && sudo apt-get install -y systemd
+          sudo apt update && sudo apt install -y systemd
           sudo systemctl start systemd-journald.service	
          # TODO: change to kubemarine runtime values feature
       - name: Set kubernetes version to cluster.yaml

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -90,16 +90,6 @@ jobs:
         run: |
           sudo journalctl -u docker > ./results/docker-logs.txt
           sudo journalctl -u docker -o json > ./results/docker-logs.json
-          
-      - name: Collect system information
-        run: |
-          uname -a > ./results/system-info.txt
-          sudo apt list --installed > ./results/installed-packages.txt
-          sudo df -h > ./results/disk-usage.txt
-          sudo free -m > ./results/memory-usage.txt
-          sudo systemctl status kubelet > ./results/kubelet-status.txt
-          sudo systemctl status docker > ./results/docker-status.txt
-          sudo systemctl status systemd-journald > ./results/journald-status.txt
   
       - name: Change not-recommended symbols in dump files
         if: failure()

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -90,16 +90,6 @@ jobs:
         run: |
           sudo journalctl -u docker > ./results/docker-logs.txt
           sudo journalctl -u docker -o json > ./results/docker-logs.json
-
-      - name: Collect system information
-        run: |
-          uname -a > ./results/system-info.txt
-          sudo apt list --installed > ./results/installed-packages.txt
-          sudo df -h > ./results/disk-usage.txt
-          sudo free -m > ./results/memory-usage.txt
-          sudo systemctl status kubelet > ./results/kubelet-status.txt
-          sudo systemctl status docker > ./results/docker-status.txt
-          sudo systemctl status systemd-journald > ./results/journald-status.txt
   
       - name: Change not-recommended symbols in dump files
         if: failure()

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -85,13 +85,11 @@ jobs:
           sudo journalctl -u coredns -o json > ./results/coredns-logs.json
           sudo journalctl > ./results/all-logs.txt
           sudo journalctl -o json > ./results/all-logs.json
-          sudo cp /var/log/syslog ./results/syslog.txt
 
       - name: Collect Docker logs
         run: |
           sudo journalctl -u docker > ./results/docker-logs.txt
           sudo journalctl -u docker -o json > ./results/docker-logs.json
-          sudo cp /var/log/docker.log ./results/docker.log.txt
 
       - name: Collect network logs
         run: |

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -90,6 +90,16 @@ jobs:
         run: |
           sudo journalctl -u docker > ./results/docker-logs.txt
           sudo journalctl -u docker -o json > ./results/docker-logs.json
+          
+      - name: Collect system information
+        run: |
+          uname -a > ./results/system-info.txt
+          sudo apt list --installed > ./results/installed-packages.txt
+          sudo df -h > ./results/disk-usage.txt
+          sudo free -m > ./results/memory-usage.txt
+          sudo systemctl status kubelet > ./results/kubelet-status.txt
+          sudo systemctl status docker > ./results/docker-status.txt
+          sudo systemctl status systemd-journald > ./results/journald-status.txt
   
       - name: Change not-recommended symbols in dump files
         if: failure()

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -71,6 +71,11 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: kubemarine check_paas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_paas_dump/
+      - name: Collect kubelet logs
+        run: |
+          journalctl -u kubelet --no-pager > ./results/kubelet.log
+          journalctl -u kubelet.service --no-pager > ./results/kubelet_service.log
+          journalctl -u kubelet.service --no-pager -o json > ./results/kubelet_service.json
       - name: Change not-recommended symbols in dump files
         if: failure()
         run: rename 's/[:]/_/g' ./results/*/dump/*

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -98,12 +98,6 @@ jobs:
           sudo df -h > ./results/disk-usage.txt
           sudo free -m > ./results/memory-usage.txt
           sudo systemctl status kubelet > ./results/kubelet-status.txt
-          sudo systemctl status kube-proxy > ./results/kube-proxy-status.txt
-          sudo systemctl status kube-apiserver > ./results/kube-apiserver-status.txt
-          sudo systemctl status kube-controller-manager > ./results/kube-controller-manager-status.txt
-          sudo systemctl status kube-scheduler > ./results/kube-scheduler-status.txt
-          sudo systemctl status etcd > ./results/etcd-status.txt
-          sudo systemctl status coredns > ./results/coredns-status.txt
           sudo systemctl status docker > ./results/docker-status.txt
           sudo systemctl status systemd-journald > ./results/journald-status.txt
   

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -63,7 +63,6 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y systemd
           sudo systemctl start systemd-journald.service	
-		
          # TODO: change to kubemarine runtime values feature
       - name: Set kubernetes version to cluster.yaml
         run: sed -i "s/<KUBERNETES_VERSION>/${{ matrix.kubernetes-version }}/" ${{ env.cluster_yaml_file }}

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -59,10 +59,6 @@ jobs:
         run: sudo apt remove moby-runc
       - name: Install rename
         run: sudo apt install rename
-      - name: Install and start journald
-        run: |
-          sudo apt-get update && sudo apt-get install -y systemd
-          sudo systemctl start systemd-journald.service	
          # TODO: change to kubemarine runtime values feature
       - name: Set kubernetes version to cluster.yaml
         run: sed -i "s/<KUBERNETES_VERSION>/${{ matrix.kubernetes-version }}/" ${{ env.cluster_yaml_file }}

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -75,12 +75,14 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: kubemarine check_paas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_paas_dump/
+      - name: Collect journalctl logs
+        if: failure()
+          run: |
+            sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler > ./results/journald_kube-logs.txt
+            sudo journalctl > ./results/journald-logs.txt 
       - name: Change not-recommended symbols in dump files
         if: failure()
-        run: |
-          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler > ./results/journald_kube-logs.txt
-          sudo journalctl > ./results/journald-logs.txt 
-          rename 's/[:]/_/g' ./results/*/dump/*
+        run: rename 's/[:]/_/g' ./results/*/dump/*
       - name: Collect dump artifacts
         if: failure()
         uses: actions/upload-artifact@v3
@@ -128,6 +130,11 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: kubemarine check_paas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_paas_dump/
+      - name: Collect journalctl logs
+        if: failure()
+          run: |
+            sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler > ./results/journald_kube-logs.txt
+            sudo journalctl > ./results/journald-logs.txt
       - name: Change not-recommended symbols in dump files
         if: failure()
         run: rename 's/[:]/_/g' ./results/*/dump/*

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -78,8 +78,8 @@ jobs:
       - name: Change not-recommended symbols in dump files
         if: failure()
         run: |
-          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler > ./results/kube-logs.txt
-          sudo journalctl > ./results/all-logs.txt 
+          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler > ./results/journald_kube-logs.txt
+          sudo journalctl > ./results/journald-logs.txt 
           rename 's/[:]/_/g' ./results/*/dump/*
       - name: Collect dump artifacts
         if: failure()

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -75,22 +75,6 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: kubemarine check_paas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_paas_dump/
-      - name: Collect Kubernetes logs
-        run: |
-          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler > ./results/kube-logs.txt
-          sudo journalctl -u kubelet -u kube-proxy -u kube-apiserver -u kube-controller-manager -u kube-scheduler -o json > ./results/kube-logs.json
-          sudo journalctl -u etcd > ./results/etcd-logs.txt
-          sudo journalctl -u etcd -o json > ./results/etcd-logs.json
-          sudo journalctl -u coredns > ./results/coredns-logs.txt
-          sudo journalctl -u coredns -o json > ./results/coredns-logs.json
-          sudo journalctl > ./results/all-logs.txt
-          sudo journalctl -o json > ./results/all-logs.json
-
-      - name: Collect Docker logs
-        run: |
-          sudo journalctl -u docker > ./results/docker-logs.txt
-          sudo journalctl -u docker -o json > ./results/docker-logs.json
-  
       - name: Change not-recommended symbols in dump files
         if: failure()
         run: rename 's/[:]/_/g' ./results/*/dump/*

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -509,7 +509,7 @@ def deploy_kubernetes_init(cluster: KubernetesCluster):
         kubernetes.join_other_control_planes
     ])
 
-    if false:
+    if 'worker' in cluster.nodes:
         cluster.nodes.get('worker').new_group(
             apply_filter=lambda node: 'control-plane' not in node['roles']) \
             .call(kubernetes.init_workers)

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -509,7 +509,7 @@ def deploy_kubernetes_init(cluster: KubernetesCluster):
         kubernetes.join_other_control_planes
     ])
 
-    if 'worker' in cluster.nodes:
+    if false:
         cluster.nodes.get('worker').new_group(
             apply_filter=lambda node: 'control-plane' not in node['roles']) \
             .call(kubernetes.init_workers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "jinja2==3.1.*",
     "MarkupSafe==2.1.*",
     "invoke==1.6.*",
-    "ruamel.yaml==0.17.22",
+    "ruamel.yaml==0.17.*",
     "pygelf==0.4.*",
     "toml==0.10.*",
     "python-dateutil==2.8.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "jinja2==3.1.*",
     "MarkupSafe==2.1.*",
     "invoke==1.6.*",
-    "ruamel.yaml==0.17.*",
+    "ruamel.yaml==0.17.22",
     "pygelf==0.4.*",
     "toml==0.10.*",
     "python-dateutil==2.8.*",


### PR DESCRIPTION
### Description
The provided code is an update to the existing Integration Tests workflow for a Kubernetes CI system. It adds additional logs to be collected using journalctl. The logs are stored in the ./results directory for further analysis in case of test failures.
* 

**Fixes** - Issue #430 


### Solution
This change will collect all journalctl logs and kube-logs in order to debug Kubernetes install failure. 
* 


### Test Cases

You can make any change which will make the installation step fail, here in this case i have modified kubemarine/procedure/install.py script in order to fail the process as below
In place of `if 'worker' in cluster.nodes:` i have replaced it with `if false:`
https://github.com/Netcracker/KubeMarine/blob/c39e330cf2113ef79bb55e9763ec355ac9221065/kubemarine/procedures/install.py#L512


ER: Journalctl log and kube-logs need to be uploaded as artifact

AR: Journalctl log and kube-logs are collected.
[default_cluster_procedure_dumps-v1.25.7 (3).zip](https://github.com/Netcracker/KubeMarine/files/11505052/default_cluster_procedure_dumps-v1.25.7.3.zip)

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


