### PR TITLE
[MANOPD-85857] Fix chattr error.

### DIFF
--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -148,7 +148,7 @@ def import_nodes(cluster):
     with RemoteExecutor(cluster) as exe:
         for node in cluster.nodes['all'].get_ordered_members_list(provide_node_configs=True):
             cmd = f"readlink /etc/resolv.conf ;" \
-                  f"if [ $? ]; then sudo tar xzvf /tmp/kubemarine-backup.tar.gz -C / --overwrite; else sudo chattr -f /etc/resolv.conf; sudo tar xzvf /tmp/kubemarine-backup.tar.gz -C / --overwrite && sudo chattr -f +i /etc/resolv.conf; fi "
+                  f"if [ $? ]; then sudo tar xzvf /tmp/kubemarine-backup.tar.gz -C / --overwrite; else sudo chattr -i /etc/resolv.conf; sudo tar xzvf /tmp/kubemarine-backup.tar.gz -C / --overwrite && sudo chattr  +i /etc/resolv.conf; fi "
             node['connection'].sudo(cmd)
 
     result = exe.get_last_results_str()

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -28,6 +28,7 @@ from kubemarine.core.group import NodeGroup
 from kubemarine.core.resources import DynamicResources
 from kubemarine.procedures import install, backup
 from kubemarine import system, kubernetes, etcd
+from kubemarine.core.executor import RemoteExecutor
 
 
 def missing_or_empty(file):
@@ -143,9 +144,15 @@ def import_nodes(cluster):
         cluster.log.debug('Backup \'%s\' uploaded' % node['name'])
 
     cluster.log.debug('Unpacking backup...')
-    result = cluster.nodes['all'].sudo(
-        'chattr -i /etc/resolv.conf; sudo tar xzvf /tmp/kubemarine-backup.tar.gz -C / --overwrite && sudo chattr +i /etc/resolv.conf')
-    cluster.log.debug(result)
+
+    with RemoteExecutor(cluster) as exe:
+        for node in cluster.nodes['all'].get_ordered_members_list(provide_node_configs=True):
+            cmd = f"readlink /etc/resolv.conf ;" \
+                  f"if [ $? ]; then sudo tar xzvf /tmp/kubemarine-backup.tar.gz -C / --overwrite; else sudo chattr -f /etc/resolv.conf; sudo tar xzvf /tmp/kubemarine-backup.tar.gz -C / --overwrite && sudo chattr -f +i /etc/resolv.conf; fi "
+            node['connection'].sudo(cmd)
+
+    result = exe.get_last_results_str()
+    cluster.log.debug('%s',result)
 
 
 def import_etcd(cluster: KubernetesCluster):

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -148,7 +148,7 @@ def import_nodes(cluster):
     with RemoteExecutor(cluster) as exe:
         for node in cluster.nodes['all'].get_ordered_members_list(provide_node_configs=True):
             cmd = f"readlink /etc/resolv.conf ;" \
-                  f"if [ $? ]; then sudo tar xzvf /tmp/kubemarine-backup.tar.gz -C / --overwrite; else sudo chattr -i /etc/resolv.conf; sudo tar xzvf /tmp/kubemarine-backup.tar.gz -C / --overwrite && sudo chattr  +i /etc/resolv.conf; fi "
+                  f"if [ $? -ne 0 ]; then sudo chattr -i /etc/resolv.conf; sudo tar xzvf /tmp/kubemarine-backup.tar.gz -C / --overwrite && sudo chattr +i /etc/resolv.conf; else sudo tar xzvf /tmp/kubemarine-backup.tar.gz -C / --overwrite; fi "
             node['connection'].sudo(cmd)
 
     result = exe.get_last_results_str()


### PR DESCRIPTION
### Description
If resolve.conf is not specified in the cluster.yaml file restore procedure was failing as chattr function is not supported to work with symbolic links.

### Solution
Check for symlink  has been added. If it is a regular file procedure works as was designed.
If it is a symlink it restores without using chattr function.


### How to apply
Implement code changes.


### Test Cases

**TestCase 1**

Steps:

Install cluster **with** resolv.conf section specified in cluster.yaml
Take backup of cluster
Restore cluster
Results:
**ER** - - Backup and restore finished successfully.
**AR** - - Backup and restore finished successfully.

**TestCase 2**

Steps:

Install cluster **without** resolv.conf section specified in cluster.yaml
Take backup of cluster
Restore cluster
Results:
**ER** - - Backup and restore finished successfully.
**AR** - - Backup and restore finished successfully.


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Unit tests were not updated.


