### PR TITLE
[MANOPD-90775] update_utils.py_to_Remove_password_from_job_artifacts

### DIFF
--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -207,7 +207,7 @@ def mask_sensitive_data(data):
             mask_sensitive_data(item)
 
 
-def dump_file(context, data: Union[str, bytes, object], filename: str,
+def dump_file(context, data, filename: str,
               *, dump_location=True):
     try: 
         data = yaml.safe_load(data)

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -195,8 +195,26 @@ def merge_vrrp_ips(procedure_inventory, inventory):
         inventory.move_to_end("vrrp_ips", last=False)
 
 
+def mask_sensitive_data(data):
+    if isinstance(data, dict):
+        for key, value in list(data.items()):
+            if key == "password":
+                data[key] = "*****"
+            elif isinstance(value, (dict, list)):
+                mask_sensitive_data(value)
+    elif isinstance(data, list):
+        for item in data:
+            mask_sensitive_data(item)
+
+
 def dump_file(context, data: object, filename: str,
               *, dump_location=True):
+    try: 
+        data = yaml.safe_load(data)
+        mask_sensitive_data(data)
+        data = yaml.dump(data)
+    except:
+        print(f"Error while parsing YAML")
     if dump_location:
         if not isinstance(context, dict):
             # cluster is passed instead of the context directly

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -20,7 +20,7 @@ import sys
 import time
 import tarfile
 
-from typing import Tuple, Callable, List, IO
+from typing import Tuple, Callable, List, IO, Union
 
 import yaml
 import ruamel.yaml
@@ -207,7 +207,7 @@ def mask_sensitive_data(data):
             mask_sensitive_data(item)
 
 
-def dump_file(context, data: object, filename: str,
+def dump_file(context, data: Union[str, bytes, object], filename: str,
               *, dump_location=True):
     try: 
         data = yaml.safe_load(data)


### PR DESCRIPTION
### Description
The provided code modification addresses a security concern related to storing sensitive data (such as passwords) in the files during data dumping. Earlier, the code would store passwords as plain text, which could be a security risk. The change ensures that sensitive data is masked with asterisks ("*****") before being written to the files.
* 

Fixes # (issue)
The previous version of the dump_file function did not handle sensitive data securely. It directly wrote sensitive information, like passwords, to the files. The previous version of the dump_file function did not handle sensitive data securely. It directly wrote sensitive information, like passwords, to the files.


### Test Cases

**TestCase 1**

Steps:

1. Provide password instead of keyfile in cluster.yaml and proceed with kubemarine tasks.
Run "kubemarine install"

Results:

Before - Password will be visible in the dump files,

After - Password will be masked with asterisks ("*****") before being written to the dump files.


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


