### PR TITLE
patch for kubeadm_flags

### DIFF
--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -22,8 +22,10 @@ The whole directory is automatically cleared and reset after new version of Kube
 from typing import List
 
 from kubemarine.core.patch import Patch
+from kubemarine.patches.p1_kubeadm_flags import KubeadmFlags
 
 patches: List[Patch] = [
+  KubeadmFlags(),
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/p1_kubeadm_flags.py
+++ b/kubemarine/patches/p1_kubeadm_flags.py
@@ -1,0 +1,44 @@
+from textwrap import dedent
+from io import StringIO
+
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine import kubernetes
+
+class TheAction(Action):
+    def __init__(self):
+        super().__init__("Updpate kubeadm_flags after cri upgrade")
+
+    def run(self, res: DynamicResources):
+        cluster = res.cluster()
+        path = 'plugins."io.containerd.grpc.v1.cri"'
+        target_kubernetes_version = cluster.inventory["services"]["kubeadm"]["kubernetesVersion"]
+        kubernetes_nodes = cluster.make_group_from_roles(['control-plane', 'worker'])
+        pause_version = cluster.globals['compatibility_map']['software']['pause'][target_kubernetes_version]['version']
+        sandbox = cluster.inventory["services"]["cri"]['containerdConfig'][path]["sandbox_image"]
+        param_begin_pos = sandbox.rfind(":")
+        sandbox = sandbox[:param_begin_pos] + ":" + str(pause_version)
+        for member_node in kubernetes_nodes.get_ordered_members_list():
+            kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
+            kubeadm_flags = member_node.sudo(f"cat {kubeadm_flags_file}").get_simple_out()
+            updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, f"--pod-infra-container-image={sandbox}")
+            member_node.put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
+
+
+
+class KubeadmFlags(RegularPatch):
+    def __init__(self):
+        super().__init__("kubeadm_flags")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            Patch to update --pod-infra-contianer-image version after upgrading the k8s version.
+            """.rstrip()
+        )

--- a/kubemarine/patches/p1_kubeadm_flags.py
+++ b/kubemarine/patches/p1_kubeadm_flags.py
@@ -33,15 +33,20 @@ class TheAction(Action):
         sandbox = cluster.inventory["services"]["cri"]['containerdConfig'][path]["sandbox_image"]
         param_begin_pos = sandbox.rfind(":")
         sandbox = sandbox[:param_begin_pos] + ":" + str(pause_version)
-        if "cri" in cluster.raw_inventory["services"] and "sandbox_image" in cluster.raw_inventory["services"]["cri"]["containerdConfig"][path]:
-            print("Skipping the patch for Kubeadm_Flags")
-            exit(0)
-        else :
+
+        cri_config = cluster.raw_inventory.get("services", {}).get("cri", {})
+        containerd_config = cri_config.get("containerdConfig", {})
+        sandbox_image = containerd_config.get(path, {}).get("sandbox_image")
+        if sandbox_image is None:
             for member_node in kubernetes_nodes.get_ordered_members_list():
                 kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
                 kubeadm_flags = member_node.sudo(f"cat {kubeadm_flags_file}").get_simple_out()
-                updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, f"--pod-infra-container-image={sandbox}" )
+                updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, "--pod-infra-container-image=%s" %sandbox )
                 member_node.put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
+        else:
+            cluster.log.debug("Skipping the patch for Kubeadm_Flags")
+            #return
+    
 
 
 

--- a/kubemarine/patches/p1_kubeadm_flags.py
+++ b/kubemarine/patches/p1_kubeadm_flags.py
@@ -46,11 +46,9 @@ class TheAction(Action):
                     kubeadm_flags = member_node.sudo(f"cat {kubeadm_flags_file}").get_simple_out()
                     updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, "--pod-infra-container-image=%s" %sandbox )
                     member_node.put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
+                    member_node.sudo("sudo systemctl restart kubelet")
             else:
                 cluster.log.debug("Skipping the patch for Kubeadm_Flags")
-                #return
-    
-
 
 
 class KubeadmFlags(RegularPatch):

--- a/kubemarine/patches/p1_kubeadm_flags.py
+++ b/kubemarine/patches/p1_kubeadm_flags.py
@@ -33,11 +33,15 @@ class TheAction(Action):
         sandbox = cluster.inventory["services"]["cri"]['containerdConfig'][path]["sandbox_image"]
         param_begin_pos = sandbox.rfind(":")
         sandbox = sandbox[:param_begin_pos] + ":" + str(pause_version)
-        for member_node in kubernetes_nodes.get_ordered_members_list():
-            kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
-            kubeadm_flags = member_node.sudo(f"cat {kubeadm_flags_file}").get_simple_out()
-            updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, f"--pod-infra-container-image={sandbox}")
-            member_node.put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
+        if "cri" in cluster.raw_inventory["services"] and "sandbox_image" in cluster.raw_inventory["services"]["cri"]["containerdConfig"][path]:
+            print("Skipping the patch for Kubeadm_Flags")
+            exit(0)
+        else :
+            for member_node in kubernetes_nodes.get_ordered_members_list():
+                kubeadm_flags_file = "/var/lib/kubelet/kubeadm-flags.env"
+                kubeadm_flags = member_node.sudo(f"cat {kubeadm_flags_file}").get_simple_out()
+                updated_kubeadm_flags = kubernetes._config_changer(kubeadm_flags, f"--pod-infra-container-image={sandbox}" )
+                member_node.put(StringIO(updated_kubeadm_flags), kubeadm_flags_file, backup=True, sudo=True)
 
 
 

--- a/kubemarine/patches/p1_kubeadm_flags.py
+++ b/kubemarine/patches/p1_kubeadm_flags.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2023 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from textwrap import dedent
 from io import StringIO
 


### PR DESCRIPTION
### Description
* Patch for updating --pod-infra-container-image version in /var/lib/kubelet/kubeadm-flags.env file

Fixes # (issue)
* MANOPD-88293

### Solution
* Apply this patch for the old clusters where --pod-infra-container-image version was not updated in /var/lib/kubelet/kubeadm-flags.env file even after k8s upgrade.


### How to apply
* [Install task/s](https://github.com/Netcracker/KubeMarine/blob/main/documentation/Maintenance.md#kubemarine-migration-procedure)

### Test Cases

**TestCase 1**
Steps:
1. Try to upgrade k8s for e.g. from _v1.24.11_ to _v1.25.2_ or _v1.25.2_ to _v1.26.4_ (where pause image version should be new between the versions) using tag 0.18.2 or older.
2. With such upgrade, the pause version for ` --pod-infra-container-image` will not get updated in the `/var/lib/kubelet/kubeadm_falgs.env` file.
4. Then apply this patch runing` kubemarine migrate_kubemarine` command.
5. Check the `/var/lib/kubelet/kubeadm_falgs.env` file to verify if   pause version is updated for ` --pod-infra-container-image` as per the k8s version.

Note - For checking the mapping between k8s version and pause image version please refer to the below document
https://github.com/Netcracker/KubeMarine/blob/0.18.2/kubemarine/resources/configurations/compatibility/internal/kubernetes_images.yaml#L135 
