### PR TITLE
[MANOPD-90205] fix for vulnerability scanning failure

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -428,7 +428,8 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             "kubeadm join "
             " --config=/etc/kubernetes/join-config.yaml"
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-            " --v=5",
+            " --v=5 &&"
+            "sudo chown etcd:etcd /var/lib/etcd",
             hide=False)
 
         log.debug("Patching apiServer bind-address for control-plane %s" % node_name)
@@ -443,7 +444,8 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
             "kubeadm join "
             " --config=/etc/kubernetes/join-config.yaml "
             " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-            " --v=5",
+            " --v=5 &&"
+            "sudo chown etcd:etcd /var/lib/etcd",
             hide=False)
         defer.sudo("systemctl restart kubelet")
         copy_admin_config(log, defer)
@@ -570,7 +572,8 @@ def init_first_control_plane(group: NodeGroup) -> None:
         " --upload-certs"
         " --config=/etc/kubernetes/init-config.yaml"
         " --ignore-preflight-errors='" + cluster.inventory['services']['kubeadm_flags']['ignorePreflightErrors'] + "'"
-        " --v=5",
+        " --v=5 &&"
+        "sudo chown etcd:etcd /var/lib/etcd",
         hide=False)
 
     copy_admin_config(log, first_control_plane)

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -114,13 +114,15 @@ def stop_cluster(cluster: KubernetesCluster):
                                               'sudo docker rm -f $(sudo docker ps -a -q); '
                                               'sudo docker ps -a; '
                                               'sudo rm -rf /var/lib/etcd; '
-                                              'sudo mkdir -p /var/lib/etcd', warn=True)
+                                              'sudo mkdir -p /var/lib/etcd &&'
+                                              'sudo chown etcd:etcd /var/lib/etcd', warn=True)
     else:
         result = cluster.nodes['control-plane'].sudo('systemctl stop kubelet; '
                                               'sudo crictl rm -fa; '
                                               'sudo crictl ps -a; '
                                               'sudo rm -rf /var/lib/etcd; '
-                                              'sudo mkdir -p /var/lib/etcd', warn=True)
+                                              'sudo mkdir -p /var/lib/etcd &&'
+                                              'sudo chown etcd:etcd /var/lib/etcd', warn=True)
     cluster.log.verbose(result)
 
 

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -114,14 +114,16 @@ def stop_cluster(cluster: KubernetesCluster):
                                               'sudo docker rm -f $(sudo docker ps -a -q); '
                                               'sudo docker ps -a; '
                                               'sudo rm -rf /var/lib/etcd; '
-                                              'sudo mkdir -p /var/lib/etcd &&'
+                                              'sudo mkdir -p /var/lib/etcd && '
+                                              'sudo chmod 700 /var/lib/etcd && '
                                               'sudo chown etcd:etcd /var/lib/etcd', warn=True)
     else:
         result = cluster.nodes['control-plane'].sudo('systemctl stop kubelet; '
                                               'sudo crictl rm -fa; '
                                               'sudo crictl ps -a; '
                                               'sudo rm -rf /var/lib/etcd; '
-                                              'sudo mkdir -p /var/lib/etcd &&'
+                                              'sudo mkdir -p /var/lib/etcd && '
+                                              'sudo chmod 700 /var/lib/etcd && '
                                               'sudo chown etcd:etcd /var/lib/etcd', warn=True)
     cluster.log.verbose(result)
 


### PR DESCRIPTION
### Description
* When we run the kube-bench on cluster running with k8s v1.27.1 installed using kubemarine 0.18.2, we got below failures-

```
[FAIL] 1.1.12 Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)
```

Fixes # (issue)
**MANOPD-90205**


### Solution
* Fix for 1.1.12 - Set to ownership for data directory(/var/lib/etcd) as etcd:etcd 


### Test Cases

**TestCase 1**

* Find the latest version of kube-becnh utility [https://github.com/aquasecurity/kube-bench/releases](url) 
* Upload archive to the master/worker node, for example
`scp -i ~/.ssh/shift_test_key ~/kube-bench_0.6.15_linux_amd64.tar.gz ubuntu@:/home/ubuntu`
 
* Unpack it to the separate folder
`tar -xvf kube-bench_0.6.15_linux_amd64.tar.gz`

* Run check as (latest Kubernetes Benchmark will be used by default [https://github.com/aquasecurity/kube-bench/blob/main/docs/platforms.md#cis-kubernetes-benchmark-support])
`./kube-bench --config-dir <pwd>/cfg --config <pwd>/cfg/config.yaml`




Results:

| Before | After |
| ------ | ------ |
| [FAIL] 1.1.12 Ensure that the etcd data directory ownership is set to etcd:etcd (Automated) | [PASS] 1.1.12 Ensure that the etcd data directory ownership is set to etcd:etcd (Automated) |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
