### PR TITLE
[MANOPD-88830] Adding new requirements before installing a cluster on RHEL 8-based nodes

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -237,8 +237,8 @@ installation on the same OS impossible. To avoid it one should implement those s
 
 After the successful execution of the commands, it is necessary to complete the installation by excluding the **prepare.cri.install** task.
 
-**Warning**: RHEL 8 does not have python preinstalled. For `check_iaas` to work correctly, need to install python on the nodes. Should follow these steps before the installation procedure
-1. Install `python 3.9` from standard RHEL repository:
+**Warning**: RHEL 8 does not have Python preinstalled. For `check_iaas` to work correctly, it is required to install Python on the nodes. Execute the following step before the installation procedure.
+* Install `python 3.9` from the standard RHEL repository:
 ```
 # dnf install python3.9 -y
 ```

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -234,7 +234,14 @@ installation on the same OS impossible. To avoid it one should implement those s
 # rpm --install --nodeps --replacefiles --excludepath=/bin/runc /tmp/containerd.io-1.6.9-3.1.el8.x86_64.rpm
 # systemctl enable containerd
 ```
+
 After the successful execution of the commands, it is necessary to complete the installation by excluding the **prepare.cri.install** task.
+
+**Warning**: Rhel 8 does not have python preinstalled. For `check_iaas` to work correctly, need to install python on the nodes. Should follow these steps before the installation procedure
+1. Install `python 3.9` from standard RHEL repository:
+```
+# dnf install python3.9 -y
+```
 
 **Unattended-upgrades** 
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -237,7 +237,7 @@ installation on the same OS impossible. To avoid it one should implement those s
 
 After the successful execution of the commands, it is necessary to complete the installation by excluding the **prepare.cri.install** task.
 
-**Warning**: Rhel 8 does not have python preinstalled. For `check_iaas` to work correctly, need to install python on the nodes. Should follow these steps before the installation procedure
+**Warning**: RHEL 8 does not have python preinstalled. For `check_iaas` to work correctly, need to install python on the nodes. Should follow these steps before the installation procedure
 1. Install `python 3.9` from standard RHEL repository:
 ```
 # dnf install python3.9 -y


### PR DESCRIPTION
### Description
* There is no pre-installed python on RHEL 8-based nodes.
* Therefore, `check_iaas` ends with a lot of warnings, since the tests require python installed on the nodes
* It is necessary adding python installation on nodes to the pre-installation requirements

Fixes # (issue)
[MANOPD-88830]

### Solution
* New pre-installation requirements for RHEL 8 have been added to the documentation

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


