### PR TITLE
[MANOPD-87147] Improving colors

### DIFF
--- a/documentation/Logging.md
+++ b/documentation/Logging.md
@@ -51,6 +51,8 @@ kubemarine install \
 
 **Note**: Be careful when specifying the format and date format. Enclose the entire `log` argument, but do not enclose the `format` and `datefmt` sections. Also, do not use separators like `=` or `;` in the format, otherwise it can cause a parsing failure.
 
+**Note**: Kubemarine uses ANSI codes to display text and background colors. In order for the colors to be displayed correctly in Windows, you need to use Windows Terminal.
+
 ## Output to File
 
 Kubemarine allows you to output logs to a file. For this, the following parameters are supported:

--- a/kubemarine/core/log.py
+++ b/kubemarine/core/log.py
@@ -337,10 +337,6 @@ def init_log_from_context_args(globals, context, raw_inventory) -> Log:
 
     if not stdout_specified:
         stdout_settings = deepcopy(globals['logging']['default_targets']['stdout'])
-        # Globals lacks of colorize property, so calculated value for Windows is "false".
-        # But it is still convenient to specify the value explicitly even for Windows for debugging purpose.
-        if 'colorize' not in stdout_settings:
-            stdout_settings['colorize'] = True
         handlers.append(LogHandler(target='stdout', **stdout_settings))
 
     log = Log(raw_inventory, handlers)

--- a/kubemarine/core/log.py
+++ b/kubemarine/core/log.py
@@ -340,7 +340,7 @@ def init_log_from_context_args(globals, context, raw_inventory) -> Log:
         # Globals lacks of colorize property, so calculated value for Windows is "false".
         # But it is still convenient to specify the value explicitly even for Windows for debugging purpose.
         if 'colorize' not in stdout_settings:
-            stdout_settings['colorize'] = (os.name != 'nt')
+            stdout_settings['colorize'] = True
         handlers.append(LogHandler(target='stdout', **stdout_settings))
 
     log = Log(raw_inventory, handlers)

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -36,7 +36,7 @@ from kubemarine.testsuite import TestSuite, TestCase, TestFailure, TestWarn
 from kubemarine.core.group import NodeGroupResult
 
 def connection_ssh_connectivity(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '001', 'SSH', 'Connectivity', default_results='Connected'):
+    with TestCase(cluster, '001', 'SSH', 'Connectivity', default_results='Connected'):
         failed_nodes = []
         for node in cluster.nodes['all'].get_ordered_members_list(provide_node_configs=True):
             try:
@@ -54,7 +54,7 @@ def connection_ssh_connectivity(cluster):
 
 
 def connection_ssh_latency_single(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '002',  'SSH', 'Latency - Single Thread',
+    with TestCase(cluster, '002',  'SSH', 'Latency - Single Thread',
                   minimal=cluster.globals['compatibility_map']['network']['connection']['latency']['single']['critical'],
                   recommended=cluster.globals['compatibility_map']['network']['connection']['latency']['single']['recommended']) as tc:
         i = 0
@@ -82,7 +82,7 @@ def connection_ssh_latency_single(cluster):
 
 
 def connection_ssh_latency_multiple(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '003',  'SSH', 'Latency - Multi Thread',
+    with TestCase(cluster, '003',  'SSH', 'Latency - Multi Thread',
                   minimal=cluster.globals['compatibility_map']['network']['connection']['latency']['multi']['critical'],
                   recommended=cluster.globals['compatibility_map']['network']['connection']['latency']['multi']['recommended']) as tc:
         i = 0
@@ -109,7 +109,7 @@ def connection_ssh_latency_multiple(cluster):
 
 
 def connection_sudoer_access(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '004', 'SSH', 'Sudoer Access', default_results='Access provided'):
+    with TestCase(cluster, '004', 'SSH', 'Sudoer Access', default_results='Access provided'):
         non_root = []
         for host, node_context in cluster.context['nodes'].items():
             access_info = node_context['access']
@@ -130,7 +130,7 @@ def hardware_members_amount(cluster, group_name):
     if group_name == 'all':
         beauty_name = 'Total Node'
 
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '005',  'Hardware', '%ss Amount' % beauty_name,
+    with TestCase(cluster, '005',  'Hardware', '%ss Amount' % beauty_name,
                   minimal=cluster.globals['compatibility_map']['hardware']['minimal'][group_name]['amount'],
                   recommended=cluster.globals['compatibility_map']['hardware']['recommended'][group_name]['amount']) as tc:
         amount = 0
@@ -168,7 +168,7 @@ def hardware_cpu(cluster, group_name):
     minimal_cpu = cluster.globals['compatibility_map']['hardware']['minimal'][group_name]['vcpu'] \
         if group_name == 'balancer' or cluster.nodes.get('all').nodes_amount() > 1 \
         else cluster.globals['compatibility_map']['hardware']['minimal']['control-plane']['vcpu']
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '006',  'Hardware', 'VCPUs Amount - %ss' % group_name.capitalize(),
+    with TestCase(cluster, '006',  'Hardware', 'VCPUs Amount - %ss' % group_name.capitalize(),
                   minimal=minimal_cpu,
                   recommended=cluster.globals['compatibility_map']['hardware']['recommended'][group_name]['vcpu']) as tc:
         if cluster.nodes.get(group_name) is None or cluster.nodes[group_name].is_empty():
@@ -205,7 +205,7 @@ def hardware_cpu(cluster, group_name):
 
 
 def hardware_ram(cluster, group_name):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '007',  'Hardware', 'RAM Amount - %ss' % group_name.capitalize(),
+    with TestCase(cluster, '007',  'Hardware', 'RAM Amount - %ss' % group_name.capitalize(),
                   minimal=cluster.globals['compatibility_map']['hardware']['minimal'][group_name]['ram'],
                   recommended=cluster.globals['compatibility_map']['hardware']['recommended'][group_name]['ram']) as tc:
         if cluster.nodes.get(group_name) is None or cluster.nodes[group_name].is_empty():
@@ -237,7 +237,7 @@ def hardware_ram(cluster, group_name):
 
 
 def system_distributive(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '008', 'System', 'Distibutive') as tc:
+    with TestCase(cluster, '008', 'System', 'Distibutive') as tc:
         supported_distributives = cluster.globals['compatibility_map']['distributives'].keys()
 
         cluster.log.debug(system.fetch_os_versions(cluster))
@@ -292,7 +292,7 @@ def check_kernel_version(cluster):
     """
     This method compares the linux kernel version with the bad version
     """
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '015', "Software", "Kernel version") as tc:
+    with TestCase(cluster, '015', "Software", "Kernel version") as tc:
         bad_results = {}
         unstable_kernel_ubuntu = cluster.globals['compatibility_map']['distributives']['ubuntu'][0].get('unstable_kernel')
         unstable_kernel_centos = []
@@ -318,7 +318,7 @@ def check_kernel_version(cluster):
 
 
 def check_access_to_thirdparties(cluster: KubernetesCluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '012', 'Software', 'Thirdparties Availability') as tc:
+    with TestCase(cluster, '012', 'Software', 'Thirdparties Availability') as tc:
         detect_preinstalled_python(cluster)
         broken = []
         nodes_without_python = set()
@@ -414,7 +414,7 @@ def check_package_repositories(cluster: KubernetesCluster):
 
 
 def check_access_to_package_repositories(cluster: KubernetesCluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '013', 'Software', 'Package Repositories') as tc:
+    with TestCase(cluster, '013', 'Software', 'Package Repositories') as tc:
         detect_preinstalled_python(cluster)
         check_resolv_conf(cluster)
         broken = []
@@ -507,7 +507,7 @@ def check_access_to_package_repositories(cluster: KubernetesCluster):
 
 
 def check_access_to_packages(cluster: KubernetesCluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '014', 'Software', 'Package Availability') as tc:
+    with TestCase(cluster, '014', 'Software', 'Package Availability') as tc:
         check_package_repositories(cluster)
         broken = []
         warnings = []
@@ -673,7 +673,7 @@ def assign_random_ips(cluster: KubernetesCluster, nodes: dict, subnet):
 
 
 def pod_subnet_connectivity(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '009', 'Network', 'PodSubnet', default_results='Connected'),\
+    with TestCase(cluster, '009', 'Network', 'PodSubnet', default_results='Connected'),\
             suspend_firewalld(cluster):
         pod_subnet = cluster.inventory['services']['kubeadm']['networking']['podSubnet']
         nodes = _get_not_balancers(cluster)
@@ -689,7 +689,7 @@ def pod_subnet_connectivity(cluster):
 
 
 def service_subnet_connectivity(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '010', 'Network', 'ServiceSubnet', default_results='Connected'),\
+    with TestCase(cluster, '010', 'Network', 'ServiceSubnet', default_results='Connected'),\
             suspend_firewalld(cluster):
         service_subnet = cluster.inventory['services']['kubeadm']['networking']['serviceSubnet']
         nodes = _get_not_balancers(cluster)
@@ -861,7 +861,7 @@ def install_tcp_listener(cluster: KubernetesCluster, nodes: dict, tcp_ports):
 
 
 def check_tcp_ports(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '011', 'Network', 'TCPPorts', default_results='Connected'),\
+    with TestCase(cluster, '011', 'Network', 'TCPPorts', default_results='Connected'),\
             suspend_firewalld(cluster):
         tcp_ports = ["80", "443", "179", "5473", "6443", "8443", "2379", "2380", "9091", "9094", "10250", "10254",
                      "10257", "10259", "30001", "30002"]

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -36,7 +36,7 @@ from kubemarine.testsuite import TestSuite, TestCase, TestFailure, TestWarn
 from kubemarine.core.group import NodeGroupResult
 
 def connection_ssh_connectivity(cluster):
-    with TestCase(cluster.context['testsuite'], '001', 'SSH', 'Connectivity', default_results='Connected'):
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '001', 'SSH', 'Connectivity', default_results='Connected'):
         failed_nodes = []
         for node in cluster.nodes['all'].get_ordered_members_list(provide_node_configs=True):
             try:
@@ -54,7 +54,7 @@ def connection_ssh_connectivity(cluster):
 
 
 def connection_ssh_latency_single(cluster):
-    with TestCase(cluster.context['testsuite'], '002',  'SSH', 'Latency - Single Thread',
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '002',  'SSH', 'Latency - Single Thread',
                   minimal=cluster.globals['compatibility_map']['network']['connection']['latency']['single']['critical'],
                   recommended=cluster.globals['compatibility_map']['network']['connection']['latency']['single']['recommended']) as tc:
         i = 0
@@ -82,7 +82,7 @@ def connection_ssh_latency_single(cluster):
 
 
 def connection_ssh_latency_multiple(cluster):
-    with TestCase(cluster.context['testsuite'], '003',  'SSH', 'Latency - Multi Thread',
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '003',  'SSH', 'Latency - Multi Thread',
                   minimal=cluster.globals['compatibility_map']['network']['connection']['latency']['multi']['critical'],
                   recommended=cluster.globals['compatibility_map']['network']['connection']['latency']['multi']['recommended']) as tc:
         i = 0
@@ -109,7 +109,7 @@ def connection_ssh_latency_multiple(cluster):
 
 
 def connection_sudoer_access(cluster):
-    with TestCase(cluster.context['testsuite'], '004', 'SSH', 'Sudoer Access', default_results='Access provided'):
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '004', 'SSH', 'Sudoer Access', default_results='Access provided'):
         non_root = []
         for host, node_context in cluster.context['nodes'].items():
             access_info = node_context['access']
@@ -130,7 +130,7 @@ def hardware_members_amount(cluster, group_name):
     if group_name == 'all':
         beauty_name = 'Total Node'
 
-    with TestCase(cluster.context['testsuite'], '005',  'Hardware', '%ss Amount' % beauty_name,
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '005',  'Hardware', '%ss Amount' % beauty_name,
                   minimal=cluster.globals['compatibility_map']['hardware']['minimal'][group_name]['amount'],
                   recommended=cluster.globals['compatibility_map']['hardware']['recommended'][group_name]['amount']) as tc:
         amount = 0
@@ -168,7 +168,7 @@ def hardware_cpu(cluster, group_name):
     minimal_cpu = cluster.globals['compatibility_map']['hardware']['minimal'][group_name]['vcpu'] \
         if group_name == 'balancer' or cluster.nodes.get('all').nodes_amount() > 1 \
         else cluster.globals['compatibility_map']['hardware']['minimal']['control-plane']['vcpu']
-    with TestCase(cluster.context['testsuite'], '006',  'Hardware', 'VCPUs Amount - %ss' % group_name.capitalize(),
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '006',  'Hardware', 'VCPUs Amount - %ss' % group_name.capitalize(),
                   minimal=minimal_cpu,
                   recommended=cluster.globals['compatibility_map']['hardware']['recommended'][group_name]['vcpu']) as tc:
         if cluster.nodes.get(group_name) is None or cluster.nodes[group_name].is_empty():
@@ -205,7 +205,7 @@ def hardware_cpu(cluster, group_name):
 
 
 def hardware_ram(cluster, group_name):
-    with TestCase(cluster.context['testsuite'], '007',  'Hardware', 'RAM Amount - %ss' % group_name.capitalize(),
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '007',  'Hardware', 'RAM Amount - %ss' % group_name.capitalize(),
                   minimal=cluster.globals['compatibility_map']['hardware']['minimal'][group_name]['ram'],
                   recommended=cluster.globals['compatibility_map']['hardware']['recommended'][group_name]['ram']) as tc:
         if cluster.nodes.get(group_name) is None or cluster.nodes[group_name].is_empty():
@@ -237,7 +237,7 @@ def hardware_ram(cluster, group_name):
 
 
 def system_distributive(cluster):
-    with TestCase(cluster.context['testsuite'], '008', 'System', 'Distibutive') as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '008', 'System', 'Distibutive') as tc:
         supported_distributives = cluster.globals['compatibility_map']['distributives'].keys()
 
         cluster.log.debug(system.fetch_os_versions(cluster))
@@ -292,7 +292,7 @@ def check_kernel_version(cluster):
     """
     This method compares the linux kernel version with the bad version
     """
-    with TestCase(cluster.context['testsuite'], '015', "Software", "Kernel version") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '015', "Software", "Kernel version") as tc:
         bad_results = {}
         unstable_kernel_ubuntu = cluster.globals['compatibility_map']['distributives']['ubuntu'][0].get('unstable_kernel')
         unstable_kernel_centos = []
@@ -318,7 +318,7 @@ def check_kernel_version(cluster):
 
 
 def check_access_to_thirdparties(cluster: KubernetesCluster):
-    with TestCase(cluster.context['testsuite'], '012', 'Software', 'Thirdparties Availability') as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '012', 'Software', 'Thirdparties Availability') as tc:
         detect_preinstalled_python(cluster)
         broken = []
         nodes_without_python = set()
@@ -414,7 +414,7 @@ def check_package_repositories(cluster: KubernetesCluster):
 
 
 def check_access_to_package_repositories(cluster: KubernetesCluster):
-    with TestCase(cluster.context['testsuite'], '013', 'Software', 'Package Repositories') as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '013', 'Software', 'Package Repositories') as tc:
         detect_preinstalled_python(cluster)
         check_resolv_conf(cluster)
         broken = []
@@ -507,7 +507,7 @@ def check_access_to_package_repositories(cluster: KubernetesCluster):
 
 
 def check_access_to_packages(cluster: KubernetesCluster):
-    with TestCase(cluster.context['testsuite'], '014', 'Software', 'Package Availability') as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '014', 'Software', 'Package Availability') as tc:
         check_package_repositories(cluster)
         broken = []
         warnings = []
@@ -673,7 +673,7 @@ def assign_random_ips(cluster: KubernetesCluster, nodes: dict, subnet):
 
 
 def pod_subnet_connectivity(cluster):
-    with TestCase(cluster.context['testsuite'], '009', 'Network', 'PodSubnet', default_results='Connected'),\
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '009', 'Network', 'PodSubnet', default_results='Connected'),\
             suspend_firewalld(cluster):
         pod_subnet = cluster.inventory['services']['kubeadm']['networking']['podSubnet']
         nodes = _get_not_balancers(cluster)
@@ -689,7 +689,7 @@ def pod_subnet_connectivity(cluster):
 
 
 def service_subnet_connectivity(cluster):
-    with TestCase(cluster.context['testsuite'], '010', 'Network', 'ServiceSubnet', default_results='Connected'),\
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '010', 'Network', 'ServiceSubnet', default_results='Connected'),\
             suspend_firewalld(cluster):
         service_subnet = cluster.inventory['services']['kubeadm']['networking']['serviceSubnet']
         nodes = _get_not_balancers(cluster)
@@ -861,7 +861,7 @@ def install_tcp_listener(cluster: KubernetesCluster, nodes: dict, tcp_ports):
 
 
 def check_tcp_ports(cluster):
-    with TestCase(cluster.context['testsuite'], '011', 'Network', 'TCPPorts', default_results='Connected'),\
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '011', 'Network', 'TCPPorts', default_results='Connected'),\
             suspend_firewalld(cluster):
         tcp_ports = ["80", "443", "179", "5473", "6443", "8443", "2379", "2380", "9091", "9094", "10250", "10254",
                      "10257", "10259", "30001", "30002"]

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -38,7 +38,7 @@ from deepdiff import DeepDiff
 
 
 def services_status(cluster: KubernetesCluster, service_type: str):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '201', "Services", "%s Status" % service_type.capitalize(),
+    with TestCase(cluster, '201', "Services", "%s Status" % service_type.capitalize(),
                   default_results='active (running)'):
         service_name = service_type
 
@@ -170,7 +170,7 @@ def system_packages_versions(cluster: KubernetesCluster, pckg_alias: str):
     :param cluster: main cluster object.
     :param pckg_alias: system package alias to retrieve "package_name" association.
     """
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '205', "Services", f"{pckg_alias} version") as tc:
+    with TestCase(cluster, '205', "Services", f"{pckg_alias} version") as tc:
         _check_same_os(cluster)
         hosts_to_packages = pckgs.get_association_hosts_to_packages(cluster.nodes['all'], cluster.inventory, pckg_alias)
         if not hosts_to_packages:
@@ -188,7 +188,7 @@ def mandatory_packages_versions(cluster: KubernetesCluster):
     Failure is shown if check is not successful.
     :param cluster: main cluster object.
     """
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '205', "Services", "Mandatory package versions") as tc:
+    with TestCase(cluster, '205', "Services", "Mandatory package versions") as tc:
         _check_same_os(cluster)
         hosts_to_packages = {}
         group = cluster.nodes['all']
@@ -209,7 +209,7 @@ def generic_packages_versions(cluster: KubernetesCluster):
     Verifies that user-provided packages are installed on required nodes and have equal versions.
     Warning is shown if check is not successful.
     """
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '206', "Services", f"Generic packages version") as tc:
+    with TestCase(cluster, '206', "Services", f"Generic packages version") as tc:
         _check_same_os(cluster)
         packages = cluster.inventory['services']['packages'].get('install', {}).get('include', [])
         hosts_to_packages = {host: packages for host in cluster.nodes['all'].get_hosts()}
@@ -263,7 +263,7 @@ def get_nodes_description(cluster):
 
 
 def kubelet_version(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '203', "Services", "Kubelet Version",
+    with TestCase(cluster, '203', "Services", "Kubelet Version",
                   default_results=cluster.inventory['services']['kubeadm']['kubernetesVersion']):
         nodes_description = get_nodes_description(cluster)
         bad_versions = []
@@ -288,7 +288,7 @@ def thirdparties_hashes(cluster):
     If hash is not specified, then thirdparty is skipped.
     If there is no thirdparties with hashes, then warning is shown.
     """
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '212', "Thirdparties", "Hashes") as tc:
+    with TestCase(cluster, '212', "Thirdparties", "Hashes") as tc:
         successful = []
         warnings = []
         broken = []
@@ -437,7 +437,7 @@ def find_hosts_missing_thirdparty(group, path) -> List[str]:
 
 
 def kubernetes_nodes_existence(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '209', "Kubernetes", "Nodes Existence",
+    with TestCase(cluster, '209', "Kubernetes", "Nodes Existence",
                   default_results="All nodes presented"):
         nodes_description = get_nodes_description(cluster)
         nodes_names = kubernetes.get_actual_roles(nodes_description).keys()
@@ -457,7 +457,7 @@ def kubernetes_nodes_existence(cluster):
 
 
 def kubernetes_nodes_roles(cluster: KubernetesCluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '210', "Kubernetes", "Nodes Roles",
+    with TestCase(cluster, '210', "Kubernetes", "Nodes Roles",
                   default_results="All nodes have the correct roles"):
         nodes_description = get_nodes_description(cluster)
         nodes_roles = kubernetes.get_actual_roles(nodes_description)
@@ -484,7 +484,7 @@ def kubernetes_nodes_roles(cluster: KubernetesCluster):
 
 
 def kubernetes_nodes_condition(cluster, condition_type):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '211', "Kubernetes", "Nodes Condition - %s" % condition_type) as tc:
+    with TestCase(cluster, '211', "Kubernetes", "Nodes Condition - %s" % condition_type) as tc:
         nodes_description = get_nodes_description(cluster)
         expected_status = 'False'
         if condition_type == 'Ready':
@@ -526,7 +526,7 @@ def get_not_running_pods(cluster):
 def kubernetes_pods_condition(cluster):
     system_namespaces = ["kube-system", "ingress-nginx", "kube-public", "kubernetes-dashboard", "default"]
     critical_states = cluster.globals['pods']['critical_states']
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '207', "Kubernetes", "Pods Condition") as tc:
+    with TestCase(cluster, '207', "Kubernetes", "Pods Condition") as tc:
         pods_description = get_not_running_pods(cluster)
         total_failed_amount = len(pods_description.split('\n')[1:])
         critical_system_failed_amount = 0
@@ -556,7 +556,7 @@ def kubernetes_pods_condition(cluster):
 
 
 def kubernetes_dashboard_status(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '208', "Plugins", "Dashboard Availability") as tc:
+    with TestCase(cluster, '208', "Plugins", "Dashboard Availability") as tc:
         retries = 10
         test_succeeded = False
         i = 0
@@ -590,7 +590,7 @@ def kubernetes_dashboard_status(cluster):
 
 
 def nodes_pid_max(cluster):
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '202', "Nodes", "Nodes pid_max correctly installed") as tc:
+    with TestCase(cluster, '202', "Nodes", "Nodes pid_max correctly installed") as tc:
         control_plane = cluster.nodes['control-plane'].get_any_member()
         yaml = ruamel.yaml.YAML()
         nodes_failed_pid_max_check = {}
@@ -639,7 +639,7 @@ def verify_selinux_status(cluster: KubernetesCluster) -> None:
     if cluster.get_os_family() not in ('rhel', 'rhel8'):
         return
 
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '213', "Security", "Selinux security policy") as tc:
+    with TestCase(cluster, '213', "Security", "Selinux security policy") as tc:
         group = cluster.nodes['all']
         selinux_configured, selinux_result, selinux_parsed_result = \
             selinux.is_config_valid(group,
@@ -698,7 +698,7 @@ def verify_selinux_config(cluster: KubernetesCluster) -> None:
     if cluster.get_os_family() not in ('rhel', 'rhel8'):
         return
 
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '214', "Security", "Selinux configuration") as tc:
+    with TestCase(cluster, '214', "Security", "Selinux configuration") as tc:
         group = cluster.nodes['all']
         selinux_configured, selinux_result, selinux_parsed_result = \
             selinux.is_config_valid(group,
@@ -721,7 +721,7 @@ def verify_firewalld_status(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '215', "Security", "Firewalld status") as tc:
+    with TestCase(cluster, '215', "Security", "Firewalld status") as tc:
         group = cluster.nodes['all']
         firewalld_disabled, firewalld_result = system.is_firewalld_disabled(group)
         cluster.log.debug(firewalld_result)
@@ -740,7 +740,7 @@ def verify_time_sync(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '218', "System", "Time difference") as tc:
+    with TestCase(cluster, '218', "System", "Time difference") as tc:
         group = cluster.nodes['all']
         current_node_time, nodes_timestamp, time_diff = system.get_nodes_time(group)
         cluster.log.verbose('Current node time: %s' % current_node_time)
@@ -766,7 +766,7 @@ def verify_swap_state(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '216', "System", "Swap state") as tc:
+    with TestCase(cluster, '216', "System", "Swap state") as tc:
         group = cluster.nodes['all']
         swap_disabled, swap_result = system.is_swap_disabled(group)
         cluster.log.debug(swap_result)
@@ -786,7 +786,7 @@ def verify_modprobe_rules(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '217', "System", "Modprobe rules") as tc:
+    with TestCase(cluster, '217', "System", "Modprobe rules") as tc:
         group = cluster.nodes['all']
         modprobe_valid, modprobe_result = system.is_modprobe_valid(group)
         cluster.log.debug(modprobe_result)
@@ -804,7 +804,7 @@ def etcd_health_status(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     """
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '219', "ETCD", "Health status ETCD") as tc:
+    with TestCase(cluster, '219', "ETCD", "Health status ETCD") as tc:
         try:
             etcd_health_status = etcd.wait_for_health(cluster, cluster.nodes['control-plane'].get_any_member())
         except Exception as e:
@@ -822,7 +822,7 @@ def control_plane_configuration_status(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     '''
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '220', "Control plane", "configuration status") as tc:
+    with TestCase(cluster, '220', "Control plane", "configuration status") as tc:
         results = []
         static_pod_names = {'kube-apiserver': 'apiServer',
                             'kube-controller-manager': 'controllerManager',
@@ -927,7 +927,7 @@ def control_plane_health_status(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     '''
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '221', "Control plane", "health status") as tc:
+    with TestCase(cluster, '221', "Control plane", "health status") as tc:
         static_pods = ['kube-apiserver', 'kube-controller-manager', 'kube-scheduler']
         static_pod_names = []
 
@@ -959,7 +959,7 @@ def default_services_configuration_status(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     '''
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '222', "Default services", "configuration status") as tc:
+    with TestCase(cluster, '222', "Default services", "configuration status") as tc:
         first_control_plane = cluster.nodes['control-plane'].get_first_member()
         original_coredns_cm = generate_configmap(cluster.inventory)
         original_coredns_cm = yaml.safe_load(original_coredns_cm)
@@ -1011,7 +1011,7 @@ def default_services_health_status(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     '''
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '223', "Default services", "health status") as tc:
+    with TestCase(cluster, '223', "Default services", "health status") as tc:
         entities_to_check = {"kube-system": [{"DaemonSet": ["calico-node", "kube-proxy"]},
                                              {"Deployment": ["calico-kube-controllers", "coredns"]}],
                              "ingress-nginx": [{"DaemonSet": ["ingress-nginx-controller"]}]}
@@ -1048,7 +1048,7 @@ def calico_config_check(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     '''
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '224', "Calico", "configuration check") as tc:
+    with TestCase(cluster, '224', "Calico", "configuration check") as tc:
         message = ""
         correct_config = True
         first_control_plane = cluster.nodes['control-plane'].get_first_member()
@@ -1091,7 +1091,7 @@ def kubernetes_admission_status(cluster):
     The method checks status of Pod Security Admissions, default Pod Security Profile,
     and 'kube-apiserver.yaml' and 'kubeadm-config' consistancy
     """
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '225', "Kubernetes", "Pod Security Admissions") as tc:
+    with TestCase(cluster, '225', "Kubernetes", "Pod Security Admissions") as tc:
         first_control_plane = cluster.nodes['control-plane'].get_first_member()
         profile_inv = ""
         if cluster.inventory["rbac"]["admission"] == "pss" and \
@@ -1162,7 +1162,7 @@ def geo_check(cluster):
 
     # Here we actually collect information about all statuses, but report information about DNS only.
     # Other statuses are reported in other TestCases below. This is done for better UX.
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '226', "Geo Monitor", "Geo check - DNS resolving") as tc_dns:
+    with TestCase(cluster, '226', "Geo Monitor", "Geo check - DNS resolving") as tc_dns:
         geo_monitor_inventory = cluster.procedure_inventory["geo-monitor"]
         namespace = geo_monitor_inventory["namespace"]
         service = geo_monitor_inventory["service"]
@@ -1210,7 +1210,7 @@ def geo_check(cluster):
             raise TestFailure("found failed DNS statuses", hint=yaml.safe_dump(collected_results["dnsStatus"]["failed"]))
         tc_dns.success("all peer names resolved")
 
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '226', "Geo Monitor", "Geo check - Pod-to-service") as tc_svc:
+    with TestCase(cluster, '226', "Geo Monitor", "Geo check - Pod-to-service") as tc_svc:
         if not collected_results["statusCollected"]:
             raise TestFailure("configuration error", hint="DNS check failed with error, statuses not collected")
 
@@ -1221,7 +1221,7 @@ def geo_check(cluster):
             raise TestWarn("found skipped peer services", hint=yaml.safe_dump(collected_results["svcStatus"]["skipped"]))
         tc_svc.success("all peer services available")
 
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '226', "Geo Monitor", "Geo check - Pod-to-pod") as tc_pod:
+    with TestCase(cluster, '226', "Geo Monitor", "Geo check - Pod-to-pod") as tc_pod:
         if not collected_results["statusCollected"]:
             raise TestFailure("configuration error", hint="DNS check failed with error, statuses not collected")
 
@@ -1243,7 +1243,7 @@ def verify_apparmor_status(cluster: KubernetesCluster) -> None:
     if cluster.get_os_family() in ['rhel', 'rhel8']:
         return
 
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '227', "Security", "Apparmor security policy") as tc:
+    with TestCase(cluster, '227', "Security", "Apparmor security policy") as tc:
         group = cluster.nodes['all'].get_accessible_nodes()
         results = group.sudo("aa-enabled")
         enabled_nodes = []
@@ -1271,7 +1271,7 @@ def verify_apparmor_config(cluster: KubernetesCluster) -> None:
     if cluster.get_os_family() in ['rhel', 'rhel8']:
         return
 
-    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '228', "Security", "Apparmor security policy") as tc:
+    with TestCase(cluster, '228', "Security", "Apparmor security policy") as tc:
         expected_profiles = cluster.inventory['services']['kernel_security'].get('apparmor', {})
         group = cluster.nodes['all'].get_accessible_nodes()
         if expected_profiles:

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -38,7 +38,7 @@ from deepdiff import DeepDiff
 
 
 def services_status(cluster: KubernetesCluster, service_type: str):
-    with TestCase(cluster.context['testsuite'], '201', "Services", "%s Status" % service_type.capitalize(),
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '201', "Services", "%s Status" % service_type.capitalize(),
                   default_results='active (running)'):
         service_name = service_type
 
@@ -170,7 +170,7 @@ def system_packages_versions(cluster: KubernetesCluster, pckg_alias: str):
     :param cluster: main cluster object.
     :param pckg_alias: system package alias to retrieve "package_name" association.
     """
-    with TestCase(cluster.context['testsuite'], '205', "Services", f"{pckg_alias} version") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '205', "Services", f"{pckg_alias} version") as tc:
         _check_same_os(cluster)
         hosts_to_packages = pckgs.get_association_hosts_to_packages(cluster.nodes['all'], cluster.inventory, pckg_alias)
         if not hosts_to_packages:
@@ -188,7 +188,7 @@ def mandatory_packages_versions(cluster: KubernetesCluster):
     Failure is shown if check is not successful.
     :param cluster: main cluster object.
     """
-    with TestCase(cluster.context['testsuite'], '205', "Services", "Mandatory package versions") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '205', "Services", "Mandatory package versions") as tc:
         _check_same_os(cluster)
         hosts_to_packages = {}
         group = cluster.nodes['all']
@@ -209,7 +209,7 @@ def generic_packages_versions(cluster: KubernetesCluster):
     Verifies that user-provided packages are installed on required nodes and have equal versions.
     Warning is shown if check is not successful.
     """
-    with TestCase(cluster.context['testsuite'], '206', "Services", f"Generic packages version") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '206', "Services", f"Generic packages version") as tc:
         _check_same_os(cluster)
         packages = cluster.inventory['services']['packages'].get('install', {}).get('include', [])
         hosts_to_packages = {host: packages for host in cluster.nodes['all'].get_hosts()}
@@ -263,7 +263,7 @@ def get_nodes_description(cluster):
 
 
 def kubelet_version(cluster):
-    with TestCase(cluster.context['testsuite'], '203', "Services", "Kubelet Version",
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '203', "Services", "Kubelet Version",
                   default_results=cluster.inventory['services']['kubeadm']['kubernetesVersion']):
         nodes_description = get_nodes_description(cluster)
         bad_versions = []
@@ -288,7 +288,7 @@ def thirdparties_hashes(cluster):
     If hash is not specified, then thirdparty is skipped.
     If there is no thirdparties with hashes, then warning is shown.
     """
-    with TestCase(cluster.context['testsuite'], '212', "Thirdparties", "Hashes") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '212', "Thirdparties", "Hashes") as tc:
         successful = []
         warnings = []
         broken = []
@@ -437,7 +437,7 @@ def find_hosts_missing_thirdparty(group, path) -> List[str]:
 
 
 def kubernetes_nodes_existence(cluster):
-    with TestCase(cluster.context['testsuite'], '209', "Kubernetes", "Nodes Existence",
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '209', "Kubernetes", "Nodes Existence",
                   default_results="All nodes presented"):
         nodes_description = get_nodes_description(cluster)
         nodes_names = kubernetes.get_actual_roles(nodes_description).keys()
@@ -457,7 +457,7 @@ def kubernetes_nodes_existence(cluster):
 
 
 def kubernetes_nodes_roles(cluster: KubernetesCluster):
-    with TestCase(cluster.context['testsuite'], '210', "Kubernetes", "Nodes Roles",
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '210', "Kubernetes", "Nodes Roles",
                   default_results="All nodes have the correct roles"):
         nodes_description = get_nodes_description(cluster)
         nodes_roles = kubernetes.get_actual_roles(nodes_description)
@@ -484,7 +484,7 @@ def kubernetes_nodes_roles(cluster: KubernetesCluster):
 
 
 def kubernetes_nodes_condition(cluster, condition_type):
-    with TestCase(cluster.context['testsuite'], '211', "Kubernetes", "Nodes Condition - %s" % condition_type) as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '211', "Kubernetes", "Nodes Condition - %s" % condition_type) as tc:
         nodes_description = get_nodes_description(cluster)
         expected_status = 'False'
         if condition_type == 'Ready':
@@ -526,7 +526,7 @@ def get_not_running_pods(cluster):
 def kubernetes_pods_condition(cluster):
     system_namespaces = ["kube-system", "ingress-nginx", "kube-public", "kubernetes-dashboard", "default"]
     critical_states = cluster.globals['pods']['critical_states']
-    with TestCase(cluster.context['testsuite'], '207', "Kubernetes", "Pods Condition") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '207', "Kubernetes", "Pods Condition") as tc:
         pods_description = get_not_running_pods(cluster)
         total_failed_amount = len(pods_description.split('\n')[1:])
         critical_system_failed_amount = 0
@@ -556,7 +556,7 @@ def kubernetes_pods_condition(cluster):
 
 
 def kubernetes_dashboard_status(cluster):
-    with TestCase(cluster.context['testsuite'], '208', "Plugins", "Dashboard Availability") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '208', "Plugins", "Dashboard Availability") as tc:
         retries = 10
         test_succeeded = False
         i = 0
@@ -590,7 +590,7 @@ def kubernetes_dashboard_status(cluster):
 
 
 def nodes_pid_max(cluster):
-    with TestCase(cluster.context['testsuite'], '202', "Nodes", "Nodes pid_max correctly installed") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '202', "Nodes", "Nodes pid_max correctly installed") as tc:
         control_plane = cluster.nodes['control-plane'].get_any_member()
         yaml = ruamel.yaml.YAML()
         nodes_failed_pid_max_check = {}
@@ -639,7 +639,7 @@ def verify_selinux_status(cluster: KubernetesCluster) -> None:
     if cluster.get_os_family() not in ('rhel', 'rhel8'):
         return
 
-    with TestCase(cluster.context['testsuite'], '213', "Security", "Selinux security policy") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '213', "Security", "Selinux security policy") as tc:
         group = cluster.nodes['all']
         selinux_configured, selinux_result, selinux_parsed_result = \
             selinux.is_config_valid(group,
@@ -698,7 +698,7 @@ def verify_selinux_config(cluster: KubernetesCluster) -> None:
     if cluster.get_os_family() not in ('rhel', 'rhel8'):
         return
 
-    with TestCase(cluster.context['testsuite'], '214', "Security", "Selinux configuration") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '214', "Security", "Selinux configuration") as tc:
         group = cluster.nodes['all']
         selinux_configured, selinux_result, selinux_parsed_result = \
             selinux.is_config_valid(group,
@@ -721,7 +721,7 @@ def verify_firewalld_status(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    with TestCase(cluster.context['testsuite'], '215', "Security", "Firewalld status") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '215', "Security", "Firewalld status") as tc:
         group = cluster.nodes['all']
         firewalld_disabled, firewalld_result = system.is_firewalld_disabled(group)
         cluster.log.debug(firewalld_result)
@@ -740,7 +740,7 @@ def verify_time_sync(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    with TestCase(cluster.context['testsuite'], '218', "System", "Time difference") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '218', "System", "Time difference") as tc:
         group = cluster.nodes['all']
         current_node_time, nodes_timestamp, time_diff = system.get_nodes_time(group)
         cluster.log.verbose('Current node time: %s' % current_node_time)
@@ -766,7 +766,7 @@ def verify_swap_state(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    with TestCase(cluster.context['testsuite'], '216', "System", "Swap state") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '216', "System", "Swap state") as tc:
         group = cluster.nodes['all']
         swap_disabled, swap_result = system.is_swap_disabled(group)
         cluster.log.debug(swap_result)
@@ -786,7 +786,7 @@ def verify_modprobe_rules(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    with TestCase(cluster.context['testsuite'], '217', "System", "Modprobe rules") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '217', "System", "Modprobe rules") as tc:
         group = cluster.nodes['all']
         modprobe_valid, modprobe_result = system.is_modprobe_valid(group)
         cluster.log.debug(modprobe_result)
@@ -804,7 +804,7 @@ def etcd_health_status(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     """
-    with TestCase(cluster.context['testsuite'], '219', "ETCD", "Health status ETCD") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '219', "ETCD", "Health status ETCD") as tc:
         try:
             etcd_health_status = etcd.wait_for_health(cluster, cluster.nodes['control-plane'].get_any_member())
         except Exception as e:
@@ -822,7 +822,7 @@ def control_plane_configuration_status(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     '''
-    with TestCase(cluster.context['testsuite'], '220', "Control plane", "configuration status") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '220', "Control plane", "configuration status") as tc:
         results = []
         static_pod_names = {'kube-apiserver': 'apiServer',
                             'kube-controller-manager': 'controllerManager',
@@ -927,7 +927,7 @@ def control_plane_health_status(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     '''
-    with TestCase(cluster.context['testsuite'], '221', "Control plane", "health status") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '221', "Control plane", "health status") as tc:
         static_pods = ['kube-apiserver', 'kube-controller-manager', 'kube-scheduler']
         static_pod_names = []
 
@@ -959,7 +959,7 @@ def default_services_configuration_status(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     '''
-    with TestCase(cluster.context['testsuite'], '222', "Default services", "configuration status") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '222', "Default services", "configuration status") as tc:
         first_control_plane = cluster.nodes['control-plane'].get_first_member()
         original_coredns_cm = generate_configmap(cluster.inventory)
         original_coredns_cm = yaml.safe_load(original_coredns_cm)
@@ -1011,7 +1011,7 @@ def default_services_health_status(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     '''
-    with TestCase(cluster.context['testsuite'], '223', "Default services", "health status") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '223', "Default services", "health status") as tc:
         entities_to_check = {"kube-system": [{"DaemonSet": ["calico-node", "kube-proxy"]},
                                              {"Deployment": ["calico-kube-controllers", "coredns"]}],
                              "ingress-nginx": [{"DaemonSet": ["ingress-nginx-controller"]}]}
@@ -1048,7 +1048,7 @@ def calico_config_check(cluster):
     :param cluster: KubernetesCluster object
     :return: None
     '''
-    with TestCase(cluster.context['testsuite'], '224', "Calico", "configuration check") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '224', "Calico", "configuration check") as tc:
         message = ""
         correct_config = True
         first_control_plane = cluster.nodes['control-plane'].get_first_member()
@@ -1091,7 +1091,7 @@ def kubernetes_admission_status(cluster):
     The method checks status of Pod Security Admissions, default Pod Security Profile,
     and 'kube-apiserver.yaml' and 'kubeadm-config' consistancy
     """
-    with TestCase(cluster.context['testsuite'], '225', "Kubernetes", "Pod Security Admissions") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '225', "Kubernetes", "Pod Security Admissions") as tc:
         first_control_plane = cluster.nodes['control-plane'].get_first_member()
         profile_inv = ""
         if cluster.inventory["rbac"]["admission"] == "pss" and \
@@ -1162,7 +1162,7 @@ def geo_check(cluster):
 
     # Here we actually collect information about all statuses, but report information about DNS only.
     # Other statuses are reported in other TestCases below. This is done for better UX.
-    with TestCase(cluster.context['testsuite'], '226', "Geo Monitor", "Geo check - DNS resolving") as tc_dns:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '226', "Geo Monitor", "Geo check - DNS resolving") as tc_dns:
         geo_monitor_inventory = cluster.procedure_inventory["geo-monitor"]
         namespace = geo_monitor_inventory["namespace"]
         service = geo_monitor_inventory["service"]
@@ -1210,7 +1210,7 @@ def geo_check(cluster):
             raise TestFailure("found failed DNS statuses", hint=yaml.safe_dump(collected_results["dnsStatus"]["failed"]))
         tc_dns.success("all peer names resolved")
 
-    with TestCase(cluster.context['testsuite'], '226', "Geo Monitor", "Geo check - Pod-to-service") as tc_svc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '226', "Geo Monitor", "Geo check - Pod-to-service") as tc_svc:
         if not collected_results["statusCollected"]:
             raise TestFailure("configuration error", hint="DNS check failed with error, statuses not collected")
 
@@ -1221,7 +1221,7 @@ def geo_check(cluster):
             raise TestWarn("found skipped peer services", hint=yaml.safe_dump(collected_results["svcStatus"]["skipped"]))
         tc_svc.success("all peer services available")
 
-    with TestCase(cluster.context['testsuite'], '226', "Geo Monitor", "Geo check - Pod-to-pod") as tc_pod:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '226', "Geo Monitor", "Geo check - Pod-to-pod") as tc_pod:
         if not collected_results["statusCollected"]:
             raise TestFailure("configuration error", hint="DNS check failed with error, statuses not collected")
 
@@ -1243,7 +1243,7 @@ def verify_apparmor_status(cluster: KubernetesCluster) -> None:
     if cluster.get_os_family() in ['rhel', 'rhel8']:
         return
 
-    with TestCase(cluster.context['testsuite'], '227', "Security", "Apparmor security policy") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '227', "Security", "Apparmor security policy") as tc:
         group = cluster.nodes['all'].get_accessible_nodes()
         results = group.sudo("aa-enabled")
         enabled_nodes = []
@@ -1271,7 +1271,7 @@ def verify_apparmor_config(cluster: KubernetesCluster) -> None:
     if cluster.get_os_family() in ['rhel', 'rhel8']:
         return
 
-    with TestCase(cluster.context['testsuite'], '228', "Security", "Apparmor security policy") as tc:
+    with TestCase(cluster.context['testsuite'], cluster.context['execution_arguments'], '228', "Security", "Apparmor security policy") as tc:
         expected_profiles = cluster.inventory['services']['kernel_security'].get('apparmor', {})
         group = cluster.nodes['all'].get_accessible_nodes()
         if expected_profiles:

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -335,6 +335,7 @@ logging:
     stdout:
       level: debug
       correct_newlines: True
+      colorize: true
     dump:
       level: verbose
       format: "%(asctime)s %(process)s %(thread)s %(name)s %(levelname)s [%(module)s.%(funcName)s] %(message)s"


### PR DESCRIPTION
### Description
TestCase and TestSuite classes from [testsuite.py](https://github.com/Netcracker/KubeMarine/blob/main/kubemarine/testsuite.py) always use colors to display text and background, even if `colorize=false` is specified in the arguments.

### Solution
Now, when calling TestCase, execution arguments are also passed, after which `colorize=false` is checked  in them for stdout.

Also now in Windows, colors are also used by default. And the small doc update about using Windows Terminal in Windows for correct color display.

### Test Cases
Run check_paas/check_iaas procedure with `colorize=false` for stdout
` kubemarine check_paas --log="stdout;level=warning;colorize=false"`

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts



