### PR TITLE
[MANOPD-88293] Update kubeadm-flags.env after successful upgrade of k8s version

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -1398,3 +1398,16 @@ def fix_flag_kubelet(cluster: KubernetesCluster, node: dict):
     if kubeadm_flags.find('--container-runtime=remote') != -1:
         kubeadm_flags = kubeadm_flags.replace('--container-runtime=remote', '')
         node['connection'].put(io.StringIO(kubeadm_flags), kubeadm_file, backup=True, sudo=True)
+ 
+
+def _config_changer(config, word, delemeter="="):
+    equal_pos = word.find(delemeter) + 1
+    param_begin_pos = config.find(word[:equal_pos])
+    if param_begin_pos != -1:
+        param_end_pos = config[param_begin_pos:].find(" ")
+        if param_end_pos == -1:
+            return config[:param_begin_pos] + word + "\""
+        return config[:param_begin_pos] + word + config[param_end_pos + param_begin_pos:]
+    else:
+        param_end_pos = config.rfind("\"")
+        return config[:param_end_pos] + " " + word[:] + "\""

--- a/kubemarine/procedures/migrate_cri.py
+++ b/kubemarine/procedures/migrate_cri.py
@@ -261,22 +261,9 @@ def release_calico_leaked_ips(cluster):
     
 
 def edit_config(kubeadm_flags):
-    kubeadm_flags = _config_changer(kubeadm_flags, "--container-runtime=remote")
-    return _config_changer(kubeadm_flags,
+    kubeadm_flags = kubernetes._config_changer(kubeadm_flags, "--container-runtime=remote")
+    return kubernetes._config_changer(kubeadm_flags,
                            "--container-runtime-endpoint=unix:///run/containerd/containerd.sock")
-
-
-def _config_changer(config, word):
-    equal_pos = word.find("=") + 1
-    param_begin_pos = config.find(word[:equal_pos])
-    if param_begin_pos != -1:
-        param_end_pos = config[param_begin_pos:].find(" ")
-        if param_end_pos == -1:
-            return config[:param_begin_pos] + word + "\""
-        return config[:param_begin_pos] + word + config[param_end_pos + param_begin_pos:]
-    else:
-        param_end_pos = config.rfind("\"")
-        return config[:param_end_pos] + " " + word[:] + "\""
 
 
 def migrate_cri_finalize_inventory(cluster, inventory_to_finalize):

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -140,13 +140,13 @@ def upgrade_containerd(cluster: KubernetesCluster):
 
             kubernetes_nodes = cluster.make_group_from_roles(['control-plane', 'worker'])
             tokens = []
-            for node in kubernetes_nodes.get_ordered_members_list():
+            for member_node in kubernetes_nodes.get_ordered_members_list():
                 kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
                 pause_version = cluster.globals['compatibility_map']['software']['pause'][target_kubernetes_version]['version']
-                kubeadm_flags = node.sudo(f"cat {kubeadm_flags_file}").get_simple_out()
+                kubeadm_flags = member_node.sudo(f"cat {kubeadm_flags_file}").get_simple_out()
                 updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, f"--pod-infra-container-image={sandbox}")
-                node.put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
-            
+                member_node.put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
+
             with kubernetes_nodes.new_executor() as exe:
                 for node in exe.group.get_ordered_members_list():
                     os_specific_associations = cluster.get_associations_for_node(node.get_host(), 'containerd')

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -20,6 +20,7 @@ from io import StringIO
 from itertools import chain
 from typing import List
 
+import re
 import toml
 
 from kubemarine import kubernetes, plugins
@@ -137,6 +138,22 @@ def upgrade_containerd(cluster: KubernetesCluster):
                 if isinstance(value, dict):
                     config_string += f"\n[{key}]\n{toml.dumps(value)}"
             utils.dump_file(cluster, config_string, 'containerd-config.toml')
+            
+            node_group=cluster.nodes['control-plane'].include_group(
+                        cluster.nodes.get('worker')).get_ordered_members_list(
+                        provide_node_configs=True)
+            for node in node_group:
+                if "control-plane" in node["roles"]:
+                    control_plane = node
+                else:
+                    control_plane = cluster.nodes["control-plane"].get_first_member(provide_node_configs=True)
+                kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
+                pause_version = cluster.globals['compatibility_map']['software']['pause'][target_kubernetes_version]['version']
+                kubeadm_flags = node['connection'].sudo(f"cat {kubeadm_flags_file}",
+                                        is_async=False).get_simple_out()
+                updated_kubeadm_flags = re.sub(r'pause:.*\..*', f"pause:{pause_version}", kubeadm_flags)
+                node['connection'].put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
+            
             with RemoteExecutor(cluster) as exe:
                 for node in cluster.nodes['control-plane'].include_group(
                         cluster.nodes.get('worker')).get_ordered_members_list(

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -146,7 +146,7 @@ def upgrade_containerd(cluster: KubernetesCluster):
                 pause_version = cluster.globals['compatibility_map']['software']['pause'][target_kubernetes_version]['version']
                 kubeadm_flags = node['connection'].sudo(f"cat {kubeadm_flags_file}",
                                         is_async=False).get_simple_out()
-                updated_kubeadm_flags = re.sub(r'pause:.*\..*', f"pause:{pause_version}", kubeadm_flags)
+                updated_kubeadm_flags = re.sub(r'(pause:.*\.[^"]*)', f"pause:{pause_version}", kubeadm_flags)
                 node['connection'].put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
             
             with RemoteExecutor(cluster) as exe:

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -141,7 +141,7 @@ def upgrade_containerd(cluster: KubernetesCluster):
             
             for node in cluster.nodes['control-plane'].include_group(
                         cluster.nodes.get('worker')).get_ordered_members_list(
-                        provide_node_configs=True)
+                        provide_node_configs=True):
                 kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
                 pause_version = cluster.globals['compatibility_map']['software']['pause'][target_kubernetes_version]['version']
                 kubeadm_flags = node['connection'].sudo(f"cat {kubeadm_flags_file}",

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -146,7 +146,7 @@ def upgrade_containerd(cluster: KubernetesCluster):
                 
                 kubeadm_flags = node['connection'].sudo(f"cat {kubeadm_flags_file}",
                                         is_async=False).get_simple_out()
-                updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, f"pause:{pause_version}",delemeter=":")
+                updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, f"--pod-infra-container-image={sandbox}")
                 node['connection'].put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
                 
 

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -31,6 +31,7 @@ from kubemarine.core.resources import DynamicResources
 from kubemarine.procedures import install
 
 
+
 def system_prepare_thirdparties(cluster: KubernetesCluster):
     if not cluster.inventory['services'].get('thirdparties', {}):
         cluster.log.debug("Skipped - no thirdparties defined in config file")
@@ -142,11 +143,10 @@ def upgrade_containerd(cluster: KubernetesCluster):
             for node in kubernetes_nodes.get_ordered_members_list():
                 kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
                 pause_version = cluster.globals['compatibility_map']['software']['pause'][target_kubernetes_version]['version']
-                
-                kubeadm_flags = node.sudo(f"cat {kubeadm_flags_file}",
-                                        is_async=False).get_simple_out()
+                kubeadm_flags = node.sudo(f"cat {kubeadm_flags_file}").get_simple_out()
                 updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, f"--pod-infra-container-image={sandbox}")
                 node.put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
+            
             with kubernetes_nodes.new_executor() as exe:
                 for node in exe.group.get_ordered_members_list():
                     os_specific_associations = cluster.get_associations_for_node(node.get_host(), 'containerd')

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -148,7 +148,6 @@ def upgrade_containerd(cluster: KubernetesCluster):
                                         is_async=False).get_simple_out()
                 updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, f"pause:{pause_version}",delemeter=":")
                 node['connection'].put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
-                node['connection'].sudo("systemctl restart kubelet")
                 
 
             with RemoteExecutor(cluster) as exe:
@@ -161,6 +160,7 @@ def upgrade_containerd(cluster: KubernetesCluster):
                                            sudo=True, mkdir=True)
                     node['connection'].sudo(f"sudo systemctl restart {os_specific_associations['service_name']} && "
                                             f"systemctl status {os_specific_associations['service_name']}")
+                    node['connection'].sudo("systemctl restart kubelet")
             return exe.get_last_results_str()
 
 

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -139,7 +139,7 @@ def upgrade_containerd(cluster: KubernetesCluster):
 
             kubernetes_nodes = cluster.make_group_from_roles(['control-plane', 'worker'])
             tokens = []
-            for node in kubernetes_nodes:
+            for node in kubernetes_nodes.get_ordered_members_list():
                 kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
                 pause_version = cluster.globals['compatibility_map']['software']['pause'][target_kubernetes_version]['version']
                 

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -138,8 +138,7 @@ def upgrade_containerd(cluster: KubernetesCluster):
             utils.dump_file(cluster, config_string, 'containerd-config.toml')
 
             for node in cluster.nodes['control-plane'].include_group(
-                        cluster.nodes.get('worker')).get_ordered_members_list(
-                        provide_node_configs=True):
+                        cluster.nodes.get('worker')).get_ordered_members_list():
                 kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
                 pause_version = cluster.globals['compatibility_map']['software']['pause'][target_kubernetes_version]['version']
                 

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -147,7 +147,6 @@ def upgrade_containerd(cluster: KubernetesCluster):
                 kubeadm_flags = node['connection'].sudo(f"cat {kubeadm_flags_file}",
                                         is_async=False).get_simple_out()
                 updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, f"pause:{pause_version}",delemeter=":")
-                # updated_kubeadm_flags = re.sub(r'(pause:.*\.[^"]*)', f"pause:{pause_version}", kubeadm_flags)
                 node['connection'].put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
                 
 

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -139,14 +139,9 @@ def upgrade_containerd(cluster: KubernetesCluster):
                     config_string += f"\n[{key}]\n{toml.dumps(value)}"
             utils.dump_file(cluster, config_string, 'containerd-config.toml')
             
-            node_group=cluster.nodes['control-plane'].include_group(
+            for node in cluster.nodes['control-plane'].include_group(
                         cluster.nodes.get('worker')).get_ordered_members_list(
                         provide_node_configs=True)
-            for node in node_group:
-                if "control-plane" in node["roles"]:
-                    control_plane = node
-                else:
-                    control_plane = cluster.nodes["control-plane"].get_first_member(provide_node_configs=True)
                 kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
                 pause_version = cluster.globals['compatibility_map']['software']['pause'][target_kubernetes_version]['version']
                 kubeadm_flags = node['connection'].sudo(f"cat {kubeadm_flags_file}",

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -148,6 +148,7 @@ def upgrade_containerd(cluster: KubernetesCluster):
                                         is_async=False).get_simple_out()
                 updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, f"pause:{pause_version}",delemeter=":")
                 node['connection'].put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
+                node['connection'].sudo("systemctl restart kubelet")
                 
 
             with RemoteExecutor(cluster) as exe:


### PR DESCRIPTION
### Description
*  kubeadm-flags.env file is not getting updated to reflect the upgrade version for pause.
* As per current design, this file not expected to update.
* Additional code required to update the upgraded version for pause image after successful upgradation of k8s version.

Fixes # 
[MANOPD-88293](https://psup.netcracker.com/browse/MANOPD-88293)


### Solution
* Merging of this code will result in ability to update the upgraded version for pause image in **kubeadm-flags.env** file
 during the upgrade procedure of kubemarine.

### Test Cases
**TestCase 1**
Run the `kubemarine upgrade` procedure to upgrade the k8s version.

Results:

| Before | After |
| ------ | ------ |
| **kubeadm-flags.env** file still shows the pause image version as per the older k8s version | **kubeadm-flags.env** file will be updated with the upgraded version for pause image as per new k8s version  |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts



