### PR TITLE
Refactoring Check Paas, Check IaaS tests

### DIFF
--- a/kubemarine/__main__.py
+++ b/kubemarine/__main__.py
@@ -154,8 +154,11 @@ Usage: kubemarine <procedure> <arguments>
 ''' % '\n'.join(descriptions_print_list))
         sys.exit(1)
 
-    import_procedure(arguments[0]).main(arguments[1:])
-
+    result = import_procedure(arguments[0]).main(arguments[1:])
+    if result is not None:
+        from kubemarine.testsuite import TestSuite
+        if isinstance(result, TestSuite) and result.is_any_test_failed():
+            sys.exit(1)
 
 def import_procedure(name):
     module_name = 'kubemarine.procedures.%s' % name

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -992,9 +992,10 @@ def main(cli_arguments=None):
     print(testsuite.get_final_summary())
     testsuite.print_final_status(result.logger)
     make_reports(context)
-    if testsuite.is_any_test_failed():
-        sys.exit(1)
+    return testsuite
 
 
 if __name__ == '__main__':
-    main()
+    testsuite = main()
+    if testsuite.is_any_test_failed():
+        sys.exit(1)

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1415,9 +1415,10 @@ def main(cli_arguments=None):
     print(testsuite.get_final_summary(show_minimal=False, show_recommended=False))
     testsuite.print_final_status(result.logger)
     check_iaas.make_reports(context)
-    if testsuite.is_any_test_failed():
-        sys.exit(1)
+    return testsuite
 
 
 if __name__ == '__main__':
-    main()
+    testsuite = main()
+    if testsuite.is_any_test_failed():
+        sys.exit(1)


### PR DESCRIPTION
### Description
* Due to the previous changes in check paas, the internal gitlab ci was broken. (https://github.com/Netcracker/KubeMarine/pull/426)
* Therefore, internal gitlab ci is not working right now.
* Because the context return from the function was removed in check paas and check iaas.

### Solution
* The code was refactored in check paas and check iaas, context output was added to the function

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


