### PR TITLE
[PSUPCLPL-12898] Enabling proxy protocol for ingress-nginx and HAProxy

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3837,6 +3837,7 @@ For example:
     config_map:
       server-tokens: "False"
 ```
+**Warning**: Ingress-nginx and HAproxy use proxy protocol in the default configuration. If you are using a load balancer without a proxy protocol, it should also be disabled in ingress-nginx. To do this, specify `use-proxy-protocol: "false"` in configmap.
 
 * The `custom_headers` parameter sets specified custom headers before sending the traffic to backends. Before proceeding, refer to the official NGINX Ingress Controller documentation at [https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/).
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3837,7 +3837,12 @@ For example:
     config_map:
       server-tokens: "False"
 ```
-**Warning**: Ingress-nginx and HAproxy use proxy protocol in the default configuration. If you are using a load balancer without a proxy protocol, it should also be disabled in ingress-nginx. To do this, specify `use-proxy-protocol: "false"` in configmap.
+Default config_map settings:
+```yaml
+  allow-snippet-annotations: "true"
+  use-proxy-protocol: "true"
+```
+**Warning**: Ingress-nginx and HAproxy use proxy protocol in the default configuration. If you are using a load balancer without a proxy protocol, it **must** also be disabled in ingress-nginx. To do this, specify `use-proxy-protocol: "false"` in configmap.
 
 * The `custom_headers` parameter sets specified custom headers before sending the traffic to backends. Before proceeding, refer to the official NGINX Ingress Controller documentation at [https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/).
 

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -557,6 +557,8 @@ plugins:
                 namespace: ingress-nginx
             pods:
               - ingress-nginx-controller
+    config_map:
+      use-proxy-protocol: "true"
     webhook:
       image: 'ingress-nginx/kube-webhook-certgen:{{ globals.compatibility_map.software["nginx-ingress-controller"][services.kubeadm.kubernetesVersion]["webhook-version"] }}'
     controller:

--- a/kubemarine/templates/haproxy.cfg.j2
+++ b/kubemarine/templates/haproxy.cfg.j2
@@ -28,7 +28,7 @@ backend http_backend
     default-server      inter 2s fall 2 rise 3
 {%- for node in nodes -%}
 {% if 'worker' in node['roles'] %}
-    server {{ node['name'] }} {{ node['internal_address'] }}:80 check port 80
+    server {{ node['name'] }} {{ node['internal_address'] }}:80 check port 80 send-proxy
 {%- endif %}
 {%- endfor %}
 
@@ -47,7 +47,7 @@ backend https_backend
     default-server      inter 2s fall 2 rise 3
 {%- for node in nodes -%}
 {% if 'worker' in node['roles'] %}
-    server {{ node['name'] }} {{ node['internal_address'] }}:443 check port 443
+    server {{ node['name'] }} {{ node['internal_address'] }}:443 check port 443 send-proxy
 {%- endif %}
 {%- endfor %}
 

--- a/test/unit/plugins/test_nginx_ingress.py
+++ b/test/unit/plugins/test_nginx_ingress.py
@@ -116,7 +116,8 @@ class ManifestEnrichment(_AbstractManifestEnrichmentTest):
         self.assertEqual({
             "allow-snippet-annotations": "true",
             "foo": "bar",
-            "proxy-set-headers": "ingress-nginx/custom-headers"
+            "proxy-set-headers": "ingress-nginx/custom-headers",
+            "use-proxy-protocol": "true"
         }, default_cm, "Unexpected ingress-nginx-controller ConfigMap content")
 
         custom_headers = self.get_obj(manifest, "ConfigMap_custom-headers")['data']


### PR DESCRIPTION
### Description
Without a proxy protocol, the x-forwarded-for header contains the IP of the load balancer, not the client IP

Fixes # (issue)
PSUPCLPL-12898


### Solution
Enabling proxy protocol for ingress-nginx and HAProxy



### Test Cases
1. Run `kubemarine install --tasks="deploy.loadbalancer.haproxy.configure,deploy.plugins"` for exist cluster or create new one
2. Check the ingress-nginx-controller configmap, it should contain `"use-proxy-protocol": "true"`.
3. Check configuration of HAproxy, it should contain `send-proxy`  for servers in http/https_backend.


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
`"use-proxy-protocol": "true"` has been added to ./test/unit/plugins/test_nginx_ingress.py for testing configmap.


