### PR TITLE
[PSUPCLPL-12540] Ability to specify arguments for ingress-nginx-controller in cluster.yaml

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3808,6 +3808,16 @@ For example:
       X-Request-Start: t=${msec}
       X-Using-Nginx-Controller: "true"
 ```
+
+* The `args` parameter is used to add cli arguments to ingress-nginx-controller. Before proceeding, refer to the official NGINX Ingress Controller documentation at [https://kubernetes.github.io/ingress-nginx/user-guide/cli-arguments/](https://kubernetes.github.io/ingress-nginx/user-guide/cli-arguments/).
+
+For example:
+```yaml
+  nginx-ingress-controller:
+    controller:
+      args: ['--disable-full-test', '--disable-catch-all']
+```
+
 ###### monitoring
 By default 10254 port is opened and provides Prometheus metrics.
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3818,6 +3818,8 @@ For example:
       args: ['--disable-full-test', '--disable-catch-all']
 ```
 
+**Warning**: Arguments for ingress-nginx-controller are also added from [nginx-ingress-controller-v*-original.yaml](https://github.com/Netcracker/KubeMarine/blob/main/kubemarine/plugins/yaml/), from other parameters in cluster.yaml (`controller.ssl.enableSslPassthrough` and `controller.ssl.default-certificate`) and `--watch-ingress-without-class=true` is added by default. Make sure there are no conflicts, otherwise the task will be interrupted.
+
 ###### monitoring
 By default 10254 port is opened and provides Prometheus metrics.
 

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -26,6 +26,7 @@ This section provides troubleshooting information for Kubemarine and Kubernetes 
   - [Long Pulling of Images](#long-pulling-of-images)
   - [No Pod-to-Pod Traffic for Some Nodes with More Than One Network Interface](#no-pod-to-pod-traffic-for-some-nodes-with-more-than-one-network-interface)
   - [No Pod-to-Pod Traffic for Some Nodes with More Than One IPs with Different CIDR Notation](#no-pod-to-pod-traffic-for-some-nodes-with-more-than-one-ips-with-different-cidr-notation)
+  - [Ingress Cannot Be Created or Updated](#ingress-cannot-be-created-or-updated)
 - [Troubleshooting Kubemarine](#troubleshooting-kubemarine)
   - [Failures During Kubernetes Upgrade Procedure](#failures-during-kubernetes-upgrade-procedure)
   - [Numerous Generation of Auditd System Messages](#numerous-generation-of-auditd-system)
@@ -606,6 +607,31 @@ plugins:
 ```
 For more information on IP autodetection methods, refer to the [official documentation](https://docs.tigera.io/calico/3.25/reference/configure-calico-node#ip-autodetection-methods).
 
+## Ingress Cannot Be Created or Updated
+
+**Symptoms**: Ingress cannot be created or updated with following error:
+```
+Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": failed to call webhook: Post "https://ingress-nginx-controller-admission.ingress-nginx.svc:443/networking/v1/ingresses?timeout=10s": context deadline exceeded
+```
+
+**Root cause**: This issue can occur in clusters with a large number of ingresses when the admission webhook is enabled. Testing a new configuration takes too much time and does not fit into the timeout.
+
+**Solution**: There are two ways to solve this.
+* Increase the timeout:
+```
+$ kubectl edit ValidatingWebhookConfiguration ingress-nginx-admission
+...
+  timeoutSeconds: 30
+```
+* Add the `--disable-full-test` [argument](https://kubernetes.github.io/ingress-nginx/user-guide/cli-arguments/) for the ingress-nginx-controller:
+```
+$ kubectl edit ds ingress-nginx-controller
+...
+spec:
+  containers:
+      args:
+        - '--disable-full-test'
+```
 
 # Troubleshooting Kubemarine
 

--- a/kubemarine/plugins/nginx_ingress.py
+++ b/kubemarine/plugins/nginx_ingress.py
@@ -249,6 +249,20 @@ class IngressNginxManifestProcessor(Processor):
             ('--watch-ingress-without-class=', 'true')
         ]
         ssl_options = self.inventory['plugins']['nginx-ingress-controller']['controller']['ssl']
+        additional_args = self.inventory['plugins']['nginx-ingress-controller']['controller'].get('args')
+
+        if additional_args:
+            for arg in additional_args:
+                pars_arg = arg.split('=')
+                for i, container_arg in enumerate(container_args):
+                    if container_arg.startswith(pars_arg[0]):
+                       raise Exception(
+                           f"{pars_arg[0]!r} argument is already defined in ingress-nginx-controller container specification.")
+                else:
+                    container_args.append(arg)
+                    self.log.verbose(f"The {arg!r} argument has been added to "
+                                     f"'spec.template.spec.containers.[{container_pos}].args' in the {key}")
+
         if ssl_options['enableSslPassthrough']:
             extra_args.append(('--enable-ssl-passthrough',))
         if ssl_options.get('default-certificate'):

--- a/kubemarine/resources/schemas/definitions/plugins/nginx-ingress-controller.json
+++ b/kubemarine/resources/schemas/definitions/plugins/nginx-ingress-controller.json
@@ -43,6 +43,10 @@
           },
           "additionalProperties": false
         },
+        "args": {
+          "type": "array",
+          "description": "Additional arguments."
+        },
         "nodeSelector": {
           "$ref": "generic_plugin.json#/definitions/CommonNodeSelector"
         },


### PR DESCRIPTION
### Description
Added the ability to specify arguments for ingress-nginx-controller in cluster.yaml
The need for this arose in PSUPCLPL-12540
Also added new issue to Troubleshooting.md

### How to apply
Run `kubemarine install --tasks="deploy.plugins"` with additional args for ingress-nginx-controller. For example:
```
...
plugins:
  nginx-ingress-controller:
    install: true
    controller:
      args: ['--disable-full-test', '--disable-catch-all']
```

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts



