### PR TITLE
[MANOPD-82304] IN update for CoreDNS rewrite plugin

### DIFF
--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -333,7 +333,7 @@ services:
                 answer: '{% raw %}{{ .Name }}{% endraw %} 3600 IN A {{ control_plain["internal"] }}'
             reject-aaaa:
               enabled: '{{ nodes[0]["internal_address"]|isipv4 }}'
-              priority: 999
+              priority: 1
               class: IN
               type: AAAA
               data:


### PR DESCRIPTION
### Description
IN contains an example of CoreDNS' `rewrite` plugin usage in `cluster.yaml` which doesn't work.

Fixes # (issue)
MANOPD-82304

### Solution
* IN's updated. `rewrite` example is working now. Also updated information about `priority` parameter in `Corefile` config and an example of usage is added.
* Changed priority of CoreDNS template for AAAA queries rejection in non-IPv6 environments.

### How to apply
Not applicable 

### Test Cases
Add `rewrite` plugin to cluster.yaml, for example:
```
services:
  coredns:
    configmap:
      Corefile:
        '.:53':
          rewrite:
            default:
              data:
                name:
                - regex
                - (.*)\.cluster-1\.local {1}.cluster.local
                answer:
                - name
                - (.*)\.cluster\.local {1}.cluster-1.local
```
and run install job with task `deploy.coredns`.

ER: job finishes successfully, Coredns configmap contains rewrite section.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


