### PR TITLE
[MANOPD-88703] Added RHEL 8.8 support

### DIFF
--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -326,6 +326,7 @@ compatibility_map:
           - '8.4'
           - '8.6'
           - '8.7'
+          - '8.8'
     rocky:
       - os_family: 'rhel8'
         versions:


### PR DESCRIPTION
### Description
Updated golbals.yaml to add rhel_8.8 version in the supported os family.

Fixes # (issue)


### Solution
Add RHEL 8.8 family

### Test Cases

**TestCase 1**

Test Configuration: 
- OS: rhel_8.8

Steps:

1. Kubemarine check_iaas

AR: Check_iaas suceeded

2. Kubemarine install

AR: Installation suceeded

3. Kubemarine check_pass

AR: check_pass suceeded

4. kubemarine upgrade

 create a procedure.yaml and add the version to be upgraded
 upgrade_plan:
  - v1.27.1
  
 AR: Upgraded successfully 

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


