### PR TITLE
[PSUPCLPL-13194] Restore calicoctl executable

### DIFF
--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -52,8 +52,11 @@ class GenericGroupResult(Mapping[str, _RESULT]):
         return iter(self._result)
 
     def get_simple_out(self) -> str:
+        return self.get_simple_result().stdout
+
+    def get_simple_result(self) -> RunnersResult:
         if len(self) != 1:
-            raise NotImplementedError("Simple output can be returned only for NodeGroupResult consisted of "
+            raise NotImplementedError("Simple result can be returned only for NodeGroupResult consisted of "
                                       "exactly one node, but %s were provided." % list(self.keys()))
 
         res = list(self.values())[0]
@@ -61,7 +64,7 @@ class GenericGroupResult(Mapping[str, _RESULT]):
             raise NotImplementedError("It does not make sense to return simple output for result of type %s"
                                       % type(res))
 
-        return res.stdout
+        return res
 
     def __str__(self) -> str:
         host_outputs = []


### PR DESCRIPTION
### Description
Restore procedure skips thirdparties that are managed by plugins. If restore procedure reverts older versions of plugins, new versions of thirdparties reside on the nodes, thus introducing a mismatch. By default, this is relevant for `calicoctl `.

### Solution
Restore all thirdparties including those that are managed by plugins.

### Test Cases

**TestCase 1**

Restore `calicoctl ` executable.

Steps:

1. Install Kubernetes v1.26.3
2. Take backup
3. Upgrade to Kubernetes v1.26.4

ER: `calico` is upgraded from v3.24.2 to v3.25.1

4. Restore from backup taken at step 2.
5. Run `check_paas`.

Results:

| Before | After |
| ------ | ------ |
| `thirdparties.hashes` fails with "expected sha is not equal to actual sha for /usr/bin/calicoctl" |  `thirdparties.hashes` is successful |

**TestCase 2**

Check mismatch of client and cluster version of `calico`.

Steps:

1. Specify incorrect version of `calicoctl` in `services.thirdparties./usr/bin/calicoctl.source` that does not correspond to the version of `calico` plugin.
2. Install the cluster.
3. Run `check_paas`.

Results:

| Before | After |
| ------ | ------ |
| `calico.config_check` fails with "invalid literal for int() with base 10: ''" |  `calico.config_check` fails with "client version mismatches the cluster version" |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
