### PR TITLE
[MANOPD-90298] add "serializeImagePulls: false" by default to kubelet config

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -1483,7 +1483,7 @@ By default, the installer uses the following parameters:
 
 `cgroupDriver` field defines which cgroup driver the kubelet controls. [Configuring the kubelet cgroup driver](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/#configuring-the-kubelet-cgroup-driver).
 
-`serializeImagePulls` parameter defines whether the images will be pulled in parallel or one at a time.
+`serializeImagePulls` parameter defines whether the images will be pulled in parallel (false) or one at a time.
 
 **Warning**: If you want to change the values of variables `podPidsLimit` and `maxPods`, you have to update the value of the `pid_max` (this value should not less than result of next expression: `maxPods * podPidsLimit + 2048`), which can be done using task `prepare.system.sysctl`. To get more info about `pid_max` you can go to [sysctl](#sysctl) section.
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -1477,10 +1477,13 @@ By default, the installer uses the following parameters:
 |podPidsLimit|4096|
 |maxPods|110|
 |cgroupDriver|systemd|
+|serializeImagePulls|false|
 
 `podPidsLimit` the default value is chosen to prevent [Fork Bomb](https://en.wikipedia.org/wiki/Fork_bomb)
 
 `cgroupDriver` field defines which cgroup driver the kubelet controls. [Configuring the kubelet cgroup driver](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/#configuring-the-kubelet-cgroup-driver).
+
+`serializeImagePulls` parameter defines whether the images will be pulled in parallel or one at a time.
 
 **Warning**: If you want to change the values of variables `podPidsLimit` and `maxPods`, you have to update the value of the `pid_max` (this value should not less than result of next expression: `maxPods * podPidsLimit + 2048`), which can be done using task `prepare.system.sysctl`. To get more info about `pid_max` you can go to [sysctl](#sysctl) section.
 

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -36,6 +36,7 @@ services:
     protectKernelDefaults: true
     podPidsLimit: 4096
     cgroupDriver: systemd
+    serializeImagePulls: false
   kubeadm_flags:
     ignorePreflightErrors: Port-6443,CoreDNSUnsupportedPlugins
   kubeadm:


### PR DESCRIPTION
### Description
`serializeImagePulls: false`  allows parallel image pulling. 
There is only one recommendation when there is no need to use this, on nodes that run docker daemon with version < 1.9 or an aufs storage backend.
By default, this option is true.

Fixes # (issue)
MANOPD-90298

### Solution
Parameter has been added to default.yaml, to allows parallel image pulling


### How to apply
1 - You need to add a parameter serializeImagePulls: false to config.yaml
Path /var/lib/kubelet/config.yaml
Example:
```
apiVersion: kubelet.config.k8s.io/v1beta1
...
serializeImagePulls: false
...
```
2 - You need to restart kubelet with the command:
`systemctl restart kubelet`

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


