### PR TITLE
Psupclpl 13060 kubemarine haproxy template maxconn defect

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3071,7 +3071,7 @@ services:
   loadbalancer:
     haproxy:
       global:
-         maxconn: 10000
+        maxconn: 10000
       defaults:
         timeout_connect: '10s'
         timeout_client: '1m'

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3098,7 +3098,7 @@ These settings can be overrided in the **cluster.yaml**. Currently, the followin
     <td>global.maxconn</td>
     <td>integer</td>
     <td>10000</td>
-    <td>"maxconn" the total number of connections allowed, process-wide.</td>
+    <td>"maxconn". Set the total number of connections allowed, process-wide.</td>
   </tr>
   <tr>
     <td>defaults.timeout_connect</td>

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3070,6 +3070,8 @@ By default, the following configuration is used:
 services:
   loadbalancer:
     haproxy:
+      global:
+         maxconn: 10000
       defaults:
         timeout_connect: '10s'
         timeout_client: '1m'
@@ -3092,6 +3094,12 @@ These settings can be overrided in the **cluster.yaml**. Currently, the followin
   </tr>
 </thead>
 <tbody>
+  <tr>
+    <td>global.maxconn</td>
+    <td>integer</td>
+    <td>10000</td>
+    <td>"maxconn" the total number of connections allowed, process-wide.</td>
+  </tr>
   <tr>
     <td>defaults.timeout_connect</td>
     <td>string</td>

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -348,6 +348,8 @@ services:
 
   loadbalancer:
     haproxy:
+      global:
+        maxconn: '10000'
       defaults:
         timeout_connect: '10s'
         timeout_client: '1m'

--- a/kubemarine/resources/schemas/definitions/services/loadbalancer.json
+++ b/kubemarine/resources/schemas/definitions/services/loadbalancer.json
@@ -30,6 +30,11 @@
           "default": "/etc/haproxy/haproxy_mntc.cfg",
           "description": "Maintenance config flie location"
         },
+        "global": {
+          "type": "integer",
+          "default": 10000,
+          "description": "Set the total number of connections allowed, process-wide.",
+        },
         "defaults": {
           "type": "object",
           "description": "Parameters that are passed directly to the 'defaults' section of haproxy.cfg file.",

--- a/kubemarine/templates/haproxy.cfg.j2
+++ b/kubemarine/templates/haproxy.cfg.j2
@@ -2,6 +2,7 @@ global
     log                 127.0.0.1 local2 debug
     user haproxy
     group haproxy
+    maxconn             10000
 
 defaults
     log                 global

--- a/kubemarine/templates/haproxy.cfg.j2
+++ b/kubemarine/templates/haproxy.cfg.j2
@@ -2,7 +2,7 @@ global
     log                 127.0.0.1 local2 debug
     user haproxy
     group haproxy
-    maxconn             10000
+    maxconn             {{ config_options['global']['maxconn'] }}
 
 defaults
     log                 global


### PR DESCRIPTION
### Description
* At least for haproxy version 1.8, maxconn option in the default section set cumulative number of connections only for backends. And if there is no maxconn option in the Global section than for frontends applying default number equal 2000 connections.

Fixes # (issue)
PSUPCLPL-13060

### Solution
*  Added maxconn value to global section in haproxy config.  


### Test Cases

**TestCase 1**
- take any haproxy 1.8 installation
- define maxconn option only in the Default section greater then 2k,
- create more then 2001 passive connections to the haproxy on any frontend (service).
```
import socket
import time
 
try:
    maxconn = 10
    host = '10.109.54.92'
    timeout = 30
 
    pool = [ socket.socket(socket.AF_INET, socket.SOCK_STREAM) for x in range(maxconn) ]
    [ x.connect((host, 80)) for x in pool ]
    time.sleep(timeout)
 
finally:
    [ x.close() for x in pool ]
    for x in pool:
        x = None
 
print('Done')
```
- try to curl some service or use "ab" util: `curl http://service_url/` or `ab -k -c50 -n 10000 http://service_url/`



Test Configuration:

- Hardware: 
- OS: 
- Inventory: 

Steps:

1. 

Results:

| Before | After |
| ------ | ------ |
| Thus if number of incoming connection is greater then 2k, every connection from above, is moving to the haproxy waiting queue. From client side it is looks like ERR_TIMED_OUT. | no errors appear |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


