### PR TITLE
Edit helm command to install chart in apply_helm function

### DIFF
--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -785,7 +785,7 @@ def apply_helm(cluster: KubernetesCluster, config, plugin_name=None):
         cluster.log.debug("Deployed release %s is not found. Installing it..." % release)
         deployment_mode = "install"
 
-    command = prepare_for_helm_command + f'{deployment_mode} {release} {chart_path} --debug'
+    command = prepare_for_helm_command + f'{deployment_mode} {release} {chart_path} --create-namespace --debug'
     output = subprocess.check_output(command, shell=True)
     cluster.log.debug(output.decode('utf-8'))
 


### PR DESCRIPTION
### Description
If using custom procedure with helm installation in new namespace of k8s cluster, you always get "CRITICAL KME0001: Unexpected exception". It happens because "`helm install`" calls  without flag `--create-namespace`


### Solution
In **def apply_helm** kubemarine/plugins/__init__.py, line 788, add flag `--create-namespace`. It will not breaking procedure, because helm handle exception if namespace already exist.   


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


