### PR TITLE
[MANOPD-89259] Use_ssh_password_instead_of_ssh_key_in_k8s_installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ To install a Kubernetes cluster using Kubemarine:
    ```yaml
    node_defaults:
      keyfile: "/home/username/.ssh/id_rsa"
+     password: password@123     #Use either keyfile or password.
      username: "centos"
 
    vrrp_ips:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To install a Kubernetes cluster using Kubemarine:
    ```yaml
    node_defaults:
      keyfile: "/home/username/.ssh/id_rsa"
-     password: password@123     #Use either keyfile or password.
+     password: '{{ env.PASS }}'     #Either keyfile or password can be used.
      username: "centos"
 
    vrrp_ips:

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -558,6 +558,7 @@ For example, you can have the following inventory content:
 ```yaml
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
+  password: "your_password"
   username: "centos"
 
 node:
@@ -566,6 +567,7 @@ node:
     roles: ["balancer"]
   - name: "control-plane"
     keyfile: "/home/username/another.key"
+    password: "your_password"
     internal_address: "192.168.0.2"
     roles: ["control-plane"]
 ```
@@ -577,21 +579,23 @@ node:
   - name: "lb"
     username: "centos"
     keyfile: "/home/username/.ssh/id_rsa"
+    password: "your_password"
     internal_address: "192.168.0.1"
     roles: ["balancer"]
   - name: "control-plane"
     username: "centos"
     keyfile: "/home/username/another.key"
+    password: "your_password"
     internal_address: "192.168.0.2"
     roles: ["control-plane"]
 ```
 
 Following are the parameters allowed to be specified in the `node_defaults` section:
-* keyfile, username, connection_port, connection_timeout and gateway.
+* keyfile, password, username, connection_port, connection_timeout and gateway.
 * labels, and taints - specify at global level only if the [Mini-HA Scheme](#mini-ha-scheme) is used.
-
 For more information about the listed parameters, refer to the following section.
 
+Note: To establish an ssh connection, you can use either a keyfile or a password.
 ### nodes
 
 In the `nodes` section, it is necessary to describe each node of the future cluster.
@@ -601,6 +605,7 @@ The following options are supported:
 |Name|Type|Mandatory|Default Value|Example|Description|
 |---|---|---|---|---|---|
 |keyfile|string|**yes**| |`/home/username/.ssh/id_rsa`|**Absolute** path to keyfile on local machine to access the cluster machines|
+|password|string|**yes**| |`password@123`|Password to access the cluster machines|
 |username|string|no|`root`|`centos`|Username for SSH-access the cluster machines|
 |name|string|no| |`k8s-control-plane-1`|Cluster member name. If omitted, Kubemarine calculates the name by the member role and position in the inventory. Note that this leads to undefined behavior when adding or removing nodes.|
 |address|ip address|no| |`10.101.0.1`|External node's IP-address|
@@ -616,6 +621,7 @@ An example with parameters values is as follows:
 ```yaml
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
+  password: "password@123"
   username: "centos"
 
 nodes:
@@ -930,6 +936,7 @@ The following parameters are supported:
 |**address**|ip address|**yes**|Gateway node's IP or hostname address for connection|
 |**username**|string|**yes**|Username for SSH-access the gateway node|
 |**keyfile**|string|**yes**|**Absolute** path to keyfile on deploy node to access the gateway node|
+|**password**|string|**yes**|Password to access the gateway node|
 
 An example is as follows:
 
@@ -938,10 +945,13 @@ gateway_nodes:
   - name: k8s-gateway-1
     address: 10.102.0.1
     username: root
+    password: "password@123"
     keyfile: "/home/username/.ssh/id_rsa"
+    
   - name: k8s-gateway-2
     address: 10.102.0.2
     username: root
+    password: "password@123"
     keyfile: "/home/username/.ssh/id_rsa"
 ```
 
@@ -965,6 +975,7 @@ nodes:
 
 **Note**: If the gateway is not specified on the node, then the connection is direct.
 
+**Note**: To establish an ssh connection, you can use either a keyfile or a password.
 ### vrrp_ips
 
 *Installation task*: `deploy.loadbalancer.keepalived`
@@ -1477,10 +1488,13 @@ By default, the installer uses the following parameters:
 |podPidsLimit|4096|
 |maxPods|110|
 |cgroupDriver|systemd|
+|serializeImagePulls|false|
 
 `podPidsLimit` the default value is chosen to prevent [Fork Bomb](https://en.wikipedia.org/wiki/Fork_bomb)
 
 `cgroupDriver` field defines which cgroup driver the kubelet controls. [Configuring the kubelet cgroup driver](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/#configuring-the-kubelet-cgroup-driver).
+
+`serializeImagePulls` parameter defines whether the images will be pulled in parallel (false) or one at a time.
 
 **Warning**: If you want to change the values of variables `podPidsLimit` and `maxPods`, you have to update the value of the `pid_max` (this value should not less than result of next expression: `maxPods * podPidsLimit + 2048`), which can be done using task `prepare.system.sysctl`. To get more info about `pid_max` you can go to [sysctl](#sysctl) section.
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -558,7 +558,7 @@ For example, you can have the following inventory content:
 ```yaml
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
-  password: "your_password"
+  password: '{{ env.PASS }}'
   username: "centos"
 
 node:
@@ -567,7 +567,7 @@ node:
     roles: ["balancer"]
   - name: "control-plane"
     keyfile: "/home/username/another.key"
-    password: "your_password"
+    password: '{{ env.PASS }}'
     internal_address: "192.168.0.2"
     roles: ["control-plane"]
 ```
@@ -579,13 +579,13 @@ node:
   - name: "lb"
     username: "centos"
     keyfile: "/home/username/.ssh/id_rsa"
-    password: "your_password"
+    password: '{{ env.PASS }}'
     internal_address: "192.168.0.1"
     roles: ["balancer"]
   - name: "control-plane"
     username: "centos"
     keyfile: "/home/username/another.key"
-    password: "your_password"
+    password: '{{ env.PASS }}'
     internal_address: "192.168.0.2"
     roles: ["control-plane"]
 ```
@@ -595,7 +595,9 @@ Following are the parameters allowed to be specified in the `node_defaults` sect
 * labels, and taints - specify at global level only if the [Mini-HA Scheme](#mini-ha-scheme) is used.
 For more information about the listed parameters, refer to the following section.
 
-Note: To establish an ssh connection, you can use either a keyfile or a password.
+Note: To establish an ssh connection, you can use either a keyfile or a password. In case if you are specifying both, keyfile will be considered on priority.
+
+Note: Set an environment variable with the desired password. For example, you can use `export PASS="your_password"`. In the cluster.yaml file, specify the password field using the environment variable syntax. For instance: `password: '{{ env.PASS }}'`. This syntax instructs the code to fetch the value from the PASS environment variable and substitute it into the password field when reading the configuration file.
 ### nodes
 
 In the `nodes` section, it is necessary to describe each node of the future cluster.
@@ -604,8 +606,8 @@ The following options are supported:
 
 |Name|Type|Mandatory|Default Value|Example|Description|
 |---|---|---|---|---|---|
-|keyfile|string|**yes**| |`/home/username/.ssh/id_rsa`|**Absolute** path to keyfile on local machine to access the cluster machines|
-|password|string|**yes**| |`password@123`|Password to access the cluster machines|
+|keyfile|string|no| |`/home/username/.ssh/id_rsa`|**Absolute** path to keyfile on local machine to access the cluster machines, Either a keyfile or a password should be provided|
+|password|string|no| |`password@123`|Password to access the cluster machines, Either a keyfile or a password should be provided|
 |username|string|no|`root`|`centos`|Username for SSH-access the cluster machines|
 |name|string|no| |`k8s-control-plane-1`|Cluster member name. If omitted, Kubemarine calculates the name by the member role and position in the inventory. Note that this leads to undefined behavior when adding or removing nodes.|
 |address|ip address|no| |`10.101.0.1`|External node's IP-address|
@@ -621,7 +623,7 @@ An example with parameters values is as follows:
 ```yaml
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
-  password: "password@123"
+  password: '{{ env.PASS }}'     #Either keyfile or password can be used.
   username: "centos"
 
 nodes:
@@ -935,8 +937,8 @@ The following parameters are supported:
 |**name**|string|**yes**|Gateway node name|
 |**address**|ip address|**yes**|Gateway node's IP or hostname address for connection|
 |**username**|string|**yes**|Username for SSH-access the gateway node|
-|**keyfile**|string|**yes**|**Absolute** path to keyfile on deploy node to access the gateway node|
-|**password**|string|**yes**|Password to access the gateway node|
+|**keyfile**|string|no|**Absolute** path to keyfile on local machine to access the cluster machines, Either a keyfile or a password should be provided|
+|**password**|string|no|Password to access the cluster machines, Either a keyfile or a password should be provided|
 
 An example is as follows:
 
@@ -945,13 +947,13 @@ gateway_nodes:
   - name: k8s-gateway-1
     address: 10.102.0.1
     username: root
-    password: "password@123"
+    password: '{{ env.PASS }}'
     keyfile: "/home/username/.ssh/id_rsa"
     
   - name: k8s-gateway-2
     address: 10.102.0.2
     username: root
-    password: "password@123"
+    password: '{{ env.PASS }}'
     keyfile: "/home/username/.ssh/id_rsa"
 ```
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -558,7 +558,6 @@ For example, you can have the following inventory content:
 ```yaml
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
-  password: '{{ env.PASS }}'
   username: "centos"
 
 node:
@@ -567,7 +566,6 @@ node:
     roles: ["balancer"]
   - name: "control-plane"
     keyfile: "/home/username/another.key"
-    password: '{{ env.PASS }}'
     internal_address: "192.168.0.2"
     roles: ["control-plane"]
 ```
@@ -579,13 +577,11 @@ node:
   - name: "lb"
     username: "centos"
     keyfile: "/home/username/.ssh/id_rsa"
-    password: '{{ env.PASS }}'
     internal_address: "192.168.0.1"
     roles: ["balancer"]
   - name: "control-plane"
     username: "centos"
     keyfile: "/home/username/another.key"
-    password: '{{ env.PASS }}'
     internal_address: "192.168.0.2"
     roles: ["control-plane"]
 ```
@@ -597,7 +593,7 @@ For more information about the listed parameters, refer to the following section
 
 Note: To establish an ssh connection, you can use either a keyfile or a password. In case if you are specifying both, keyfile will be considered on priority.
 
-Note: Set an environment variable with the desired password. For example, you can use `export PASS="your_password"`. In the cluster.yaml file, specify the password field using the environment variable syntax. For instance: `password: '{{ env.PASS }}'`. This syntax instructs the code to fetch the value from the PASS environment variable and substitute it into the password field when reading the configuration file.
+Note: Set an environment variable with the desired password. For example, you can use `export PASS="your_password"`. In the cluster.yaml file, specify the password field using the environment variable syntax. For instance: `password: '{{ env.PASS }}'`. This syntax instructs the code to fetch the value from the PASS environment variable and substitute it into the password field when reading the configuration file. See more details about [environment variables](#environment-variables) 
 ### nodes
 
 In the `nodes` section, it is necessary to describe each node of the future cluster.

--- a/examples/cluster.yaml/allinone-cluster-ol7.yaml
+++ b/examples/cluster.yaml/allinone-cluster-ol7.yaml
@@ -1,6 +1,6 @@
 node_defaults:
   keyfile: /home/user/id_rsa
-  password: password@123     #Use either keyfile or password.
+  password: '{{ env.PASS }}'     #Either keyfile or password can be used.
   username: cloud-user
 
 vrrp_ips:

--- a/examples/cluster.yaml/allinone-cluster-ol7.yaml
+++ b/examples/cluster.yaml/allinone-cluster-ol7.yaml
@@ -1,5 +1,6 @@
 node_defaults:
   keyfile: /home/user/id_rsa
+  password: password@123     #Use either keyfile or password.
   username: cloud-user
 
 vrrp_ips:

--- a/examples/cluster.yaml/allinone-cluster.yaml
+++ b/examples/cluster.yaml/allinone-cluster.yaml
@@ -1,6 +1,6 @@
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
-  password: password@123     #Use either keyfile or password.
+  password: '{{ env.PASS }}'     #Either keyfile or password can be used.
   username: "centos"
 
 nodes:

--- a/examples/cluster.yaml/allinone-cluster.yaml
+++ b/examples/cluster.yaml/allinone-cluster.yaml
@@ -1,5 +1,6 @@
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
+  password: password@123     #Use either keyfile or password.
   username: "centos"
 
 nodes:

--- a/examples/cluster.yaml/full-cluster.yaml
+++ b/examples/cluster.yaml/full-cluster.yaml
@@ -1,6 +1,6 @@
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
-  password: password@123     #Use either keyfile or password.
+  password: '{{ env.PASS }}'     #Either keyfile or password can be used.
   username: "centos"
 
 vrrp_ips:

--- a/examples/cluster.yaml/full-cluster.yaml
+++ b/examples/cluster.yaml/full-cluster.yaml
@@ -1,5 +1,6 @@
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
+  password: password@123     #Use either keyfile or password.
   username: "centos"
 
 vrrp_ips:

--- a/examples/cluster.yaml/miniha-cluster.yaml
+++ b/examples/cluster.yaml/miniha-cluster.yaml
@@ -1,6 +1,6 @@
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
-  password: password@123     #Use either keyfile or password.
+  password: '{{ env.PASS }}'     #Either keyfile or password can be used.
   username: "centos"
 
 vrrp_ips:

--- a/examples/cluster.yaml/miniha-cluster.yaml
+++ b/examples/cluster.yaml/miniha-cluster.yaml
@@ -1,5 +1,6 @@
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
+  password: password@123     #Use either keyfile or password.
   username: "centos"
 
 vrrp_ips:

--- a/examples/cluster.yaml/minimal-cluster.yaml
+++ b/examples/cluster.yaml/minimal-cluster.yaml
@@ -1,6 +1,6 @@
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
-  password: password@123     #Use either keyfile or password.
+  password: '{{ env.PASS }}'     #Either keyfile or password can be used.
   username: "centos"
 
 nodes:

--- a/examples/cluster.yaml/minimal-cluster.yaml
+++ b/examples/cluster.yaml/minimal-cluster.yaml
@@ -1,5 +1,6 @@
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
+  password: password@123     #Use either keyfile or password.
   username: "centos"
 
 nodes:

--- a/examples/cluster.yaml/typical-cluster.yaml
+++ b/examples/cluster.yaml/typical-cluster.yaml
@@ -1,6 +1,6 @@
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
-  password: password@123     #Use either keyfile or password.
+  password: '{{ env.PASS }}'     #Either keyfile or password can be used.
   username: "centos"
 
 vrrp_ips:

--- a/examples/cluster.yaml/typical-cluster.yaml
+++ b/examples/cluster.yaml/typical-cluster.yaml
@@ -1,5 +1,6 @@
 node_defaults:
   keyfile: "/home/username/.ssh/id_rsa"
+  password: password@123     #Use either keyfile or password.
   username: "centos"
 
 vrrp_ips:

--- a/kubemarine/core/connections.py
+++ b/kubemarine/core/connections.py
@@ -50,7 +50,6 @@ class ConnectionPool:
             creds['key_filename'] = os.path.expanduser(conn_details['keyfile'])
         elif conn_details.get('password'):
             creds['password'] = conn_details.get('password')
-        #else:     
         cfg = fabric.Config(overrides={'run': {'encoding': "utf-8"}})
         return fabric.connection.Connection(
             host=ip,
@@ -66,7 +65,7 @@ class ConnectionPool:
 
     def _create_connection(self, ip: str, node: dict) -> fabric.connection.Connection:
         if node.get('keyfile') is None and node.get('password') is None:
-            raise Exception('There is no keyfile specified in configfile for node \'%s\'' % node['name'])
+            raise Exception('There is neither keyfile not password specified in configfile for node \'%s\'' % node['name'])
 
         gateway = None
         if 'gateway' in node:

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -97,11 +97,12 @@ def make_ansible_inventory(location, c):
         config[role] = []
         config['cluster:children'].append(role)
         for node in cluster.nodes[role].get_final_nodes().get_ordered_members_configs_list():
-            record = "%s ansible_host=%s ansible_ssh_user=%s ansible_ssh_private_key_file=%s ip=%s" % \
+            record = "%s ansible_host=%s ansible_ssh_user=%s ansible_ssh_pass=%s ansible_ssh_private_key_file=%s ip=%s" % \
                      (node['name'],
                       node['connect_to'],
                       node.get('username', cluster.globals['connection']['defaults']['username']),
-                      node['keyfile'],
+                      node.get('password'),
+                      node.get('keyfile'),
                       node['internal_address'])
             if node.get('address') is not None:
                 record += ' external_ip=%s' % node['address']

--- a/kubemarine/resources/schemas/definitions/gateway_node.json
+++ b/kubemarine/resources/schemas/definitions/gateway_node.json
@@ -12,7 +12,15 @@
       "description": "Gateway node's IP or hostname address for connection"
     }
   },
-  "required": ["name", "address", "username", "keyfile"],
+  "required": ["name", "address", "username"],
+  "oneOf": [
+    {
+      "required": ["keyfile"]
+    },
+    {
+      "required": ["password"]
+    }
+  ],
   "propertyNames": {
     "anyOf": [
       {"$ref": "node_defaults.json#/definitions/SSHAccessCommonPropertyNames"},

--- a/kubemarine/resources/schemas/definitions/node_defaults.json
+++ b/kubemarine/resources/schemas/definitions/node_defaults.json
@@ -13,6 +13,10 @@
           "type": "string",
           "description": "Absolute path to keyfile on local machine to access the remote machine(s)"
         },
+        "password": {
+          "type": "string",
+          "description": "Password for SSH-access the remote machine(s)"
+        },
         "username": {
           "type": "string",
           "default": "root",
@@ -34,7 +38,7 @@
       }
     },
     "SSHAccessCommonPropertyNames": {
-      "enum": ["keyfile", "username", "connection_port", "connection_timeout"]
+      "enum": ["keyfile", "password", "username", "connection_port", "connection_timeout"]
     },
     "CommonNodeProperties": {
       "allOf": [{"$ref": "#/definitions/SSHAccessCommonProperties"}],


### PR DESCRIPTION
### Description
 This change aims to enhance the kubemarine system by introducing support for both SSH key and SSH password authentication methods during installation, maintenance, and checks. Currently, only SSH key authentication is supported, and this change will provide users with the flexibility to choose their preferred authentication method.
* 

Fixes # (issue)
The current kubemarine system only supports SSH key authentication, which restricts users who prefer to use passwords for authentication or have systems that do not support SSH key-based authentication.

### Solution
Updated Authentication Logic: Modify the code to handle both SSH key and SSH password authentication methods based on user-provided connection details.
* 


### Test Cases

**TestCase 1**

1. Provide password instead of keyfile in cluster.yaml and proceed with kubemarine tasks.

```
node_defaults:
  username: "centos"
  password: '{{ env.PASS }}' 
```
  Run "kubemarine check_iaas"
Results:

**Before** - 
`kubemarine check_iaas
Loading inventory file 'cluster.yaml'
2023-07-06 18:22:09,484 INFO Running action 'check iaas'
Excluded tasks:
        No excluded tasks
2023-07-06 18:22:10,159 ERROR Inventory file is failed to be validated against the schema.
2023-07-06 18:22:10,201 CRITICAL FAILURE!
2023-07-06 18:22:10,201 CRITICAL Property name 'password' is not one of ['keyfile', 'username', 'connection_port', 'connection_timeout', 'labels', 'taints', 'gateway']
2023-07-06 18:22:10,201 CRITICAL On inventory['node_defaults']`


**After** 
Check_iaas runs successfully

**TestCase 2**

Provide both keyfile and password in cluster.yaml and run Kubemarine tasks.

```
node_defaults:
  username: "centos"
  keyfile: "~/.ssh/id_rsa"
  password: '{{ env.PASS }}' 
```
  Run "kubemarine install"
  
Results:
**Before** - 
  ` kubemarine install
Loading inventory file 'cluster.yaml'
2023-07-06 18:42:06,303 INFO Running action 'install'
Excluded tasks:
        No excluded tasks
2023-07-06 18:42:06,620 ERROR Inventory file is failed to be validated against the schema.
2023-07-06 18:42:06,621 CRITICAL FAILURE!
2023-07-06 18:42:06,622 CRITICAL Property name 'password' is not one of ['keyfile', 'username', 'connection_port', 'connection_timeout', 'labels', 'taints', 'gateway']
2023-07-06 18:42:06,622 CRITICAL On inventory['node_defaults']`
  
**After** 
k8s installation runs successfully


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts




