### PR TITLE
[MANOPD-88960] Remove PSP from defaults for Kubernetes higher than 1.24 version

### DIFF
--- a/kubemarine/admission.py
+++ b/kubemarine/admission.py
@@ -804,7 +804,7 @@ def update_finalized_inventory(cluster: KubernetesCluster, inventory_to_finalize
         current_config["pod-security"] = cluster.procedure_inventory["psp"].get("pod-security", current_config.get("pod-security", "enabled"))
     # remove PSP section from cluster_finalyzed.yaml  
     minor_version = int(inventory_to_finalize["services"]["kubeadm"]["kubernetesVersion"].split('.')[1])
-    if minor_version >= 24:
+    if minor_version > 24:
         del inventory_to_finalize["rbac"]["psp"]
 
 


### PR DESCRIPTION
### Description
Please include a summary of the change and describe issue. Please also include relevant motivation and context.
* Removes an unnecessary block responsible for the PSP from the cluster_finalyzed.yaml of versions older than 1.24

Fixes # (issue)
MANOPD-88960


### Solution
Describe solution. List all changes that you made during implementation.
* added a condition under which the PSP block will be removed from the cluster_finalyzed.yaml file if the kubernetes version is older than 1.24


### How to apply
Not applicable


### Test Cases
Deploy clusterser older than 1.24
check cluster_finalyzed.yaml, there should not be a PSP block:
```
psp:
    custom-policies:
      bindings-list: []
      psp-list: []
      roles-list: []
    oob-policies:
      anyuid: enabled
      default: enabled
      host-network: enabled
    pod-security: enabled
```

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


