### PR TITLE
[MANOPD-81667] fix make_finalized_inventory

### DIFF
--- a/kubemarine/admission.py
+++ b/kubemarine/admission.py
@@ -793,6 +793,8 @@ def finalize_inventory_pss(cluster: KubernetesCluster, inventory_to_finalize: di
         default_merger.merge(current_config.setdefault("defaults", {}), procedure_config["defaults"])
     if "exemptions" in procedure_config:
         default_merger.merge(current_config.setdefault("exemptions", {}), procedure_config["exemptions"])
+        # we have to remove duplicates keeping the items order
+        current_config["exemptions"]["namespaces"] = list(dict.fromkeys(current_config["exemptions"]["namespaces"]))
 
     return inventory_to_finalize
 

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -319,13 +319,14 @@ class KubernetesCluster(Environment):
     def make_finalized_inventory(self):
         from kubemarine.core import defaults
         from kubemarine.procedures import remove_node
-        from kubemarine import controlplane, cri, packages
+        from kubemarine import admission, controlplane, cri, packages
 
         cluster_finalized_functions = {
             packages.cache_package_versions,
             packages.remove_unused_os_family_associations,
             cri.remove_invalid_cri_config,
             remove_node.remove_node_finalize_inventory,
+            admission.finalize_inventory,
             defaults.escape_jinja_characters_for_inventory,
             controlplane.controlplane_finalize_inventory,
         }

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -326,7 +326,7 @@ class KubernetesCluster(Environment):
             packages.remove_unused_os_family_associations,
             cri.remove_invalid_cri_config,
             remove_node.remove_node_finalize_inventory,
-            admission.finalize_inventory,
+            admission.update_finalized_inventory,
             defaults.escape_jinja_characters_for_inventory,
             controlplane.controlplane_finalize_inventory,
         }


### PR DESCRIPTION
### Description
After running manage_psp, manage_pss procedures `cluster_finalized.yaml` doesn't contain appropriate changes within `rbac:psp:pod_security`.

Fixes # (issue)
MANOPD-81667

### Solution
Add `admission.update_finalized_inventory()` function which is called from to `core.cluster.make_finalize_inventory()`.

### How to apply
Not applicable

### Test Cases
Deploy cluster with `pod-security: psp`.
Run `manage_psp` procedure with the following procedure.yaml:
```
psp:
  pod-security: disabled
```
ER: job finishes successfully, `cluster_finalized.yaml` contains disabled psp:
```
...
rbac:
  psp:
    pod-seciruty: disabled
...
```

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


