### PR TITLE
[MANOPD-90205] fix for vulnerability scanning failures

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -428,7 +428,7 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             " --config=/etc/kubernetes/join-config.yaml"
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
             " --v=5 && "
-            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml"
+            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml && "
             " sudo systemctl restart kubelet ",
             hide=False)
 
@@ -445,7 +445,7 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             " --config=/etc/kubernetes/join-config.yaml "
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
             " --v=5 && "
-            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml"
+            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml && "
             " sudo systemctl restart kubelet ",
             hide=False)
         defer.sudo("systemctl restart kubelet")
@@ -574,7 +574,7 @@ def init_first_control_plane(group: NodeGroup) -> None:
         " --config=/etc/kubernetes/init-config.yaml"
         " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
         " --v=5 && "
-        " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml"
+        " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml && "
         " sudo systemctl restart kubelet ",
         hide=False)
 

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -442,7 +442,8 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             "kubeadm join "
             " --config=/etc/kubernetes/join-config.yaml "
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-            " --v=5",
+            " --v=5 && "
+            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
             hide=False)
         defer.sudo("systemctl restart kubelet")
         copy_admin_config(log, defer)
@@ -569,7 +570,8 @@ def init_first_control_plane(group: NodeGroup) -> None:
         " --upload-certs"
         " --config=/etc/kubernetes/init-config.yaml"
         " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-        " --v=5",
+        " --v=5 && "
+        " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
         hide=False)
 
     copy_admin_config(log, first_control_plane)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -427,9 +427,7 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             "kubeadm join "
             " --config=/etc/kubernetes/join-config.yaml"
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-            " --v=5 && "
-            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml && "
-            " sudo systemctl restart kubelet ",
+            " --v=5",
             hide=False)
 
         log.debug("Patching apiServer bind-address for control-plane %s" % node_name)
@@ -444,9 +442,7 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             "kubeadm join "
             " --config=/etc/kubernetes/join-config.yaml "
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-            " --v=5 && "
-            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml && "
-            " sudo systemctl restart kubelet ",
+            " --v=5",
             hide=False)
         defer.sudo("systemctl restart kubelet")
         copy_admin_config(log, defer)
@@ -573,9 +569,7 @@ def init_first_control_plane(group: NodeGroup) -> None:
         " --upload-certs"
         " --config=/etc/kubernetes/init-config.yaml"
         " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-        " --v=5 && "
-        " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml && "
-        " sudo systemctl restart kubelet ",
+        " --v=5 ",
         hide=False)
 
     copy_admin_config(log, first_control_plane)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -569,7 +569,7 @@ def init_first_control_plane(group: NodeGroup) -> None:
         " --upload-certs"
         " --config=/etc/kubernetes/init-config.yaml"
         " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-        " --v=5 ",
+        " --v=5",
         hide=False)
 
     copy_admin_config(log, first_control_plane)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -428,7 +428,8 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             " --config=/etc/kubernetes/join-config.yaml"
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
             " --v=5 && "
-            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
+            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml"
+            " sudo systemctl restart kubelet ",
             hide=False)
 
         log.debug("Patching apiServer bind-address for control-plane %s" % node_name)
@@ -444,7 +445,8 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             " --config=/etc/kubernetes/join-config.yaml "
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
             " --v=5 && "
-            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
+            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml"
+            " sudo systemctl restart kubelet ",
             hide=False)
         defer.sudo("systemctl restart kubelet")
         copy_admin_config(log, defer)
@@ -572,7 +574,8 @@ def init_first_control_plane(group: NodeGroup) -> None:
         " --config=/etc/kubernetes/init-config.yaml"
         " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
         " --v=5 && "
-        " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
+        " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml"
+        " sudo systemctl restart kubelet ",
         hide=False)
 
     copy_admin_config(log, first_control_plane)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -427,7 +427,8 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             "kubeadm join "
             " --config=/etc/kubernetes/join-config.yaml"
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-            " --v=5",
+            " --v=5 && "
+            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
             hide=False)
 
         log.debug("Patching apiServer bind-address for control-plane %s" % node_name)
@@ -442,8 +443,8 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             "kubeadm join "
             " --config=/etc/kubernetes/join-config.yaml "
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-            " --v=5 ", # && "
-            #" sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
+            " --v=5 && "
+            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
             hide=False)
         defer.sudo("systemctl restart kubelet")
         copy_admin_config(log, defer)
@@ -570,8 +571,8 @@ def init_first_control_plane(group: NodeGroup) -> None:
         " --upload-certs"
         " --config=/etc/kubernetes/init-config.yaml"
         " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-        " --v=5 ",# && "
-        #" sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
+        " --v=5 && "
+        " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
         hide=False)
 
     copy_admin_config(log, first_control_plane)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -333,7 +333,7 @@ def install(group: NodeGroup) -> RunnersGroupResult:
                 hostname=node.get_node_name())
             log.debug("Uploading to '%s'..." % node.get_host())
             node.put(io.StringIO(template + "\n"), '/etc/systemd/system/kubelet.service', sudo=True)
-            node.sudo("chmod 644 /etc/systemd/system/kubelet.service")
+            node.sudo("chmod 600 /etc/systemd/system/kubelet.service")
 
         log.debug("\nReloading systemd daemon...")
         system.reload_systemctl(exe.group)
@@ -442,8 +442,8 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             "kubeadm join "
             " --config=/etc/kubernetes/join-config.yaml "
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-            " --v=5 && "
-            " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
+            " --v=5 ", # && "
+            #" sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
             hide=False)
         defer.sudo("systemctl restart kubelet")
         copy_admin_config(log, defer)
@@ -570,8 +570,8 @@ def init_first_control_plane(group: NodeGroup) -> None:
         " --upload-certs"
         " --config=/etc/kubernetes/init-config.yaml"
         " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-        " --v=5 && "
-        " sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
+        " --v=5 ",# && "
+        #" sudo sed -i '/- kube-apiserver/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml",
         hide=False)
 
     copy_admin_config(log, first_control_plane)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -333,7 +333,7 @@ def install(group: NodeGroup) -> RunnersGroupResult:
                 hostname=node.get_node_name())
             log.debug("Uploading to '%s'..." % node.get_host())
             node.put(io.StringIO(template + "\n"), '/etc/systemd/system/kubelet.service', sudo=True)
-            node.sudo("chmod 600 /etc/systemd/system/kubelet.service")
+            node.sudo("chmod 644 /etc/systemd/system/kubelet.service")
 
         log.debug("\nReloading systemd daemon...")
         system.reload_systemctl(exe.group)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -333,7 +333,7 @@ def install(group: NodeGroup) -> RunnersGroupResult:
                 hostname=node.get_node_name())
             log.debug("Uploading to '%s'..." % node.get_host())
             node.put(io.StringIO(template + "\n"), '/etc/systemd/system/kubelet.service', sudo=True)
-            node.sudo("chmod 644 /etc/systemd/system/kubelet.service")
+            node.sudo("chmod 600 /etc/systemd/system/kubelet.service")
 
         log.debug("\nReloading systemd daemon...")
         system.reload_systemctl(exe.group)

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -237,8 +237,7 @@ def system_prepare_policy(group: NodeGroup):
                 kubernetes.create_kubeadm_patches_for_node(cluster, control_plane)
 
                 control_plane.sudo(f"kubeadm init phase control-plane apiserver "
-                                   f"--config=/etc/kubernetes/audit-on-config.yaml && "
-                                   f"sudo sed -i '/- --bind-address=*/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml")
+                                   f"--config=/etc/kubernetes/audit-on-config.yaml ")
 
             if cluster.inventory['services']['cri']['containerRuntime'] == 'containerd':
                 control_plane.call(utils.wait_command_successful,

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -237,7 +237,8 @@ def system_prepare_policy(group: NodeGroup):
                 kubernetes.create_kubeadm_patches_for_node(cluster, control_plane)
 
                 control_plane.sudo(f"kubeadm init phase control-plane apiserver "
-                                   f"--config=/etc/kubernetes/audit-on-config.yaml ")
+                                   f"--config=/etc/kubernetes/audit-on-config.yaml && "
+                                   f"sudo sed -i '/- --bind-address=*/a \    - --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt' /etc/kubernetes/manifests/kube-apiserver.yaml")
 
             if cluster.inventory['services']['cri']['containerRuntime'] == 'containerd':
                 control_plane.call(utils.wait_command_successful,


### PR DESCRIPTION
### Description
* When we run the kube-bench on cluster running with k8s v1.27.1 installed using kubemarine 0.18.2, we got below failures-

```
[FAIL] 4.1.1 Ensure that the kubelet service file permissions are set to 600 or more restrictive (Automated)
```

Fixes # (issue)
**MANOPD-90205**


### Solution
* Fix for 4.1.1 - Set to 600 or more restrictive permission on kubelet service file


### Test Cases

**TestCase 1**

* Find the latest version of kube-becnh utility [https://github.com/aquasecurity/kube-bench/releases](url) 
* Upload archive to the master/worker node, for example
`scp -i ~/.ssh/shift_test_key ~/kube-bench_0.6.15_linux_amd64.tar.gz ubuntu@:/home/ubuntu`
 
* Unpack it to the separate folder
`tar -xvf kube-bench_0.6.15_linux_amd64.tar.gz`

* Run check as (latest Kubernetes Benchmark will be used by default [https://github.com/aquasecurity/kube-bench/blob/main/docs/platforms.md#cis-kubernetes-benchmark-support])
`./kube-bench --config-dir <pwd>/cfg --config <pwd>/cfg/config.yaml`




Results:

| Before | After |
| ------ | ------ |
| [FAIL] 4.1.1 Ensure that the kubelet service file permissions are set to 600 or more restrictive (Automated) | [PASS] 4.1.1 Ensure that the kubelet service file permissions are set to 600 or more restrictive (Automated) |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


