### PR TITLE
[MANOPD-90366] Improvements in remote executor and logging

### DIFF
--- a/kubemarine/__main__.py
+++ b/kubemarine/__main__.py
@@ -32,12 +32,6 @@ import yaml
 # See: https://bugs.python.org/issue29288
 u''.encode('idna')
 
-# This redirect required for fixing Fabric2 problem:
-# In Kubemarine stdout messages writes only to stdout - no stderr messaging at all,
-# but Fabric2 writes to stderr if hide=false used and remote console has stderr messages.
-sys.stderr = sys.stdout
-
-
 # Take pattern to resolve float used by ruamel instead of that is used by pyyaml.
 # https://sourceforge.net/p/ruamel-yaml/code/ci/0.17.21/tree/resolver.py#l43
 # Initially introduced for keepalived that generates random password string.

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -16,8 +16,10 @@ import io
 from typing import Union, Optional, List, Dict
 
 from kubemarine.core import utils
-from kubemarine.core.executor import RunnersResult, Token
-from kubemarine.core.group import NodeGroup, RunnersGroupResult, AbstractGroup, RunResult, DeferredGroup, GROUP_RUN_TYPE
+from kubemarine.core.executor import RunnersResult, Token, Callback
+from kubemarine.core.group import (
+    NodeGroup, RunnersGroupResult, AbstractGroup, RunResult, DeferredGroup, GROUP_RUN_TYPE
+)
 
 DEBIAN_HEADERS = 'DEBIAN_FRONTEND=noninteractive '
 
@@ -81,13 +83,14 @@ def get_install_cmd(include: Union[str, List[str]], exclude: Union[str, List[str
 
 
 def install(group: AbstractGroup[GROUP_RUN_TYPE], include: Union[str, List[str]] = None,
-            exclude: Union[str, List[str]] = None) -> GROUP_RUN_TYPE:
+            exclude: Union[str, List[str]] = None,
+            callback: Callback = None) -> GROUP_RUN_TYPE:
     if include is None:
         raise Exception('You must specify included packages to install')
 
     command = get_install_cmd(include, exclude)
 
-    return group.sudo(command)
+    return group.sudo(command, callback=callback)
 
 
 def remove(group: AbstractGroup[GROUP_RUN_TYPE], include: Union[str, List[str]] = None, exclude: Union[str, List[str]] = None,
@@ -131,9 +134,9 @@ def no_changes_found(action: str, result: RunnersResult) -> bool:
     return "0 upgraded, 0 newly installed, 0 to remove" in result.stdout
 
 
-def search(group: DeferredGroup, package: str) -> Token:
+def search(group: DeferredGroup, package: str, callback: Callback = None) -> Token:
     if package is None:
         raise Exception('You must specify package to search')
     command = DEBIAN_HEADERS + 'apt show %s' % package
 
-    return group.sudo(command, warn=True)
+    return group.sudo(command, warn=True, callback=callback)

--- a/kubemarine/apt.py
+++ b/kubemarine/apt.py
@@ -134,6 +134,6 @@ def no_changes_found(action: str, result: RunnersResult) -> bool:
 def search(group: DeferredGroup, package: str) -> Token:
     if package is None:
         raise Exception('You must specify package to search')
-    command = DEBIAN_HEADERS + 'apt show %s  || echo "Package is unavailable"' % package
+    command = DEBIAN_HEADERS + 'apt show %s' % package
 
-    return group.sudo(command)
+    return group.sudo(command, warn=True)

--- a/kubemarine/core/connections.py
+++ b/kubemarine/core/connections.py
@@ -16,21 +16,20 @@ from typing import Dict
 
 import fabric  # type: ignore[import]
 
-from kubemarine.core.environment import Environment
-
+from kubemarine.core import static
 
 Connections = Dict[str, fabric.connection.Connection]
 
 
 class ConnectionPool:
-    def __init__(self, env: Environment):
-        self._env = env
+    def __init__(self, inventory: dict):
+        self.inventory = inventory
         self._connections: Connections = {}
 
     def get_connection(self, ip: str) -> fabric.connection.Connection:
         conn = self._connections.get(ip)
         if conn is None:
-            for node in self._env.inventory['nodes']:
+            for node in self.inventory['nodes']:
                 if node.get('connect_to') == ip:
                     conn = self._create_connection(ip, node)
 
@@ -50,12 +49,12 @@ class ConnectionPool:
         cfg = fabric.Config(overrides={'run': {'encoding': "utf-8"}})
         return fabric.connection.Connection(
             host=ip,
-            user=conn_details.get('username', self._env.globals['connection']['defaults']['username']),
+            user=conn_details.get('username', static.GLOBALS['connection']['defaults']['username']),
             gateway=gateway,
-            port=conn_details.get('connection_port', self._env.globals['connection']['defaults']['port']),
+            port=conn_details.get('connection_port', static.GLOBALS['connection']['defaults']['port']),
             config=cfg,
             connect_timeout=conn_details.get('connection_timeout',
-                                             self._env.globals['connection']['defaults']['timeout']),
+                                             static.GLOBALS['connection']['defaults']['timeout']),
             connect_kwargs={
                 "key_filename": os.path.expanduser(conn_details['keyfile'])
             },
@@ -77,7 +76,7 @@ class ConnectionPool:
         # This is necessary to not share the same gateway connection instance in multiple threads
         gateway_conn = None
 
-        for gateway in self._env.inventory.get('gateway_nodes', []):
+        for gateway in self.inventory.get('gateway_nodes', []):
             if gateway.get('name') == name:
                 if gateway.get('address') is None:
                     raise Exception('There is no address specified in configfile for gateway \'%s\'' % name)

--- a/kubemarine/core/environment.py
+++ b/kubemarine/core/environment.py
@@ -15,7 +15,8 @@
 import os
 from abc import ABC, abstractmethod
 
-from kubemarine.core import static
+from kubemarine.core import log
+from kubemarine.core.connections import ConnectionPool
 
 
 class Environment(ABC):
@@ -25,8 +26,14 @@ class Environment(ABC):
         pass
 
     @property
-    def globals(self) -> dict:
-        return static.GLOBALS
+    @abstractmethod
+    def connection_pool(self) -> ConnectionPool:
+        pass
+
+    @property
+    @abstractmethod
+    def log(self) -> log.EnhancedLogger:
+        pass
 
     @staticmethod
     def is_deploying_from_windows() -> bool:

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -991,8 +991,8 @@ class DeferredGroup(AbstractGroup[Token]):
 
 
 class RemoteExecutor(RawExecutor):
-    def __init__(self, group: NodeGroup, ignore_failed: bool = False, timeout: int = None) -> None:
-        super().__init__(group.cluster.log, group.cluster.connection_pool, ignore_failed, timeout)
+    def __init__(self, group: NodeGroup, timeout: int = None) -> None:
+        super().__init__(group.cluster.log, group.cluster.connection_pool, timeout)
         self.group: DeferredGroup = group._make_defer(self)
         self.cluster = group.cluster
 

--- a/kubemarine/core/log.py
+++ b/kubemarine/core/log.py
@@ -294,6 +294,9 @@ class LoggerWriter:
         self.buf = ""
 
     def write(self, message: str) -> None:
+        # Both remote stderr and stdout are printed to local stdout
+        sys.stdout.write(message)
+
         lines = message.split('\n')
         for line in lines[:-1]:
             self.buf = self.buf + line
@@ -305,8 +308,13 @@ class LoggerWriter:
             self._log()
 
     def _log(self) -> None:
-        self.logger.log(logging.DEBUG, self.buf, extra={'real_caller': self.caller, 'prefix': self.prefix})
+        self.logger.log(logging.DEBUG, self.buf, extra={
+            'real_caller': self.caller, 'prefix': self.prefix, 'ignore_stdout': True
+        })
         self.buf = ""
+
+    def __repr__(self) -> str:
+        return f"LoggerWriter{{DEBUG,stdout}} at {hex(id(self))}"
 
 
 def parse_log_argument(argument: str) -> LogHandler:

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -35,26 +35,19 @@ from kubemarine.core.errors import pretty_print_error
 
 def do_fail(message='', reason: Exception = None, hint='', log=None):
 
-    if log:
-        log.critical('FAILURE!')
-        if message != "":
-            log.critical(message)
-    else:
-        sys.stderr.write("\033[91mFAILURE!")
-        if message != "":
-            sys.stderr.write(" - " + message + "\n")
+    if not log:
+        sys.stderr.write("\033[91m")
 
-    pretty_print_error(reason, log)
-
-    sys.stderr.write("\n")
+    pretty_print_error(message, reason, log)
 
     # Please do not rewrite this to logging approach:
     # hint should be visible only in stdout and without special formatting
     if hint != "":
-        sys.stderr.write(hint)
+        sys.stderr.write("\n")
+        sys.stderr.write(hint + "\n")
 
     if not log:
-        sys.stderr.write("\033[0m\n")
+        sys.stderr.write("\033[0m")
 
     sys.exit(1)
 

--- a/kubemarine/core/yaml_merger.py
+++ b/kubemarine/core/yaml_merger.py
@@ -42,7 +42,7 @@ def list_merger(config: Merger, path: list, base: list, nxt: list) -> list:
     return nxt
 
 
-default_merger = Merger(
+default_merger: Merger = Merger(
     [
         (list, [list_merger]),
         (dict, ["merge"])

--- a/kubemarine/cri/containerd.py
+++ b/kubemarine/cri/containerd.py
@@ -22,38 +22,42 @@ import json
 from distutils.util import strtobool
 from kubemarine import system, packages
 from kubemarine.core import utils
-from kubemarine.core.group import NodeGroup, RunnersGroupResult
+from kubemarine.core.group import NodeGroup, RunnersGroupResult, CollectorCallback
 
 
 def install(group: NodeGroup) -> RunnersGroupResult:
+    collector = CollectorCallback(group.cluster)
     with group.new_executor() as exe:
         for node in exe.group.get_ordered_members_list():
             os_specific_associations = exe.cluster.get_associations_for_node(node.get_host(), 'containerd')
 
             exe.cluster.log.debug("Installing latest containerd and podman on %s node" % node.get_node_name())
             # always install latest available containerd and podman
-            packages.install(node, include=os_specific_associations['package_name'])
+            packages.install(node, include=os_specific_associations['package_name'], callback=collector)
 
             # remove previous config.toml to avoid problems in case when previous config was broken
             node.sudo("rm -f %s && sudo systemctl restart %s"
                       % (os_specific_associations['config_location'],
-                         os_specific_associations['service_name']))
+                         os_specific_associations['service_name']),
+                      callback=collector)
 
-            system.enable_service(node, os_specific_associations['service_name'], now=True)
-    return exe.get_merged_runners_result()
+            system.enable_service(node, os_specific_associations['service_name'],
+                                  now=True, callback=collector)
+    return collector.result
 
 
 def configure(group: NodeGroup) -> RunnersGroupResult:
-    log = group.cluster.log
+    cluster = group.cluster
+    log = cluster.log
 
     log.debug("Uploading crictl configuration for containerd...")
     crictl_config = yaml.dump({"runtime-endpoint": "unix:///run/containerd/containerd.sock"})
-    utils.dump_file(group.cluster, crictl_config, 'crictl.yaml')
+    utils.dump_file(cluster, crictl_config, 'crictl.yaml')
     group.put(StringIO(crictl_config), '/etc/crictl.yaml', backup=True, sudo=True)
 
     config_string = ""
     # double loop is used to make sure that no "simple" `key: value` pairs are accidentally assigned to sections
-    containerd_config = group.cluster.inventory["services"]["cri"]['containerdConfig']
+    containerd_config = cluster.inventory["services"]["cri"]['containerdConfig']
     runc_options_path = 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options'
     if not isinstance(containerd_config[runc_options_path]['SystemdCgroup'], bool):
         containerd_config[runc_options_path]['SystemdCgroup'] = \
@@ -94,15 +98,15 @@ def configure(group: NodeGroup) -> RunnersGroupResult:
     if insecure_registries:
         log.debug("Uploading podman configuration...")
         podman_registries = f"[registries.insecure]\nregistries = {insecure_registries}\n"
-        utils.dump_file(group.cluster, podman_registries, 'podman_registries.conf')
+        utils.dump_file(cluster, podman_registries, 'podman_registries.conf')
         group.sudo("mkdir -p /etc/containers/")
         group.put(StringIO(podman_registries), "/etc/containers/registries.conf", backup=True, sudo=True)
     else:
         log.debug("Removing old podman configuration...")
         group.sudo("rm -f /etc/containers/registries.conf")
 
-    utils.dump_file(group.cluster, config_string, 'containerd-config.toml')
-    tokens = []
+    utils.dump_file(cluster, config_string, 'containerd-config.toml')
+    collector = CollectorCallback(cluster)
     with group.new_executor() as exe:
         for node in exe.group.get_ordered_members_list():
             os_specific_associations = exe.cluster.get_associations_for_node(node.get_host(), 'containerd')
@@ -110,11 +114,11 @@ def configure(group: NodeGroup) -> RunnersGroupResult:
             node.put(StringIO(config_string), os_specific_associations['config_location'],
                      backup=True, sudo=True, mkdir=True)
             log.debug("Restarting Containerd on %s node..." % node.get_node_name())
-            tokens.append(node.sudo(
+            node.sudo(
                 f"chmod 600 {os_specific_associations['config_location']} && "
                 f"sudo systemctl restart {os_specific_associations['service_name']} && "
-                f"systemctl status {os_specific_associations['service_name']}"))
-    return exe.get_merged_runners_result(tokens)
+                f"systemctl status {os_specific_associations['service_name']}", callback=collector)
+    return collector.result
 
 
 def prune(group: NodeGroup) -> RunnersGroupResult:

--- a/kubemarine/cri/docker.py
+++ b/kubemarine/cri/docker.py
@@ -28,7 +28,7 @@ def install(group: NodeGroup) -> RunnersGroupResult:
             os_specific_associations = cluster.get_associations_for_node(node.get_host(), 'docker')
             packages.install(node, include=os_specific_associations['package_name'], callback=collector)
 
-            system.enable_service(group, name=os_specific_associations['service_name'],
+            system.enable_service(node, name=os_specific_associations['service_name'],
                                   now=True, callback=collector)
 
             # remove previous daemon.json to avoid problems in case when previous config was broken

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -241,9 +241,7 @@ class FakeConnection(fabric.connection.Connection):  # type: ignore[misc]
         command_sep = r'[=\-_]{32}'
         sep_symbol = r'\&\&|;'
         final_sep = rf" ({sep_symbol}) " \
-                    rf"echo \"({command_sep})\" \1 " \
-                    rf"echo \$\? \1 " \
-                    rf"echo \"\2\" \1 " \
+                    rf"printf \"%s\\n\$\?\\n%s\\n\" \"({command_sep})\" \"\2\" \1 " \
                     rf"echo \"\2\" 1>\&2 \1 (sudo )?"
 
         self.separator_ptrn = re.compile(final_sep)
@@ -297,12 +295,9 @@ class FakeConnection(fabric.connection.Connection):  # type: ignore[misc]
                 stdout += found_result.stdout
                 stderr += found_result.stderr
                 prev_exited = found_result.exited
-                if prev_exited != 0:
-                    if sep_symbol == ';':
-                        prev_exited = 0  # todo bug of RemoteExecutor
-                    else:
-                        # stop fake execution
-                        break
+                if prev_exited != 0 and sep_symbol != ';':
+                    # stop fake execution
+                    break
 
             final_res = fabric.runners.Result(stdout=stdout, stderr=stderr, exited=prev_exited, connection=self)
             if prev_exited == 0 or kwargs.get('warn', False):

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -268,8 +268,8 @@ class FakeConnection(fabric.connection.Connection):  # type: ignore[misc]
     def _do(self, do_type, *args, **kwargs) -> fabric.runners.Result:
         if do_type in ['sudo', 'run']:
             # start fake execution of commands
-            command = list(args)[0]
-            commands, sep_symbol, command_sep = self._split_command(do_type, command)
+            original_command = list(args)[0]
+            commands, sep_symbol, command_sep = self._split_command(do_type, original_command)
 
             stdout = ""
             stderr = ""
@@ -299,7 +299,8 @@ class FakeConnection(fabric.connection.Connection):  # type: ignore[misc]
                     # stop fake execution
                     break
 
-            final_res = fabric.runners.Result(stdout=stdout, stderr=stderr, exited=prev_exited, connection=self)
+            final_res = fabric.runners.Result(stdout=stdout, stderr=stderr, exited=prev_exited,
+                                              connection=self, command=original_command)
             if prev_exited == 0 or kwargs.get('warn', False):
                 return final_res
 
@@ -550,8 +551,8 @@ def create_hosts_result(hosts: List[str], stdout='', stderr='', code=0) -> Dict[
 
 
 def create_result(stdout='', stderr='', code=0) -> RunnersResult:
-    # connection will be later replaced to fake
-    return RunnersResult(stdout=stdout, stderr=stderr, exited=code)
+    # command and 'hide' option will be later replaced with actual
+    return RunnersResult(["fake command"], [code], stdout=stdout, stderr=stderr)
 
 
 def empty_action(*args, **kwargs) -> None:

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -30,7 +30,8 @@ from kubemarine import system, plugins, admission, etcd, packages
 from kubemarine.core import utils, static, summary, log, errors
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.executor import Token
-from kubemarine.core.group import NodeGroup, NodeConfig, RunnersGroupResult, RunResult, AbstractGroup, DeferredGroup
+from kubemarine.core.group import NodeGroup, NodeConfig, RunnersGroupResult, RunResult, AbstractGroup, DeferredGroup, \
+    CollectorCallback
 from kubemarine.core.errors import KME
 
 ERROR_DOWNGRADE='Kubernetes old version \"%s\" is greater than new one \"%s\"'
@@ -1252,7 +1253,7 @@ def images_grouped_prepull(group: NodeGroup, group_size: int = None):
     groups_amount = math.ceil(nodes_amount / group_size)
 
     log.verbose("Nodes amount: %s\nGroup size: %s\nGroups amount: %s" % (nodes_amount, group_size, groups_amount))
-    tokens = []
+    collector = CollectorCallback(cluster)
     with group.new_executor() as exe:
         nodes = exe.group.get_ordered_members_list()
         for group_i in range(groups_amount):
@@ -1260,12 +1261,12 @@ def images_grouped_prepull(group: NodeGroup, group_size: int = None):
             # RemoteExecutor used for future cases, when some nodes will require another/additional actions for prepull
             for node_i in range(group_i*group_size, (group_i*group_size)+group_size):
                 if node_i < nodes_amount:
-                    tokens.append(images_prepull(nodes[node_i]))
+                    images_prepull(nodes[node_i], collector=collector)
 
-    return exe.get_merged_runners_result(tokens)
+    return collector.result
 
 
-def images_prepull(group: DeferredGroup) -> Token:
+def images_prepull(group: DeferredGroup, collector: CollectorCallback) -> Token:
     """
     Prepull kubeadm images on group.
     :param group: NodeGroup where prepull should be performed.
@@ -1283,7 +1284,8 @@ def images_prepull(group: DeferredGroup) -> Token:
 
     group.put(io.StringIO(config), '/etc/kubernetes/prepull-config.yaml', sudo=True)
 
-    return group.sudo("kubeadm config images pull --config=/etc/kubernetes/prepull-config.yaml")
+    return group.sudo("kubeadm config images pull --config=/etc/kubernetes/prepull-config.yaml",
+                      callback=collector)
 
 
 def schedule_running_nodes_report(cluster: KubernetesCluster):

--- a/kubemarine/packages.py
+++ b/kubemarine/packages.py
@@ -596,9 +596,6 @@ def get_detect_package_version_cmd(os_family: str, package_name: str) -> str:
     else:
         cmd = r"dpkg-query -f '${Package}=${Version}\n' -W %s" % package_name
 
-    # This is WA for RemoteExecutor, since any package failed others are not checked
-    # TODO: get rid of this WA and use warn=True in sudo
-    cmd += ' || true'
     return cmd
 
 
@@ -619,7 +616,7 @@ def _detect_installed_package_version(group: DeferredGroup, package: str) -> Tok
     package_name = get_package_name(os_family, package)
 
     cmd = get_detect_package_version_cmd(os_family, package_name)
-    return group.sudo(cmd)
+    return group.sudo(cmd, warn=True)
 
 
 def _parse_node_detected_package(result: RunnersResult, package: str) -> str:

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -1024,9 +1024,9 @@ def apply_source(cluster: KubernetesCluster, config: dict) -> None:
     if apply_required:
         cluster.log.debug("Applying yaml...")
         if use_sudo:
-            apply_common_group.sudo(apply_command, logging_stream=True)
+            apply_common_group.sudo(apply_command, hide=False)
         else:
-            apply_common_group.run(apply_command, logging_stream=True)
+            apply_common_group.run(apply_command, hide=False)
     else:
         cluster.log.debug('Apply is not required')
 

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -480,9 +480,10 @@ def check_access_to_package_repositories(cluster: KubernetesCluster):
                         continue
                     python_executable = cluster.context['nodes'][host]['python']['executable']
                     for repo_url in repository_urls:
-                        node.run('%s %s %s %s || echo "Package repository is unavailable"'
+                        node.run('%s %s %s %s'
                                  % (python_executable, random_temp_path, repo_url,
-                                    cluster.inventory['globals']['timeout_download']))
+                                    cluster.inventory['globals']['timeout_download']),
+                                 warn=True)
 
             results = exe.get_last_results()
             for host, url_results in results.items():
@@ -497,7 +498,7 @@ def check_access_to_package_repositories(cluster: KubernetesCluster):
                     problem_handler = broken
                 for i, result in enumerate(url_results.values()):
                     result = cast(RunnersResult, result)
-                    if "Package repository is unavailable" in result.stdout:
+                    if result.failed:
                         problem_handler.append(f"{host}, {repository_urls[i]}: {result.stderr}")
 
         # Remove file
@@ -541,7 +542,7 @@ def check_access_to_packages(cluster: KubernetesCluster):
             packages_to_check = hosts_to_packages[host]
             for i, result in enumerate(results.values()):
                 result = cast(RunnersResult, result)
-                if "Package is unavailable" in result.stdout:
+                if result.failed:
                     problem_handler.append(f"Package {packages_to_check[i]} is unavailable for node {host}")
 
         if broken:

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -30,10 +30,9 @@ from kubemarine.core import flow, utils
 from kubemarine import system, packages
 from kubemarine.core.action import Action
 from kubemarine.core.cluster import KubernetesCluster
-from kubemarine.core.executor import RunnersResult
 from kubemarine.core.resources import DynamicResources
 from kubemarine.testsuite import TestSuite, TestCase, TestFailure, TestWarn
-from kubemarine.core.group import NodeConfig, GroupException, RunnersGroupResult
+from kubemarine.core.group import NodeConfig, GroupException, GroupResultException, CollectorCallback
 
 
 def connection_ssh_connectivity(cluster: KubernetesCluster):
@@ -396,7 +395,7 @@ def check_package_repositories(cluster: KubernetesCluster):
     else:
         group = cluster.make_group(hosts)
         random_repos_conf_path = "/tmp/%s.repo" % uuid.uuid4().hex
-        tokens = []
+        collector = CollectorCallback(cluster)
         with group.new_executor() as exe:
             for node in exe.group.get_ordered_members_list():
                 # Create temp repos file
@@ -404,14 +403,12 @@ def check_package_repositories(cluster: KubernetesCluster):
 
                 # Compare with existed resolv.conf
                 predefined_repos_file = packages.get_repo_filename(node)
-                compare_token = node.sudo(
+                node.sudo(
                     '[ -f %s ] && cmp --silent %s %s' %
                     (predefined_repos_file, predefined_repos_file, random_repos_conf_path),
-                    warn=True)
-                tokens.append(compare_token)
+                    warn=True, callback=collector)
 
-        results = exe.get_merged_runners_result(tokens)
-        for host, result in results.items():
+        for host, result in collector.result.items():
             nodes_context[host]["package_repos_are_actual"] = not result.failed
 
         # Remove temp .repo file
@@ -470,6 +467,7 @@ def check_access_to_package_repositories(cluster: KubernetesCluster):
         all_group.put(io.StringIO(check_script), random_temp_path)
 
         if repository_urls:
+            collector = CollectorCallback(cluster)
             with all_group.new_executor() as exe:
                 for node in exe.group.get_ordered_members_list():
                     host = node.get_host()
@@ -483,10 +481,9 @@ def check_access_to_package_repositories(cluster: KubernetesCluster):
                         node.run('%s %s %s %s'
                                  % (python_executable, random_temp_path, repo_url,
                                     cluster.inventory['globals']['timeout_download']),
-                                 warn=True)
+                                 warn=True, callback=collector)
 
-            results = exe.get_last_results()
-            for host, url_results in results.items():
+            for host, url_results in collector.results.items():
                 # Check if resolv.conf is actual
                 resolv_conf_actual = cluster.context['nodes'][host]['resolv_conf_is_actual']
                 if not resolv_conf_actual:
@@ -496,8 +493,7 @@ def check_access_to_package_repositories(cluster: KubernetesCluster):
                     problem_handler = warnings
                 else:
                     problem_handler = broken
-                for i, result in enumerate(url_results.values()):
-                    result = cast(RunnersResult, result)
+                for i, result in enumerate(url_results):
                     if result.failed:
                         problem_handler.append(f"{host}, {repository_urls[i]}: {result.stderr}")
 
@@ -519,6 +515,7 @@ def check_access_to_packages(cluster: KubernetesCluster):
         warnings: List[str] = []
         group = cluster.nodes['all']
         hosts_to_packages = packages.get_all_managed_packages_for_group(group, cluster.inventory)
+        collector = CollectorCallback(cluster)
         with group.new_executor() as exe:
             for node in exe.group.get_ordered_members_list():
                 host = node.get_host()
@@ -527,10 +524,10 @@ def check_access_to_packages(cluster: KubernetesCluster):
                 cluster.log.debug(f"Packages to check for node {host}: {packages_to_check}")
 
                 for package in packages_to_check:
-                    packages.search_package(node, package)
+                    packages.search_package(node, package, callback=collector)
 
         # Check packages from install section
-        for host, results in exe.get_last_results().items():
+        for host, results in collector.results.items():
             package_repos_are_actual = cluster.context['nodes'][host]["package_repos_are_actual"]
             if not package_repos_are_actual:
                 warnings.append(f"Package repositories are not installed for {host}: "
@@ -540,8 +537,7 @@ def check_access_to_packages(cluster: KubernetesCluster):
             else:
                 problem_handler = broken
             packages_to_check = hosts_to_packages[host]
-            for i, result in enumerate(results.values()):
-                result = cast(RunnersResult, result)
+            for i, result in enumerate(results):
                 if result.failed:
                     problem_handler.append(f"Package {packages_to_check[i]} is unavailable for node {host}")
 
@@ -588,7 +584,7 @@ def suspend_firewalld(cluster: KubernetesCluster):
         try:
             nodes_to_rollback = system.stop_service(stop_firewalld_group, "firewalld").get_group()
         except GroupException as e:
-            nodes_to_rollback = e.result.get_exited_nodes_group()
+            nodes_to_rollback = e.get_exited_nodes_group()
             raise
 
         yield
@@ -639,14 +635,14 @@ def assign_random_ips(cluster: KubernetesCluster, nodes: Dict[str, NodeConfig], 
             host_to_ip[host] = random_host
             i = i + 1
 
+        collector = CollectorCallback(cluster)
         with cluster.make_group(nodes).new_executor() as exe:
             for node in exe.group.get_ordered_members_list():
                 host = node.get_host()
                 existing_alias = f"ip -o a | grep {host_to_inf[host]} | grep {host_to_ip[host]}"
-                node.sudo(existing_alias, warn=True)
+                node.sudo(existing_alias, warn=True, callback=collector)
 
-        results = exe.get_merged_runners_result()
-        for host, result in results.items():
+        for host, result in collector.result.items():
             if not result.stdout and not result.stderr and result.exited == 1:
                 # grep returned nothing, subnet is not used.
                 pass
@@ -663,7 +659,7 @@ def assign_random_ips(cluster: KubernetesCluster, nodes: Dict[str, NodeConfig], 
 
             nodes_to_rollback = cluster.make_group(nodes.keys())
         except GroupException as e:
-            nodes_to_rollback = e.result.get_exited_nodes_group()
+            nodes_to_rollback = e.get_exited_nodes_group()
             raise
 
         yield host_to_ip
@@ -821,8 +817,10 @@ def install_tcp_listener(cluster: KubernetesCluster, nodes: Dict[str, NodeConfig
     skipped_nodes = {}
     nodes_to_rollback = cluster.make_group([])
     try:
+        collector = CollectorCallback(cluster)
         try:
-            with cluster.make_group(nodes).new_executor() as exe:
+            nodes_to_rollback = group = cluster.make_group(nodes)
+            with group.new_executor() as exe:
                 # Run process that LISTEN TCP port
                 for node in exe.group.get_ordered_members_list():
                     host = node.get_host()
@@ -830,22 +828,19 @@ def install_tcp_listener(cluster: KubernetesCluster, nodes: Dict[str, NodeConfig
                     ip_version = ipaddress.ip_address(internal_ip).version
                     python_executable = cluster.context['nodes'][host]['python']['executable']
                     tcp_listener_cmd = cmd_for_ports(tcp_ports, get_start_tcp_listener_cmd(python_executable, tcp_listener, ip_version))
-                    node.sudo(tcp_listener_cmd, warn=True)
-
-            results = exe.get_merged_runners_result()
-            nodes_to_rollback = results.get_group()
+                    node.sudo(tcp_listener_cmd, warn=True, callback=collector)
         except GroupException as e:
-            nodes_to_rollback = e.result.get_exited_nodes_group()
+            nodes_to_rollback = e.get_exited_nodes_group()
             raise
 
         port_in_use = re.compile(r'^(\d+) in use$')
-        for host, result in results.items():
+        for host, result in collector.result.items():
             matcher = port_in_use.match(result.stderr.strip())
             if matcher is not None:
                 skipped_nodes[nodes[host]["name"]] = matcher.group(1)
                 del nodes[host]
             elif result.exited != 0:
-                raise GroupException(results)
+                raise GroupResultException(collector.result)
             else:
                 cluster.log.verbose(result)
 

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -152,7 +152,6 @@ def upgrade_containerd(cluster: KubernetesCluster):
                     os_specific_associations = cluster.get_associations_for_node(node.get_host(), 'containerd')
                     node.put(StringIO(config_string), os_specific_associations['config_location'],
                              backup=True, sudo=True, mkdir=True)
-                    print("Running !!!!!!!!!!!!!")
                     node.sudo(
                         f"sudo systemctl restart {os_specific_associations['service_name']} && "
                         f"systemctl status {os_specific_associations['service_name']} && " 

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -152,9 +152,10 @@ def upgrade_containerd(cluster: KubernetesCluster):
                     os_specific_associations = cluster.get_associations_for_node(node.get_host(), 'containerd')
                     node.put(StringIO(config_string), os_specific_associations['config_location'],
                              backup=True, sudo=True, mkdir=True)
+                    print("Running !!!!!!!!!!!!!")
                     node.sudo(
                         f"sudo systemctl restart {os_specific_associations['service_name']} && "
-                        f"systemctl status {os_specific_associations['service_name']} &&" 
+                        f"systemctl status {os_specific_associations['service_name']} && " 
                         f"sudo systemctl restart kubelet",
                         callback=collector)
             return collector.result

--- a/kubemarine/testsuite.py
+++ b/kubemarine/testsuite.py
@@ -52,10 +52,6 @@ class TestCase:
         elif type is TestWarn:
             self.warn(value)
         else:
-            if isinstance(value, GroupException):
-                self.cluster.log.debug(value.result)
-            else:
-                print_exc()
             self.exception(value)
         print(self.get_summary(show_hint=True))
         return True
@@ -93,7 +89,12 @@ class TestCase:
 
     def exception(self, results):
         self.status = TC_EXCEPTED
-        self.results = results
+        if isinstance(results, GroupException):
+            self.cluster.log.debug(results)
+            self.results = "Remote group exception"
+        else:
+            print_exc()
+            self.results = results
         return self
 
     def get_summary(self, show_description=False, show_hint=False, show_minimal=False, show_recommended=False):

--- a/kubemarine/yum.py
+++ b/kubemarine/yum.py
@@ -141,6 +141,6 @@ def no_changes_found(action: str, result: RunnersResult) -> bool:
 def search(group: DeferredGroup, package: str) -> Token:
     if package is None:
         raise Exception('You must specify package to search')
-    command = 'yum list %s || echo "Package is unavailable"' % package
+    command = 'yum list %s' % package
 
-    return group.sudo(command)
+    return group.sudo(command, warn=True)

--- a/kubemarine/yum.py
+++ b/kubemarine/yum.py
@@ -17,8 +17,10 @@ import io
 from typing import Union, Optional, List, Dict
 
 from kubemarine.core import utils
-from kubemarine.core.executor import RunnersResult, Token
-from kubemarine.core.group import NodeGroup, RunnersGroupResult, AbstractGroup, RunResult, DeferredGroup, GROUP_RUN_TYPE
+from kubemarine.core.executor import RunnersResult, Token, Callback
+from kubemarine.core.group import (
+    NodeGroup, RunnersGroupResult, AbstractGroup, RunResult, DeferredGroup, GROUP_RUN_TYPE
+)
 
 
 def ls_repofiles(group: NodeGroup) -> RunnersGroupResult:
@@ -83,13 +85,14 @@ def get_install_cmd(include: Union[str, List[str]], exclude: Union[str, List[str
 
 
 def install(group: AbstractGroup[GROUP_RUN_TYPE], include: Union[str, List[str]] = None,
-            exclude: Union[str, List[str]] = None) -> GROUP_RUN_TYPE:
+            exclude: Union[str, List[str]] = None,
+            callback: Callback = None) -> GROUP_RUN_TYPE:
     if include is None:
         raise Exception('You must specify included packages to install')
 
     command = get_install_cmd(include, exclude)
 
-    return group.sudo(command)
+    return group.sudo(command, callback=callback)
 
 
 def remove(group: AbstractGroup[GROUP_RUN_TYPE], include: Union[str, List[str]] = None,
@@ -138,9 +141,9 @@ def no_changes_found(action: str, result: RunnersResult) -> bool:
         raise Exception(f"Unknown action {action}")
 
 
-def search(group: DeferredGroup, package: str) -> Token:
+def search(group: DeferredGroup, package: str, callback: Callback = None) -> Token:
     if package is None:
         raise Exception('You must specify package to search')
     command = 'yum list %s' % package
 
-    return group.sudo(command, warn=True)
+    return group.sudo(command, warn=True, callback=callback)

--- a/test/unit/core/test_executor.py
+++ b/test/unit/core/test_executor.py
@@ -18,11 +18,9 @@ import unittest
 
 from concurrent.futures import TimeoutError
 
-from invoke import UnexpectedExit
-
 from kubemarine import demo
-from kubemarine.core.executor import RunnersResult
-from kubemarine.core.group import GroupException
+from kubemarine.core.executor import RunnersResult, UnexpectedExit
+from kubemarine.core.group import GroupException, RemoteGroupException, CollectorCallback
 
 
 class RemoteExecutorTest(unittest.TestCase):
@@ -32,11 +30,12 @@ class RemoteExecutorTest(unittest.TestCase):
     def test_get_merged_results_all_success(self):
         results = demo.create_nodegroup_result(self.cluster.nodes["all"], stdout="foo\n")
         self.cluster.fake_shell.add(results, "run", ["echo \"foo\""])
+        collector = CollectorCallback(self.cluster)
         with self.cluster.nodes["all"].new_executor() as exe:
-            exe.group.run("echo \"foo\"")
+            exe.group.run("echo \"foo\"", callback=collector)
             exe.flush()
 
-            for result in exe.get_merged_runners_result().values():
+            for result in collector.result.values():
                 self.assertEqual("foo\n", result.stdout)
 
     def test_flush_all_fail(self):
@@ -47,19 +46,20 @@ class RemoteExecutorTest(unittest.TestCase):
             exception = None
             try:
                 exe.flush()
-            except GroupException as exc:
+            except RemoteGroupException as exc:
                 exception = exc
-            for result in exception.result.values():
-                self.assertIsInstance(result, UnexpectedExit)
+            for tokenized_results in exception.results.values():
+                self.assertIsInstance(list(tokenized_results.values())[0], UnexpectedExit)
 
     def test_get_merged_results_all_exited_warn(self):
         results = demo.create_nodegroup_result(self.cluster.nodes["all"], code=1)
         self.cluster.fake_shell.add(results, "run", ["false"])
+        collector = CollectorCallback(self.cluster)
         with self.cluster.nodes["all"].new_executor() as exe:
-            exe.group.run("false", warn=True)
+            exe.group.run("false", warn=True, callback=collector)
             exe.flush()
 
-            for result in exe.get_merged_runners_result().values():
+            for result in collector.result.values():
                 self.assertIsInstance(result, RunnersResult)
                 self.assertEqual(1, result.exited)
 
@@ -71,23 +71,24 @@ class RemoteExecutorTest(unittest.TestCase):
             exception = None
             try:
                 exe.flush()
-            except GroupException as exc:
+            except RemoteGroupException as exc:
                 exception = exc
-            for result in exception.result.values():
-                self.assertIsInstance(result, TimeoutError)
+            for tokenized_results in exception.results.values():
+                self.assertIsInstance(list(tokenized_results.values())[0], TimeoutError)
 
     def test_get_merged_results_multiple_commands(self):
         results = demo.create_nodegroup_result(self.cluster.nodes["all"], stdout="foo\n")
         self.cluster.fake_shell.add(results, "run", ["echo \"foo\""])
         results = demo.create_nodegroup_result(self.cluster.nodes["all"], stdout="bar\n")
         self.cluster.fake_shell.add(results, "run", ["echo \"bar\""])
+        collector = CollectorCallback(self.cluster)
         with self.cluster.nodes["all"].new_executor() as exe:
-            exe.group.run("echo \"foo\"")
-            exe.group.run("echo \"bar\"")
+            exe.group.run("echo \"foo\"", callback=collector)
+            exe.group.run("echo \"bar\"", callback=collector)
 
             exe.flush()
 
-            for result in exe.get_merged_runners_result().values():
+            for result in collector.result.values():
                 self.assertEqual("foo\nbar\n", result.stdout)
 
     def test_get_merged_results_filter_last_command_result(self):
@@ -95,17 +96,17 @@ class RemoteExecutorTest(unittest.TestCase):
         self.cluster.fake_shell.add(results, "run", ["echo \"foo\""])
         results = demo.create_nodegroup_result(self.cluster.nodes["all"], stdout="bar\n")
         self.cluster.fake_shell.add(results, "run", ["echo \"bar\""])
-        tokens = []
+        collector = CollectorCallback(self.cluster)
         with self.cluster.nodes["all"].new_executor() as exe:
             exe.group.run("echo \"foo\"")
-            tokens.append(exe.group.run("echo \"bar\""))
+            exe.group.run("echo \"bar\"", callback=collector)
 
             exe.flush()
 
-            for result in exe.get_merged_runners_result(tokens).values():
+            for result in collector.result.values():
                 self.assertEqual("bar\n", result.stdout)
 
-    def test_flush_first_command_excepted_result_excepted(self):
+    def test_flush_first_command_failed_result_excepted(self):
         results = demo.create_nodegroup_result(self.cluster.nodes["all"], code=1)
         self.cluster.fake_shell.add(results, "run", ["false"])
         results = demo.create_nodegroup_result(self.cluster.nodes["all"], stdout="bar\n")
@@ -118,25 +119,57 @@ class RemoteExecutorTest(unittest.TestCase):
             exception = None
             try:
                 exe.flush()
-            except GroupException as exc:
+            except RemoteGroupException as exc:
                 exception = exc
 
             self.assertIsNotNone(exception, "Exception was not raised")
-            for result in exception.result.values():
-                self.assertIsInstance(result, UnexpectedExit)
+            for tokenized_results in exception.results.values():
+                self.assertIsInstance(list(tokenized_results.values())[0], UnexpectedExit)
 
             for host in self.cluster.nodes['all'].get_hosts():
                 self.assertIsNone(self.cluster.fake_fs.read(host, '/fake/path'))
+
+    def test_second_command_failed_first_collected(self):
+        results = demo.create_nodegroup_result(self.cluster.nodes["all"], stdout="foo\n")
+        self.cluster.fake_shell.add(results, "run", ["echo \"foo\""])
+        results = demo.create_nodegroup_result(self.cluster.nodes["all"], stdout="bar\n", code=1)
+        self.cluster.fake_shell.add(results, "run", ["echo \"bar\" && false"])
+        with self.cluster.nodes["all"].new_executor() as exe:
+            first_token = exe.group.run("echo \"foo\"")
+            exe.group.run("echo \"bar\" && false")
+
+            exception = None
+            try:
+                exe.flush()
+            except RemoteGroupException as exc:
+                exception = exc
+
+            self.assertIsNotNone(exception, "Exception was not raised")
+            self.assertEqual(exe.group.nodes, set(exception.results), "Exception results were not collected")
+            for tokenized_results in exception.results.values():
+                self.assertEqual(2, len(tokenized_results), "Two commands should be run")
+                result = list(tokenized_results.values())[1]
+                self.assertIsInstance(result, UnexpectedExit)
+                self.assertEqual("echo \"bar\" && false", result.result.command,
+                                 "Unexpected exit should contain original command string of only failed command")
+                self.assertEqual("bar\n", result.result.stdout,
+                                 "Unexpected exit should contain stdout of only failed command")
+
+            last_results = exe.get_last_results()
+            self.assertEqual(exe.group.nodes, set(last_results), "Last results were not collected")
+            for tokenized_results in last_results.values():
+                result = tokenized_results.get(first_token)
+                self.assertIsNotNone(result, "Result of the first command was not collected")
+                self.assertEqual("echo \"foo\"", result.command,
+                                 "Unexpected command string of the first successful command")
+                self.assertEqual("foo\n", result.stdout,
+                                 "Unexpected result of the first successful command")
 
     def test_not_throw_on_failed_all_warn(self):
         results = demo.create_nodegroup_result(self.cluster.nodes["all"], code=1)
         self.cluster.fake_shell.add(results, "run", ["false"])
         with self.cluster.nodes["all"].new_executor() as exe:
             exe.group.run("false", warn=True)
-
-        for result in exe.get_merged_runners_result().values():
-            self.assertIsInstance(result, RunnersResult)
-            self.assertEqual(1, result.exited)
 
     def test_throw_on_failed_all_excepted(self):
         results = demo.create_exception_result(self.cluster.nodes["all"], TimeoutError())
@@ -150,9 +183,10 @@ class RemoteExecutorTest(unittest.TestCase):
         results = demo.create_nodegroup_result(group, stdout="foo\n")
         self.cluster.fake_shell.add(results, "run", ["echo \"foo\""])
 
-        group.run("echo \"foo\"")
+        collector = CollectorCallback(self.cluster)
+        group.run("echo \"foo\"", callback=collector)
         group.flush()
-        for result in group.executor.get_merged_runners_result().values():
+        for result in collector.result.values():
             self.assertEqual("foo\n", result.stdout)
 
     def test_execute_members_without_context(self):
@@ -160,12 +194,104 @@ class RemoteExecutorTest(unittest.TestCase):
         results = demo.create_nodegroup_result(group, stdout="foo\n")
         self.cluster.fake_shell.add(results, "run", ["echo \"foo\""])
 
+        collector = CollectorCallback(self.cluster)
         for node in group.get_ordered_members_list():
-            node.run("echo \"foo\"")
+            node.run("echo \"foo\"", callback=collector)
 
         group.flush()
-        for result in group.executor.get_merged_runners_result().values():
+        self.assertEqual(group.nodes_amount(), len(collector.result))
+        for result in collector.result.values():
             self.assertEqual("foo\n", result.stdout)
+
+    def test_collect_results_with_callback(self):
+        group = self.cluster.nodes["all"].new_defer()
+        results = demo.create_hosts_result(group.get_hosts(), stdout="foo\n")
+        self.cluster.fake_shell.add(results, "run", ["echo \"foo\""])
+        for i, host in enumerate(group.get_hosts()):
+            result = demo.create_result(stdout=f"bar{i}\n")
+            self.cluster.fake_shell.add({host: result}, "run", [f"echo \"bar{i}\""])
+
+        callback = CollectorCallback(self.cluster)
+        group.run("echo \"foo\"", callback=callback)
+        for i, node in enumerate(group.get_ordered_members_list()):
+            node.run(f"echo \"bar{i}\"", callback=callback)
+
+        group.flush()
+        for i, host in enumerate(group.get_hosts()):
+            result = callback.results.get(host, [])
+            self.assertEqual(2, len(result), "Result was not collected")
+            self.assertEqual("foo\n", result[0].stdout, "Result was not collected")
+            self.assertEqual(f"bar{i}\n", result[1].stdout, "Result was not collected")
+
+    def test_command_failed_result_not_collected_with_callback(self):
+        group = self.cluster.nodes["all"].new_defer()
+        results = demo.create_hosts_result(group.get_hosts(), stdout="foo\n")
+        self.cluster.fake_shell.add(results, "run", ["echo \"foo\""])
+        results = demo.create_hosts_result(group.get_hosts(), code=1)
+        self.cluster.fake_shell.add(results, "run", ["false"])
+
+        callback = CollectorCallback(self.cluster)
+        group.run("echo \"foo\"", callback=callback)
+        group.run("false", callback=callback)
+        with self.assertRaises(GroupException):
+            group.flush()
+
+        for i, host in enumerate(group.get_hosts()):
+            result = callback.results.get(host, [])
+            self.assertEqual(1, len(result), "Result should be partially collected")
+            self.assertEqual("foo\n", result[0].stdout, "Result was not collected")
+
+    def test_represent_group_exception(self):
+        group = self.cluster.nodes["control-plane"].new_defer()
+        results = demo.create_hosts_result(group.get_hosts(), stdout="foo\n")
+        self.cluster.fake_shell.add(results, "run", ["echo \"foo\""])
+        results = demo.create_hosts_result(group.get_hosts(), stdout="bar\n")
+        self.cluster.fake_shell.add(results, "run", ["echo \"bar\""])
+        results = demo.create_hosts_result(group.get_hosts(), stderr="failed\n", code=1)
+        self.cluster.fake_shell.add(results, "run", ["echo \"failed\" 2>&1 && false"])
+
+        group.run("echo \"foo\"")
+        group.run("echo \"bar\"")
+        group.get_first_member().run("echo \"failed\" 2>&1 && false")
+        group.get_ordered_members_list()[2].put(io.StringIO('test'), '/fake/path')
+
+        exception = None
+        try:
+            group.flush()
+        except RemoteGroupException as exc:
+            exception = exc
+
+        self.assertIsNotNone(exception, "Exception was not raised")
+        expected_results_str = ("""\
+            10.101.1.2: code=0
+            \t=== stdout ===
+            \tfoo
+            \tbar
+            \t
+            \tEncountered a bad command exit code!
+            \t
+            \tCommand: 'echo "failed" 2>&1 && false'
+            \t
+            \tExit code: 1
+            \t
+            \t=== stderr ===
+            \tfailed
+            \t
+            10.101.1.3: code=0
+            \t=== stdout ===
+            \tfoo
+            \tbar
+            \t
+            10.101.1.4: code=0
+            \t=== stdout ===
+            \tfoo
+            \tbar
+            \t"""
+                                ).replace("""\
+            """, ""
+                                          )
+        self.assertEqual(expected_results_str, str(exception),
+                         "Unexpected textual representation of remote group exception")
 
     def test_write_large_stream(self):
         self.cluster.fake_fs.emulate_latency = True

--- a/test/unit/test_audit.py
+++ b/test/unit/test_audit.py
@@ -108,12 +108,12 @@ class NodeGroupResultsTest(unittest.TestCase):
 
         # simulate package detection command with partly installed audit
         host_to_result = {
-            '10.101.1.2': RunnersResult(stdout='%s=1:2.8.5-2ubuntu6' % package_name,
-                                        exited=0),
-            '10.101.1.3': RunnersResult(stderr='dpkg-query: no packages found matching %s' % package_name,
-                                        exited=1),
-            '10.101.1.4': RunnersResult(stdout='%s=1:2.8.5-2ubuntu6' % package_name,
-                                        exited=0)
+            '10.101.1.2': demo.create_result(stdout='%s=1:2.8.5-2ubuntu6' % package_name,
+                                             code=0),
+            '10.101.1.3': demo.create_result(stderr='dpkg-query: no packages found matching %s' % package_name,
+                                             code=1),
+            '10.101.1.4': demo.create_result(stdout='%s=1:2.8.5-2ubuntu6' % package_name,
+                                             code=0)
         }
         exp_results1 = demo.create_nodegroup_result_by_hosts(cluster, host_to_result)
         cluster.fake_shell.add(exp_results1, 'sudo', [self.get_detect_package_version_cmd('debian', package_name)])

--- a/test/unit/test_audit.py
+++ b/test/unit/test_audit.py
@@ -45,7 +45,7 @@ class NodeGroupResultsTest(unittest.TestCase):
         service_name = package_associations['service_name']
 
         # simulate package detection command
-        exp_results1 = demo.create_nodegroup_result(cluster.nodes['master'], code=0,
+        exp_results1 = demo.create_nodegroup_result(cluster.nodes['master'], code=1,
                                                     stderr='package %s is not installed' % package_name)
         cluster.fake_shell.add(exp_results1, 'sudo', [self.get_detect_package_version_cmd('rhel', package_name)])
 
@@ -69,7 +69,7 @@ class NodeGroupResultsTest(unittest.TestCase):
         service_name = package_associations['service_name']
 
         # simulate package detection command
-        exp_results1 = demo.create_nodegroup_result(cluster.nodes['master'], code=0,
+        exp_results1 = demo.create_nodegroup_result(cluster.nodes['master'], code=1,
                                                     stderr='dpkg-query: no packages found matching %s' % package_name)
         cluster.fake_shell.add(exp_results1, 'sudo', [self.get_detect_package_version_cmd('debian', package_name)])
 
@@ -111,7 +111,7 @@ class NodeGroupResultsTest(unittest.TestCase):
             '10.101.1.2': RunnersResult(stdout='%s=1:2.8.5-2ubuntu6' % package_name,
                                         exited=0),
             '10.101.1.3': RunnersResult(stderr='dpkg-query: no packages found matching %s' % package_name,
-                                        exited=0),
+                                        exited=1),
             '10.101.1.4': RunnersResult(stdout='%s=1:2.8.5-2ubuntu6' % package_name,
                                         exited=0)
         }

--- a/test/unit/test_workaround.py
+++ b/test/unit/test_workaround.py
@@ -19,16 +19,19 @@ import unittest
 from kubemarine import demo
 from paramiko.ssh_exception import SSHException
 
+from kubemarine.core import static
+from kubemarine.core.group import CollectorCallback
+
 ETCD_LEADER_CHANGED_MESSAGE = 'Error from server: rpc error: code = Unavailable desc = etcdserver: leader changed'
+
+# to increase test speed, let's override global workaround timeout value
+static.GLOBALS['workaround']['delay_period'] = 0
 
 
 class TestUnexpectedErrors(unittest.TestCase):
 
     def test_etcd_leader_changed_workaround(self):
         cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA))
-
-        # to increase test speed, let's override global workaround timeout value
-        cluster.globals['workaround']['timeout'] = 0
 
         command = ['kubectl describe nodes']
 
@@ -46,11 +49,45 @@ class TestUnexpectedErrors(unittest.TestCase):
                                                            "should have worked and got the right result, but it seems "
                                                            "something went wrong")
 
+    def test_etcd_leader_changed_workaround_executor(self):
+        cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA))
+        group = cluster.nodes["control-plane"].new_defer()
+
+        results = demo.create_hosts_result(group.get_hosts(), stdout='foo\n')
+        cluster.fake_shell.add(results, 'sudo', ['echo "foo"'])
+
+        command = 'kubectl describe nodes'
+        good_result = 'Kubernetes master is running at %s' % cluster.inventory['cluster_name']
+        results = demo.create_hosts_result(group.get_first_member().get_hosts(),
+                                           code=-1, stderr=ETCD_LEADER_CHANGED_MESSAGE)
+        cluster.fake_shell.add(results, 'sudo', [command], usage_limit=1)
+        results = demo.create_hosts_result(group.get_hosts(), stdout=good_result)
+        cluster.fake_shell.add(results, 'sudo', [command])
+
+        results = demo.create_hosts_result(group.get_hosts(), stdout='bar\n')
+        cluster.fake_shell.add(results, 'sudo', ['echo "bar"'])
+
+        collector = CollectorCallback(cluster)
+        group.sudo('echo "foo"')
+        group.sudo(command, callback=collector)
+        group.sudo('echo "bar"')
+        group.flush()
+
+        for result in collector.result.values():
+            self.assertEqual(good_result, result.stdout,
+                             msg="After an unsuccessful attempt, the workaround mechanism "
+                                 "should have worked and got the right result, but it seems "
+                                 "something went wrong")
+
+        executor_results = group.executor.get_last_results()
+        self.assertEqual(3, len(executor_results))
+        for tokenized_results in executor_results.values():
+            self.assertEqual(3, len(tokenized_results))
+            self.assertEqual(["foo\n", good_result, 'bar\n'],
+                             [result.stdout for result in tokenized_results.values()])
+
     def test_encountered_rsa_key(self):
         cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA))
-
-        # to increase test speed, let's override global workaround timeout value
-        cluster.globals['workaround']['timeout'] = 0
 
         command = ['kubectl describe nodes']
 
@@ -70,6 +107,42 @@ class TestUnexpectedErrors(unittest.TestCase):
             self.assertIn('is running', result.stdout, msg="After an unsuccessful attempt, the workaround mechanism "
                                                            "should have worked and got the right result, but it seems "
                                                            "something went wrong")
+
+    def test_encountered_rsa_key_executor(self):
+        cluster = demo.new_cluster(demo.generate_inventory(**demo.FULLHA))
+        group = cluster.nodes["control-plane"].new_defer()
+
+        command = 'kubectl describe nodes'
+        good_result = 'Kubernetes master is running at %s' % cluster.inventory['cluster_name']
+        results = demo.create_hosts_exception_result(group.get_first_member().get_hosts(),
+                                                     exception=SSHException('encountered RSA key, expected OPENSSH key'))
+        cluster.fake_shell.add(results, 'sudo', [command], usage_limit=1)
+        results = demo.create_hosts_result(group.get_hosts(), stdout=good_result)
+        cluster.fake_shell.add(results, 'sudo', [command])
+
+        results = demo.create_hosts_result(group.get_hosts(), stdout='bar\n')
+        cluster.fake_shell.add(results, 'sudo', ['echo "bar"'])
+
+        cluster.fake_shell.add(demo.create_nodegroup_result(group, stdout='example result'),
+                               'run', ["sudo -S -p '[sudo] password: ' last reboot"])
+
+        collector = CollectorCallback(cluster)
+        group.sudo(command, callback=collector)
+        group.sudo('echo "bar"')
+        group.flush()
+
+        for result in collector.result.values():
+            self.assertEqual(good_result, result.stdout,
+                             msg="After an unsuccessful attempt, the workaround mechanism "
+                                 "should have worked and got the right result, but it seems "
+                                 "something went wrong")
+
+        executor_results = group.executor.get_last_results()
+        self.assertEqual(3, len(executor_results))
+        for tokenized_results in executor_results.values():
+            self.assertEqual(2, len(tokenized_results))
+            self.assertEqual([good_result, 'bar\n'],
+                             [result.stdout for result in tokenized_results.values()])
 
 
 if __name__ == '__main__':

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -35,7 +35,7 @@ def stub_detect_packages(cluster: demo.FakeKubernetesCluster, packages_hosts_stu
             if host in hosts_stub:
                 results[host] = demo.create_result(stdout=hosts_stub[host])
             else:
-                results[host] = demo.create_result(stdout='not installed')
+                results[host] = demo.create_result(stdout='not installed', code=1)
 
         cmd = packages.get_detect_package_version_cmd(cluster.get_os_family(), package)
         cluster.fake_shell.add(results, 'sudo', [cmd])


### PR DESCRIPTION
### Description
* Miscellaneous improvements in RemoteExecutor / NodeGroup API and internal behavior. Rework logging of errors / commands output.

### Solution
* Implemented callbacks in RemoteExecutor. Added CollectorCallaback to collect runners results from few commands in deferred mode.
* Support merging of few commands in RemoteExecutor with `warn=True`.
* Support workarounds in RemoteExecutor. Workarounds logic is moved from NodeGroup to RemoteExecutor.
* Remove `logging_stream` property from NodeGroup. Instead, `hide=False` now streams to logging framework.
    * No longer need to redirect stderr to stdout at process level.
* Timeouts for NodeGroup and DeferredGroup now behave the same:
    * If timeout is explicitly specified in run/sudo, it is applied only to Connection.
    * RemoteExecutor has global timeout for concurrent.future for each batch of commands.
    * Commands with explicit timeout can no longer be merged.
* Added custom UnexpectedExit and CommandTimedOut exceptions instead of that from `invoke`.
* Do not print command separator when logging of UnexpectedExit exception from RemoteExecutor.
* Rework logging of output. Now runners results are printed in the same format in all cases.
* Major rework in printing of errors.
* Generic results from commands execution can no longer be merged. Only runners results can be merged now.

### Test Cases

**TestCase 1**

1. Configure inventory with wrong configurition. For example, use `containerd` and specify
   ```yaml
   services:
     packages:
       associations:
         containerd:
           service_name: "not-a-containerd"
   ```
2. Run `install` procedure.

Results:

| Before | After |
| ------ | ------ |
| Error message contains symbols like `_-=____-_-__-___=-_---=-=______-` | Error message is more pretty |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_group.py / test_executor.py / test_workaround.py - fixes to adapt to new API, and new tests for new features.