### PR TITLE
[MANOPD-88960] Remove PSP from defaults for Kubernetes higher than 1.24 version 

### DIFF
--- a/kubemarine/admission.py
+++ b/kubemarine/admission.py
@@ -802,6 +802,11 @@ def update_finalized_inventory(cluster: KubernetesCluster, inventory_to_finalize
     elif cluster.context.get('initial_procedure') == 'manage_psp':
         current_config = inventory_to_finalize.setdefault("rbac", {}).setdefault("psp", {})
         current_config["pod-security"] = cluster.procedure_inventory["psp"].get("pod-security", current_config.get("pod-security", "enabled"))
+    # remove PSP section from cluster_finalyzed.yaml  
+    minor_version = int(inventory_to_finalize["services"]["kubeadm"]["kubernetesVersion"].split('.')[1])
+    if minor_version >= 24:
+        del inventory_to_finalize["rbac"]["psp"]
+
 
     return inventory_to_finalize
 


### PR DESCRIPTION
### Description
* Removes an unnecessary block responsible for the PSP from the cluster_finalyzed.yaml of versions older than 1.24

Fixes # (issue)
MANOPD-88960

### Solution


### How to apply
Provide steps how to apply on top previous Kubemarine version to execute on existing clusters
* [Install task/s](documentation/Installation.md#installation-tasks-description)
* Manual step 
* [Upgrade procedure](documentation/Maintenance.md#upgrade-procedure)


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 

Steps:

1. 

Results:

| Before | After |
| ------ | ------ |
|  |  |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


