### PR TITLE
MANOPD-88483 Environment variables support in kubemarine cluster configuration

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -4977,7 +4977,7 @@ section:
 
 Dynamic variables have some limitations that should be considered when working with them:
 
-* Dynamic variables are not supported in inventory files of maintenance procedures (e. g. upgrade).
+* Dynamic variables are not supported in inventory files of maintenance procedures like upgrade.
 * All variables should be either valid variables that Kubemarine understands,
   or custom variables defined in the dedicated `values` section.
   ```yaml
@@ -5029,8 +5029,8 @@ section:
 ```
 
 Environment variables inherit all features and limitations of the [Dynamic Variables](#dynamic-variables) including but not limited to:
-* Ability to participate in full-fledged Jinja2 templates.
-* Recursive pointing to other variables pointing to environment variables.
+* The ability to participate in full-fledged Jinja2 templates.
+* The recursive pointing to other variables pointing to environment variables.
 
 Consider the following more complex example:
 
@@ -5043,7 +5043,7 @@ plugins:
     variable: '{{ values.variable }}'
 ```
 
-The above configuration generates the following result provided that `ENV_VARIABLE_NAME=ENV_VARIABLE_VALUE` is defined:
+The above configuration generates the following result, provided that `ENV_VARIABLE_NAME=ENV_VARIABLE_VALUE` is defined:
 
 ```yaml
 values:

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -94,6 +94,7 @@ This section provides information about the inventory, features, and steps for i
     - [Dynamic Variables](#dynamic-variables)
       - [Limitations](#limitations)
       - [Jinja2 Expressions Escaping](#jinja2-expressions-escaping)
+    - [Environment Variables](#environment-variables)
   - [Installation without Internet Resources](#installation-without-internet-resources)
 - [Installation Procedure](#installation-procedure)
   - [Installation Tasks Description](#installation-tasks-description)
@@ -4730,10 +4731,11 @@ is further used throughout the entire installation.
 
 **Note**: If [Dump Files](#dump-files) is enabled, then you can see merged **cluster.yaml** file version in the dump directory.
 
-To make sure that the information in the configuration file is not duplicated, the following advanced functionality appears in the yaml file:
+To simplify maintenance of the configuration file, the following advanced functionality appears in the yaml file:
 
 * List merge strategy
 * Dynamic variables
+* Environment Variables
 
 ### List Merge Strategy
 
@@ -4975,6 +4977,7 @@ section:
 
 Dynamic variables have some limitations that should be considered when working with them:
 
+* Dynamic variables are not supported in inventory files of maintenance procedures (e. g. upgrade).
 * All variables should be either valid variables that Kubemarine understands,
   or custom variables defined in the dedicated `values` section.
   ```yaml
@@ -5010,6 +5013,47 @@ For example:
 ```yaml
 authority: '{% raw %}{{ .Name }}{% endraw %} 3600 IN SOA'
 ```
+
+### Environment Variables
+
+Kubemarine supports environment variables inside the following places:
+* The configuration file **cluster.yaml**.
+* Jinja2 template files for plugins. For more information, refer to [template](#template).
+
+Environment variables are available through the predefined `env` Jinja2 variable.
+Refer to them inside the configuration file in the following way:
+
+```yaml
+section:
+  variable: '{{ env.ENV_VARIABLE_NAME }}'
+```
+
+Environment variables inherit all features and limitations of the [Dynamic Variables](#dynamic-variables) including but not limited to:
+* Ability to participate in full-fledged Jinja2 templates.
+* Recursive pointing to other variables pointing to environment variables.
+
+Consider the following more complex example:
+
+```yaml
+values:
+  variable: '{{ env["ENV_VARIABLE_NAME"] | default("nothing") }}'
+
+plugins:
+  my_plugin:
+    variable: '{{ values.variable }}'
+```
+
+The above configuration generates the following result provided that `ENV_VARIABLE_NAME=ENV_VARIABLE_VALUE` is defined:
+
+```yaml
+values:
+  variable: ENV_VARIABLE_VALUE
+
+plugins:
+  my_plugin:
+    variable: ENV_VARIABLE_VALUE
+```
+
 ## Installation without Internet Resources
 
 If you want to install Kubernetes in a private environment, without access to the internet, then you need to redefine the addresses of remote resources.

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -343,8 +343,7 @@ class KubernetesCluster(Environment):
         data = yaml.dump(inventory_for_dump)
         finalized_filename = "cluster_finalized.yaml"
         utils.dump_file(self, data, finalized_filename)
-        with utils.open_external(finalized_filename, 'w') as f:
-            f.write(data)
+        utils.dump_file(self, data, finalized_filename, dump_location=False)
 
     def preserve_inventory(self):
         self.log.debug("Start preserving of the information about the procedure.")

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -21,7 +21,7 @@ import yaml
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.errors import KME
 from kubemarine import jinja
-from kubemarine.core import utils, static
+from kubemarine.core import utils, static, log, os
 from kubemarine.core.yaml_merger import default_merger
 
 # All enrichment procedures should not connect to any node.
@@ -412,12 +412,13 @@ def enrich_inventory(cluster: KubernetesCluster, inventory: dict, make_dumps=Tru
     return inventory
 
 
-def compile_inventory(inventory, cluster):
+def compile_inventory(inventory: dict, cluster: KubernetesCluster):
 
     # convert references in yaml to normal values
     iterations = 100
     root = deepcopy(inventory)
     root['globals'] = static.GLOBALS
+    root['env'] = os.Environ()
 
     while iterations > 0:
 
@@ -446,38 +447,41 @@ def compile_inventory(inventory, cluster):
     return inventory
 
 
-def compile_object(log, struct, root, ignore_jinja_escapes=True):
+def compile_object(logger: log.EnhancedLogger, struct: object, root: dict, ignore_jinja_escapes=True) -> object:
     if isinstance(struct, list):
         new_struct = []
         for i, v in enumerate(struct):
-            struct[i] = compile_object(log, v, root, ignore_jinja_escapes=ignore_jinja_escapes)
+            struct[i] = compile_object(logger, v, root, ignore_jinja_escapes=ignore_jinja_escapes)
             # delete empty list entries, which can appear after jinja compilation
             if struct[i] != '':
                 new_struct.append(struct[i])
         struct = new_struct
     elif isinstance(struct, dict):
         for k, v in struct.items():
-            struct[k] = compile_object(log, v, root, ignore_jinja_escapes=ignore_jinja_escapes)
+            struct[k] = compile_object(logger, v, root, ignore_jinja_escapes=ignore_jinja_escapes)
     elif isinstance(struct, str) and ('{{' in struct or '{%' in struct):
-        struct = compile_string(log, struct, root, ignore_jinja_escapes=ignore_jinja_escapes)
+        struct = compile_string(logger, struct, root, ignore_jinja_escapes=ignore_jinja_escapes)
+
     return struct
 
 
-def compile_string(log, struct, root, ignore_jinja_escapes=True):
-    log.verbose("Rendering \"%s\"" % struct)
+def compile_string(logger: log.EnhancedLogger, struct: str, root: dict,
+                   ignore_jinja_escapes=True) -> str:
+    logger.verbose("Rendering \"%s\"" % struct)
 
     if ignore_jinja_escapes:
         iterator = escaped_expression_regex.finditer(struct)
         struct = re.sub(escaped_expression_regex, '', struct)
-        struct = jinja.new(log, root).from_string(struct).render(**root)
+        struct = jinja.new(logger, True, root).from_string(struct).render(**root)
 
+        # TODO this does not work for {raw}{jinja}{raw}{jinja}
         for match in iterator:
             span = match.span()
             struct = struct[:span[0]] + match.group() + struct[span[0]:]
     else:
-        struct = jinja.new(log, root).from_string(struct).render(**root)
+        struct = jinja.new(logger, True, root).from_string(struct).render(**root)
 
-    log.verbose("\tRendered as \"%s\"" % struct)
+    logger.verbose("\tRendered as \"%s\"" % struct)
     return struct
 
 

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -27,7 +27,7 @@ import fabric
 import invoke
 from invoke import UnexpectedExit
 
-from kubemarine.core import utils
+from kubemarine.core import utils, log
 from kubemarine.core.connections import Connections
 from kubemarine.core.executor import RemoteExecutor
 
@@ -308,6 +308,44 @@ class NodeGroupResult(fabric.group.GroupResult, Dict[fabric.connection.Connectio
         return not self == other
 
 
+def _handle_internal_logging(fn: callable) -> callable:
+    """
+    Method is a decorator that handles internal streaming of output (hide=False) of fabric (invoke).
+    Note! This decorator should be the outermost.
+
+    :param fn: Origin function to apply annotation to
+    :return: Validation wrapper function
+    """
+    def do(self: 'NodeGroup', *args, logging_stream_level: int = None, **kwargs):
+        if logging_stream_level is not None and 'hide' in kwargs:
+            raise ValueError("'hide' and 'logging_stream_level' should not be combined")
+
+        logger = self.cluster.log
+        if logging_stream_level is not None:
+            # We want to stream output immediately to logging framework, thus not hide.
+            kwargs['hide'] = False
+
+            caller = log.caller_info(logger)
+            out = log.LoggerWriter(logger, logging_stream_level, caller, '[remote] ')
+            err = log.LoggerWriter(logger, logging_stream_level, caller, '[stderr] ')
+
+            return fn(self, *args, out_stream=out, err_stream=err, **kwargs)
+
+        results = None
+        try:
+            results = fn(self, *args, **kwargs)
+            return results
+        except fabric.group.GroupException as e:
+            results = e.result
+            raise
+        finally:
+            # if hide is False, we already logged only to stdout, and should log to other handlers.
+            if results is not None and not kwargs.get('hide', True):
+                logger.debug(results, extra={'ignore_stdout': True})
+
+    return do
+
+
 class NodeGroup:
 
     def __init__(self, connections: Connections, cluster):
@@ -360,9 +398,11 @@ class NodeGroup:
 
         return group_result
 
+    @_handle_internal_logging
     def run(self, *args, **kwargs) -> Union[NodeGroupResult, int]:
         return self.do("run", *args, **kwargs)
 
+    @_handle_internal_logging
     def sudo(self, *args, **kwargs) -> Union[NodeGroupResult, int]:
         return self.do("sudo", *args, **kwargs)
 
@@ -478,12 +518,7 @@ class NodeGroup:
         raw_results = self._do_with_wa(do_type, *args, **kwargs)
         if isinstance(raw_results, int):
             return raw_results
-        group_results = self._make_result_or_fail(raw_results, lambda host, result: isinstance(result, Exception))
-
-        if not kwargs.get('hide', True):
-            self.cluster.log.debug(group_results, extra={'ignore_stdout': True})
-
-        return group_results
+        return self._make_result_or_fail(raw_results, lambda host, result: isinstance(result, Exception))
 
     def _do_with_wa(self, do_type, *args, **kwargs) -> Union[_HostToResult, int]:
         # by default all code is async, but can be set False forcibly

--- a/kubemarine/core/os.py
+++ b/kubemarine/core/os.py
@@ -18,7 +18,3 @@ class Environ(Mapping[str, str]):
         return iter(os.environ)
 
     __slots__ = []
-
-
-def environ() -> Environ:
-    return Environ()

--- a/kubemarine/core/os.py
+++ b/kubemarine/core/os.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2023 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from typing import Iterator, Mapping
 

--- a/kubemarine/core/os.py
+++ b/kubemarine/core/os.py
@@ -1,0 +1,24 @@
+import os
+from typing import Iterator, Mapping
+
+
+class Environ(Mapping[str, str]):
+    """
+    Read-only view of os.environ.
+    """
+
+    def __getitem__(self, name: str) -> str:
+        # check presence of the variable and throw KeyError if necessary
+        return os.environ[name]
+
+    def __len__(self) -> int:
+        return len(os.environ)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(os.environ)
+
+    __slots__ = []
+
+
+def environ() -> Environ:
+    return Environ()

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -20,7 +20,7 @@ import sys
 import time
 import tarfile
 
-from typing import Union, Tuple
+from typing import Tuple
 
 import yaml
 import ruamel.yaml
@@ -34,7 +34,7 @@ from kubemarine.core.executor import RemoteExecutor
 from kubemarine.core.errors import pretty_print_error
 
 
-def do_fail(message='', reason: Union[str, Exception] = '', hint='', log=None):
+def do_fail(message='', reason: Exception = None, hint='', log=None):
 
     if log:
         log.critical('FAILURE!')
@@ -152,8 +152,7 @@ def make_ansible_inventory(location, cluster):
             config_compiled += '\n' + string
         config_compiled += '\n\n'
 
-    with open_external(location, 'w') as configfile:
-        configfile.write(config_compiled)
+    dump_file({}, config_compiled, location, dump_location=False)
 
 
 def get_current_timestamp_formatted():
@@ -198,24 +197,31 @@ def merge_vrrp_ips(procedure_inventory, inventory):
         inventory.move_to_end("vrrp_ips", last=False)
 
 
-def dump_file(context, data, filename):
-    if not isinstance(context, dict):
-        # cluster is passed instead of the context directly
-        cluster = context
-        context = cluster.context
+def dump_file(context, data: object, filename: str,
+              *, dump_location=True):
+    if dump_location:
+        if not isinstance(context, dict):
+            # cluster is passed instead of the context directly
+            cluster = context
+            context = cluster.context
+
+        args = context['execution_arguments']
+        if args.get('disable_dump', True) \
+                and not (filename in ClusterStorage.PRESERVED_DUMP_FILES and context['preserve_inventory']):
+            return
+
+        prepare_dump_directory(args.get('dump_location'), reset_directory=False)
+        target_path = get_dump_filepath(context, filename)
+    else:
+        target_path = get_external_resource_path(filename)
 
     if isinstance(data, io.StringIO):
         data = data.getvalue()
     if isinstance(data, io.TextIOWrapper):
         data = data.read()
 
-    args = context['execution_arguments']
-    if not args.get('disable_dump', True) \
-            or (filename in ClusterStorage.PRESERVED_DUMP_FILES and context['preserve_inventory']):
-
-        prepare_dump_directory(args.get('dump_location'), reset_directory=False)
-        with open_utf8(get_dump_filepath(context, filename), 'w') as file:
-            file.write(data)
+    with open_utf8(target_path, 'w') as file:
+        file.write(data)
 
 
 def get_dump_filepath(context, filename):

--- a/kubemarine/jinja.py
+++ b/kubemarine/jinja.py
@@ -15,17 +15,32 @@
 import yaml
 import jinja2
 
-from kubemarine.core import defaults
+from kubemarine.core import defaults, log
 
 
-def new(log, root=None):
-    if root is None:
-        root = {}
+def new(logger: log.EnhancedLogger, recursive_compile=False, root: dict = None):
+    if recursive_compile and root is None:
+        raise Exception(
+            "If recursive compilation is enabled, "
+            "'root' parameter should also be specified to provide compilation context.")
+
+    def _precompile(filter_: str, struct: str):
+        if not isinstance(struct, str):
+            raise ValueError(f"Filter {filter_!r} can be applied only on string")
+
+        if not recursive_compile:
+            return struct
+
+        struct = precompile(logger, struct, root)
+
+        return struct
+
+
     env = jinja2.Environment()
     env.filters['toyaml'] = lambda data: yaml.dump(data, default_flow_style=False)
-    env.filters['isipv4'] = lambda ip: ":" not in precompile(log, ip, root)
-    env.filters['minorversion'] = lambda version: ".".join(precompile(log, version, root).split('.')[0:2])
-    env.filters['majorversion'] = lambda version: precompile(log, version, root).split('.')[0]
+    env.filters['isipv4'] = lambda ip: ":" not in _precompile('isipv4', ip)
+    env.filters['minorversion'] = lambda version: ".".join(_precompile('minorversion', version).split('.')[0:2])
+    env.filters['majorversion'] = lambda version: _precompile('majorversion', version).split('.')[0]
     # we need these filters because rendered cluster.yaml can contain variables like 
     # enable: 'true'
     env.filters['is_true'] = lambda v: v in ['true', 'True', 'TRUE', True]
@@ -33,8 +48,9 @@ def new(log, root=None):
     return env
 
 
-def precompile(log, struct, root):
+def precompile(logger: log.EnhancedLogger, struct: str, root: dict) -> str:
     # maybe we have non compiled string like templates/plugins/calico-{{ globals.compatibility_map }} ?
     if '{{' in struct or '{%' in struct:
-        struct = defaults.compile_object(log, struct, root)
+        struct = defaults.compile_string(logger, struct, root)
+
     return struct

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -487,9 +487,7 @@ def fetch_admin_config(cluster: KubernetesCluster) -> str:
         kubeconfig = kubeconfig.replace(cluster_name, public_cluster_ip)
 
     kubeconfig_filename = os.path.abspath("kubeconfig")
-    with utils.open_external(kubeconfig_filename, 'w') as f:
-        f.write(kubeconfig)
-
+    utils.dump_file(cluster.context, kubeconfig, kubeconfig_filename, dump_location=False)
     cluster.log.debug(f"Kubeconfig saved to {kubeconfig_filename}")
 
     return kubeconfig_filename

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -117,9 +117,8 @@ def install(cluster: KubernetesCluster):
         })
 
     cluster.log.debug('\nSaving tokens...')
-    token_filename = os.path.abspath('account-tokens.yaml')
-    with utils.open_external(token_filename, 'w') as tokenfile:
-        tokenfile.write(yaml.dump(tokens, default_flow_style=False))
-        cluster.log.debug('Tokens saved to %s' % token_filename)
+    token_filename = utils.get_external_resource_path('account-tokens.yaml')
+    utils.dump_file(cluster.context, yaml.dump(tokens), token_filename, dump_location=False)
+    cluster.log.debug('Tokens saved to %s' % token_filename)
 
     summary.schedule_report(cluster.context, summary.SummaryItem.ACCOUNT_TOKENS, token_filename)

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -16,6 +16,7 @@
 import glob
 import importlib.util
 import io
+import logging
 import os
 import re
 import shutil
@@ -991,7 +992,7 @@ def apply_source(cluster: KubernetesCluster, config: dict) -> None:
         if use_sudo:
             method = apply_common_group.sudo
         cluster.log.debug("Applying yaml...")
-        method(apply_command, hide=False)
+        method(apply_command, logging_stream_level=logging.DEBUG)
     else:
         cluster.log.debug('Apply is not required')
 

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -803,18 +803,17 @@ def process_chart_values(config, local_chart_path):
     if config_values is None and file_values is None:
         return
 
-    with utils.open_external(os.path.join(local_chart_path, 'values.yaml'), 'r+') as stream:
+    chart_values = os.path.join(local_chart_path, 'values.yaml')
+    with utils.open_external(chart_values, 'r') as stream:
         merged_values = yaml.safe_load(stream)
 
-        if file_values is not None:
-            merged_values = default_merger.merge(merged_values, file_values)
-        # Values from 'values' section have priority over values in 'values_file' section
-        if config_values is not None:
-            merged_values = default_merger.merge(merged_values, config_values)
+    if file_values is not None:
+        merged_values = default_merger.merge(merged_values, file_values)
+    # Values from 'values' section have priority over values in 'values_file' section
+    if config_values is not None:
+        merged_values = default_merger.merge(merged_values, config_values)
 
-        stream.seek(0)
-        stream.write(yaml.dump(merged_values))
-        stream.truncate()
+    utils.dump_file({}, yaml.dump(merged_values), chart_values, dump_location=False)
 
 
 def get_local_chart_path(log, config):

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -38,7 +38,7 @@ import yaml
 
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine import jinja, thirdparties
-from kubemarine.core import utils, static, errors
+from kubemarine.core import utils, static, errors, os as kos
 from kubemarine.core.yaml_merger import default_merger
 from kubemarine.core.group import NodeGroup, NodeGroupResult
 from kubemarine.kubernetes.daemonset import DaemonSet
@@ -938,7 +938,7 @@ def _apply_file(cluster: KubernetesCluster, config: dict, file_type: str) -> Non
             if split_extension[1] == ".j2":
                 source_filename = split_extension[0]
 
-            render_vars = {**cluster.inventory, 'runtime_vars': cluster.context['runtime_vars']}
+            render_vars = {**cluster.inventory, 'runtime_vars': cluster.context['runtime_vars'], 'env': kos.Environ()}
             with utils.open_utf8(file, 'r') as template_stream:
                 generated_data = jinja.new(log).from_string(template_stream.read()).render(**render_vars)
 

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -284,8 +284,7 @@ def download_resources(log, resources, location, control_plane: NodeGroup, names
         result = result.strip()
         if result and result != '':
             actual_resources.append(resource)
-            with utils.open_external(resource_file_path, 'w') as resource_file_stream:
-                resource_file_stream.write(result)
+            utils.dump_file({}, result, resource_file_path, dump_location=False)
 
     return actual_resources
 

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -385,9 +385,10 @@ logging:
       level: debug
       correct_newlines: True
       colorize: true
+      format: "%(asctime)s %(levelname)s %(message)s"
     dump:
       level: verbose
-      format: "%(asctime)s %(process)s %(thread)s %(name)s %(levelname)s [%(module)s.%(funcName)s] %(message)s"
+      format: "%(asctime)s %(levelname)s [%(module)s.%(funcName)s] %(message)s"
       colorize: False
       correct_newlines: True
 

--- a/kubemarine/testsuite.py
+++ b/kubemarine/testsuite.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import io
 import textwrap
 from traceback import *
 import csv
@@ -106,7 +106,7 @@ class TestCase:
             else:
                 output += "    OK     "
         if self.is_failed():
-            if self.check_color():    
+            if self.check_color():
                 color = "\x1b[38;5;196m"
                 output += " \x1b[48;5;196m\x1b[38;5;231m  FAIL  \x1b[49m\x1b[39m  "
             else:
@@ -159,7 +159,7 @@ class TestCase:
             if isinstance(handler, log.StdoutHandler) and handler.formatter.colorize:
                 return True
         return False
-                
+
     def get_readable_status(self):
         if self.is_succeeded():
             return 'ok'
@@ -284,47 +284,53 @@ class TestSuite:
         return results
 
     def save_csv(self, destination_file_path, delimiter=';'):
-        with utils.open_external(destination_file_path, mode='w') as stream:
-            csv_writer = csv.writer(stream, delimiter=delimiter, quotechar='"', quoting=csv.QUOTE_MINIMAL)
-            csv_writer.writerow(['group', 'status', 'test_id', 'test_name', 'current_result', 'minimal_result', 'recommended_result'])
-            for tc in self.tcs:
-                csv_writer.writerow([
-                    tc.category.lower(),
-                    tc.get_readable_status(),
-                    tc.id,
-                    tc.name,
-                    tc.results,
-                    tc.minimal,
-                    tc.recommended
-                ])
+        stream = io.StringIO()
+
+        csv_writer = csv.writer(stream, delimiter=delimiter, quotechar='"', quoting=csv.QUOTE_MINIMAL)
+        csv_writer.writerow(['group', 'status', 'test_id', 'test_name', 'current_result', 'minimal_result', 'recommended_result'])
+        for tc in self.tcs:
+            csv_writer.writerow([
+                tc.category.lower(),
+                tc.get_readable_status(),
+                tc.id,
+                tc.name,
+                tc.results,
+                tc.minimal,
+                tc.recommended
+            ])
+
+        utils.dump_file({}, stream, destination_file_path, dump_location=False)
 
     def save_html(self, destination_file_path, check_type, append_styles=True):
-        with utils.open_external(destination_file_path, mode='w') as stream:
-            stream.write('<!DOCTYPE html><html><head><meta charset="utf-8"><title>%s Check Report</title></head><body><div id="date">%s</div><div id="stats">' % (check_type, datetime.utcnow()))
-            for key, value in sorted(self.get_stats_data().items(), key=lambda _key: badges_weights[_key[0]]):
-                stream.write('<div class="%s">%s %s</div>' % (key, value, key))
-            stream.write('</div><h1>%s Check Report</h1><table>' % check_type)
-            stream.write('<thead><tr><td>Group</td><td>Status</td><td>ID</td><td>Test</td><td>Actual Result</td><td>Minimal</td><td>Recommended</td></tr></thead><tbody>')
-            for tc in self.tcs:
-                minimal = tc.minimal
-                if minimal is None:
-                    minimal = ''
-                recommended = tc.recommended
-                if recommended is None:
-                    recommended = ''
-                stream.write('<tr class="%s"><td>%s</td><td><div>%s</div></td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>' %
-                             (tc.get_readable_status(),
-                              tc.category.lower(),
-                              tc.get_readable_status(),
-                              tc.id,
-                              tc.name,
-                              tc.results,
-                              minimal,
-                              recommended
-                              ))
-            stream.write('</tbody></table>')
-            if append_styles:
-                css = utils.read_internal('resources/reports/check_report.css')
-                stream.write('<style>\n%s\n</style>' % css)
+        stream = io.StringIO()
 
-            stream.write('</body></html>')
+        stream.write('<!DOCTYPE html><html><head><meta charset="utf-8"><title>%s Check Report</title></head><body><div id="date">%s</div><div id="stats">' % (check_type, datetime.utcnow()))
+        for key, value in sorted(self.get_stats_data().items(), key=lambda _key: badges_weights[_key[0]]):
+            stream.write('<div class="%s">%s %s</div>' % (key, value, key))
+        stream.write('</div><h1>%s Check Report</h1><table>' % check_type)
+        stream.write('<thead><tr><td>Group</td><td>Status</td><td>ID</td><td>Test</td><td>Actual Result</td><td>Minimal</td><td>Recommended</td></tr></thead><tbody>')
+        for tc in self.tcs:
+            minimal = tc.minimal
+            if minimal is None:
+                minimal = ''
+            recommended = tc.recommended
+            if recommended is None:
+                recommended = ''
+            stream.write('<tr class="%s"><td>%s</td><td><div>%s</div></td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>' %
+                         (tc.get_readable_status(),
+                          tc.category.lower(),
+                          tc.get_readable_status(),
+                          tc.id,
+                          tc.name,
+                          tc.results,
+                          minimal,
+                          recommended
+                          ))
+        stream.write('</tbody></table>')
+        if append_styles:
+            css = utils.read_internal('resources/reports/check_report.css')
+            stream.write('<style>\n%s\n</style>' % css)
+
+        stream.write('</body></html>')
+
+        utils.dump_file({}, stream, destination_file_path, dump_location=False)

--- a/test/unit/core/test_cluster.py
+++ b/test/unit/core/test_cluster.py
@@ -28,8 +28,7 @@ class KubernetesClusterTest(unittest.TestCase):
 
     # TODO: add more tests
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
         self.cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA))
 
     def test_make_group_from_strs(self):
@@ -108,3 +107,7 @@ class KubernetesClusterTest(unittest.TestCase):
             'version': '7.9'
         }
         return nodes_context
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/core/test_env.py
+++ b/test/unit/core/test_env.py
@@ -1,0 +1,125 @@
+import logging
+import os
+import tempfile
+import unittest
+from typing import Dict, Optional
+from unittest import mock
+
+from kubemarine import demo, plugins
+from kubemarine.core import flow, utils, log
+from kubemarine.procedures import install
+
+
+class TestEnvironmentVariables(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.inventory = demo.generate_inventory(**demo.ALLINONE)
+        self.context = demo.create_silent_context(['--without-act'], procedure='install',
+                                                  parser=flow.new_tasks_flow_parser("Help text", install.tasks))
+        args = self.context['execution_arguments']
+        args['disable_dump'] = False
+        args['dump_location'] = self.tmpdir.name
+        utils.prepare_dump_directory(args['dump_location'])
+
+        self.resources: Optional[demo.FakeResources] = None
+
+    def tearDown(self):
+        logger = logging.getLogger("k8s.fake.local")
+        for h in logger.handlers:
+            if isinstance(h, log.FileHandlerWithHeader):
+                h.close()
+        self.tmpdir.cleanup()
+
+    def _new_resources(self) -> demo.FakeResources:
+        return demo.FakeResources(self.context, self.inventory,
+                                  nodes_context=demo.generate_nodes_context(self.inventory))
+
+    def _run(self, mock_environ: Dict[str, str]):
+        self.resources = self._new_resources()
+        with mock.patch.dict(os.environ, mock_environ):
+            flow.run_actions(self.resources, [install.InstallAction()])
+
+    def test_simple_miscellaneous_env_variables(self):
+        self.inventory['values'] = {
+            'variable': '{{ env.ENV_NAME }}',
+        }
+        self.inventory['services']['cri'] = {
+            'containerRuntime': 'containerd',
+            'containerdConfig': {
+                'plugins."io.containerd.grpc.v1.cri".registry.configs."host".auth': {
+                    'username': '{{ env.CRI_NAME }}', 'password': '{{ env["CRI_PASS"] }}'
+                }
+            }
+        }
+
+        self._run({'ENV_NAME': 'value1', 'CRI_NAME': 'me', 'CRI_PASS': 'password123'})
+
+        inventory = self.resources.last_cluster.inventory
+        self.assertEqual('value1', inventory['values']['variable'])
+
+        config = inventory['services']['cri']['containerdConfig']['plugins."io.containerd.grpc.v1.cri".registry.configs."host".auth']
+        self.assertEqual('me', config['username'])
+        self.assertEqual('password123', config['password'])
+
+    def test_substring_jinja_env_variables(self):
+        self.inventory['plugins'] = {'my_plugin': {'installation': {'procedures': [
+            {'helm': {
+                'chart_path': __file__,
+                'values': {
+                    'image': 'test-image:{{ env.IMAGE_TAG }}',
+                    'version': '{{ env.IMAGE_TAG }}'
+                }
+            }}
+        ]}}}
+
+        self._run({'IMAGE_TAG': '1.2.3'})
+
+        inventory = self.resources.last_cluster.inventory
+        values = inventory['plugins']['my_plugin']['installation']['procedures'][0]['helm']['values']
+        self.assertEqual('test-image:1.2.3', values['image'])
+        self.assertEqual('1.2.3', values['version'])
+
+    def test_expression_jinja_env_variables(self):
+        self.inventory['values'] = {
+            'variable': '{{ env.ENV_NAME1 | default("not defined") }}',
+        }
+        self._run({})
+        inventory = self.resources.last_cluster.inventory
+        self.assertEqual('not defined', inventory['values']['variable'])
+
+    def test_recursive_env_variables(self):
+        self.inventory['values'] = {
+            'variable1': '{{ values.variable3 }}',
+            'variable2': '{{ env.ENV_NAME }}',
+            'variable3': '{{ values.variable2 }}',
+        }
+        self._run({'ENV_NAME': 'value-recursive'})
+        inventory = self.resources.last_cluster.inventory
+        self.assertEqual('value-recursive', inventory['values']['variable1'])
+        self.assertEqual('value-recursive', inventory['values']['variable2'])
+        self.assertEqual('value-recursive', inventory['values']['variable3'])
+
+    def test_plugin_template_apply_env_variables(self):
+        template_file = os.path.join(self.tmpdir.name, 'template.yaml.j2')
+        with utils.open_external(template_file, 'w') as t:
+            t.write('Some {{ env.ENV_VAR }}\n')
+
+        self.inventory['plugins'] = {'my_plugin': {
+            'install': True,
+            'installation': {'procedures': [{'template': template_file}]}
+        }}
+        resources = self._new_resources()
+        with mock.patch.object(plugins, plugins.apply_source.__name__) as apply_source, \
+                mock.patch.dict(os.environ, {'ENV_VAR': 'env_value'}):
+            cluster = resources.cluster()
+            plugins.install(cluster, {'my_plugin': cluster.inventory['plugins']['my_plugin']})
+
+        source = apply_source.call_args[0][1]['source'].getvalue()
+        self.assertIn('Some env_value', source, "Env variable should be expanded")
+
+        compiled_template = utils.read_external(os.path.join(self.tmpdir.name, 'dump', 'template.yaml'))
+        self.assertIn('Some env_value', compiled_template, "Env variable should be expanded in dump files.")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/core/test_env.py
+++ b/test/unit/core/test_env.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2023 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 import tempfile

--- a/test/unit/core/test_executor.py
+++ b/test/unit/core/test_executor.py
@@ -25,8 +25,7 @@ from kubemarine.core.executor import RemoteExecutor
 
 
 class RemoteExecutorTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
         self.cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA))
 
     def test_get_merged_results_all_success(self):
@@ -148,3 +147,7 @@ class RemoteExecutorTest(unittest.TestCase):
             exe.flush()
             with self.assertRaises(GroupException):
                 exe.get_merged_result()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/core/test_group.py
+++ b/test/unit/core/test_group.py
@@ -24,8 +24,7 @@ from kubemarine import demo
 
 class NodeGroupResultsTest(unittest.TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
         self.cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA))
 
     def test_nodegroup_result_to_str(self):
@@ -205,3 +204,7 @@ class NodeGroupResultsTest(unittest.TestCase):
         results = NodeGroupResult(self.cluster, host_to_result)
         actual_group = results.get_nonzero_nodes_group()
         self.assertEqual(expected_nonzero_group, actual_group, msg="Actual group contains different nodes than expected")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/plugins/test_template.py
+++ b/test/unit/plugins/test_template.py
@@ -120,3 +120,7 @@ class TestTemplate(unittest.TestCase):
                         if len(history) == 1 and history[0]["used_times"] == 1:
                             cnt += 1
                     self.assertEqual(1, cnt)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_audit.py
+++ b/test/unit/test_audit.py
@@ -25,8 +25,7 @@ from kubemarine.demo import FakeKubernetesCluster
 
 class NodeGroupResultsTest(unittest.TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
         self.inventory = demo.generate_inventory(**demo.FULLHA)
 
     def new_debian_cluster(self) -> FakeKubernetesCluster:
@@ -167,3 +166,7 @@ class NodeGroupResultsTest(unittest.TestCase):
 
         self.assertEqual(expected_data, actual_data,
                          msg='Audit rules file contains invalid content')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_demo.py
+++ b/test/unit/test_demo.py
@@ -36,8 +36,7 @@ class TestNewCluster(unittest.TestCase):
 
 class TestFakeShell(unittest.TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
         self.cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA))
 
     def test_run(self):
@@ -74,8 +73,7 @@ class TestFakeShell(unittest.TestCase):
 
 class TestFakeFS(unittest.TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
         self.cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA))
 
     def test_put_string(self):

--- a/test/unit/test_k8s_cert.py
+++ b/test/unit/test_k8s_cert.py
@@ -27,7 +27,7 @@ class K8sCertTest(unittest.TestCase):
     def setUp(self):
         self.inventory = demo.generate_inventory(**demo.ALLINONE)
         self.context = demo.create_silent_context(procedure='cert_renew')
-        self.cert_renew = {
+        self.cert_renew: dict = {
             'kubernetes': {
                 'cert-list': []
             }
@@ -72,3 +72,7 @@ class K8sCertTest(unittest.TestCase):
         self.cert_renew['kubernetes']['cert-list'] = []
         with self.assertRaisesRegex(Exception, "Number of items equal to 0 is less than the minimum of 1"):
             self._new_cluster()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_keepalived.py
+++ b/test/unit/test_keepalived.py
@@ -24,8 +24,7 @@ from test.unit import utils
 
 class TestKeepalivedDefaultsEnrichment(unittest.TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self):
         self.inventory = demo.generate_inventory(**demo.FULLHA_KEEPALIVED)
         self.cluster = demo.new_cluster(self.inventory)
         self.cluster2 = demo.new_cluster(self.inventory)


### PR DESCRIPTION
### Description
* It is necessary to allow parameterization of the inventory file and plugin templates through the environment variables.

### Solution
* Implemented API `core.os.Environ` to read-only access the environment variables.
* Added `env` variable referring to `Environ` to Jinja compilation context for inventory file and plugin templates.
* Implemented streaming of remote command's output to logging framework.
* Changed default logging format for stdout and `debug.log`
    * Removed `cluster_name` from both formats
    * Removed process and thread ID from `debug.log`.

### Test Cases

**TestCase 1**
Environment variables in the inventory and plugin templates.

1. Configure inventory and/or plugin template with reference to environment variables in any section.
2. Run installation procedure.

ER: Environment variables are expanded and applied to the cluster correspondingly.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
Added test_env.py for environment and masked variables.
