### PR TITLE
Fix binary build for macos arm64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
             build_cmd: python scripts/ci/build_binary.py
           - target: {os: macos-11, arch: 'macos11-x86_64'}
             build_cmd: python scripts/ci/build_binary.py x86_64
-          - target: {os: macos-12, arch: 'macos12-arm64'}
+          - target: {os: macos-11, arch: 'macos11-arm64'}
             build_cmd: python scripts/ci/build_binary.py arm64
     steps:
       - name: Checkout Repo

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
             build_cmd: python scripts/ci/build_binary.py
           - target: {os: macos-11, arch: 'macos11-x86_64'}
             build_cmd: python scripts/ci/build_binary.py x86_64
-          - target: {os: macos-11, arch: 'macos11-arm64'}
+          - target: {os: macos-12, arch: 'macos12-arm64'}
             build_cmd: python scripts/ci/build_binary.py arm64
     steps:
       - name: Checkout Repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "jinja2==3.1.*",
     "MarkupSafe==2.1.*",
     "invoke==1.6.*",
-    "ruamel.yaml==0.17.*",
+    "ruamel.yaml==0.17.22",
     "pygelf==0.4.*",
     "toml==0.10.*",
     "python-dateutil==2.8.*",


### PR DESCRIPTION
### Description
* ruamel.yaml.clib has universal2 build for macos11 arm64 that is in fact not a universal2, but for x84_64.

Fixes # (issue)
https://github.com/Netcracker/KubeMarine/issues/439

### Solution
* WA: Fix dependency ruamel.yaml==0.17.22. That version has no transitive dependency on ruamel.yaml.clib for Python 3.11

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


