### PR TITLE
PSUPCLPL-13194 Optimize downloading of Kubernetes resources during backup

### DIFF
--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -11,13 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import threading
 from copy import deepcopy
 from typing import Dict, List, Union, Iterable, Tuple, Optional, Any, Callable
 
 import yaml
 
-from kubemarine.core import log, utils, static
+from kubemarine.core import log, utils, static, connections
 from kubemarine.core.connections import ConnectionPool
 from kubemarine.core.environment import Environment
 from kubemarine.core.group import NodeGroup, NodeConfig
@@ -40,8 +39,7 @@ class KubernetesCluster(Environment):
         self.context = context
         self.procedure_inventory = {} if procedure_inventory is None else deepcopy(procedure_inventory)
 
-        self._lock = threading.Lock()
-        self._connection_pool: Optional[ConnectionPool] = None
+        self._connection_pool: ConnectionPool = connections.EMPTY_POOL
 
         self._logger = logger if logger is not None \
             else log.init_log_from_context_args(self.globals, self.context, self.raw_inventory).logger
@@ -55,23 +53,18 @@ class KubernetesCluster(Environment):
         self._inventory = defaults.enrich_inventory(
             self, self.raw_inventory, make_dumps=make_dumps, enrichment_functions=custom_enrichment_fns)
 
+        self._connection_pool = self.create_connection_pool(self.ips['all'])
+
     @property
     def inventory(self) -> dict:
         return self._inventory
 
     @property
     def connection_pool(self) -> ConnectionPool:
-        if self._connection_pool is None:
-            with self._lock:
-                if self._connection_pool is None:
-                    # Connection pool should be created for each cluster object,
-                    # because it relies on partially enriched inventory
-                    self._connection_pool = self.create_connection_pool()
-
         return self._connection_pool
 
-    def create_connection_pool(self) -> ConnectionPool:
-        return ConnectionPool(self.inventory)
+    def create_connection_pool(self, hosts: List[str]) -> ConnectionPool:
+        return ConnectionPool(self.inventory, hosts)
 
     @property
     def log(self) -> log.EnhancedLogger:

--- a/kubemarine/core/connections.py
+++ b/kubemarine/core/connections.py
@@ -31,6 +31,12 @@ class ConnectionPool:
     def get_connection(self, ip: str) -> fabric.connection.Connection:
         conn = self._connections.get(ip)
         if conn is None:
+            # Each connection is not thread-safe, and should not be accessed from multiple threads simultaneously.
+            # But ConnectionPool is thread-safe, and can be access from multiple threads to connect to different nodes.
+            #
+            # The lock below does not guard anything in reality,
+            # as attempt to get the same connection should not happen in parallel.
+            # It is left only to follow best practices of writing of thread-safe classes.
             with self._lock:
                 conn = self._connections.get(ip)
                 if conn is None:

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -30,6 +30,7 @@ from concurrent.futures.thread import ThreadPoolExecutor
 import invoke
 
 from kubemarine.core import log, static
+from kubemarine.core.connections import ConnectionPool
 from kubemarine.core.environment import Environment
 
 
@@ -192,9 +193,12 @@ _T = TypeVar('_T', bound='RawExecutor')
 
 class RawExecutor:
 
-    def __init__(self, cluster: Environment, timeout: int = None) -> None:
+    def __init__(self, cluster: Environment, connection_pool: ConnectionPool = None, timeout: int = None) -> None:
         self.logger = cluster.log
-        self.connection_pool = cluster.connection_pool
+        if connection_pool is not None:
+            self.connection_pool = connection_pool
+        else:
+            self.connection_pool = cluster.connection_pool
         self.inventory = cluster.inventory
         self.timeout = timeout
         if timeout is None:

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -34,8 +34,8 @@ from kubemarine.core.environment import Environment
 
 
 class RunnersResult:
-    def __init__(self, commands: List[str], exit_codes: List[int], stdout: str, stderr: str,
-                 hide: tuple) -> None:
+    def __init__(self, commands: List[str], exit_codes: List[int], stdout: str = "", stderr: str = "",
+                 hide: bool = False) -> None:
         self.commands = commands
         self.stdout = stdout
         self.stderr = stderr
@@ -115,7 +115,7 @@ class RunnersResult:
         for x in ("stdout", "stderr"):
             val: str = getattr(self, x)
             if val:
-                val = 'already printed' if hide_already_printed and x not in self.hide else val.rstrip()
+                val = 'already printed' if hide_already_printed and not self.hide else val.rstrip()
                 ret.append(f"=== {x} ===\n"
                            f"{val.rstrip()}\n")
         return "\n".join(ret)
@@ -284,6 +284,9 @@ class RawExecutor:
 
     def _reparse_fabric_result(self, payloads: List[_PayloadItem],
                                result: fabric.runners.Result) -> List[RunnersResult]:
+        # unpack last action in list of payloads
+        _, _, kwargs = payloads[-1][0]
+
         stderrs = result.stderr.split(self._command_separator + '\n')
         raw_stdouts = result.stdout.split(self._command_separator + '\n')
         stdouts = []
@@ -301,7 +304,7 @@ class RawExecutor:
             action, _, _ = payloads[i]
             command: str = action[1][0]
             results.append(RunnersResult(
-                    [command], [code], stdouts[i], stderrs[i], hide=result.hide))
+                    [command], [code], stdouts[i], stderrs[i], hide=kwargs.get('hide', False)))
 
         return results
 
@@ -530,7 +533,7 @@ class RawExecutor:
                 self.logger.verbose("Command timed out at %s: %s" % (host, str(exception.result)))
                 return False
             elif isinstance(exception, UnexpectedExit):
-                # Do not str(exception) because it discards output if it is already printed
+                # Do not str(exception) because it discards output in case of hide=False
                 exception_message = str(exception.result)
             else:
                 exception_message = str(exception)

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -25,6 +25,7 @@ from typing import (
 )
 
 from kubemarine.core import utils, log, errors
+from kubemarine.core.connections import ConnectionPool
 from kubemarine.core.executor import (
     RawExecutor, Token, GenericResult, RunnersResult, HostToResult, Callback, TokenizedResult,
 )
@@ -769,8 +770,8 @@ class DeferredGroup(AbstractGroup[Token]):
 
 
 class RemoteExecutor(RawExecutor):
-    def __init__(self, group: NodeGroup, timeout: int = None) -> None:
-        super().__init__(group.cluster, timeout)
+    def __init__(self, group: NodeGroup, connection_pool: ConnectionPool = None, timeout: int = None) -> None:
+        super().__init__(group.cluster, connection_pool, timeout)
         self.group: DeferredGroup = group._make_defer(self)
         self.cluster = group.cluster
 

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -21,7 +21,7 @@ import uuid
 from abc import ABC, abstractmethod
 from types import FunctionType
 from typing import (
-    Callable, Dict, List, Union, Any, TypeVar, Mapping, Iterator, Optional, Iterable, Generic, Set, cast
+    Callable, Dict, List, Union, Any, TypeVar, Mapping, Iterator, Optional, Iterable, Generic, Set, cast, TextIO
 )
 
 from kubemarine.core import utils, log, errors
@@ -301,7 +301,7 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
         return not self == other
 
     def run(self, command: str,
-            warn: bool = False, hide: bool = True,
+            warn: bool = False, hide: bool = True, out_stream: TextIO = None, err_stream: TextIO = None,
             env: Dict[str, str] = None, timeout: int = None,
             callback: Callback = None) -> GROUP_RUN_TYPE:
         caller: Optional[Dict[str, object]] = None
@@ -309,10 +309,11 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
             # fetching of the caller info should be at the earliest point
             caller = log.caller_info(self.cluster.log)
         return self._run("run", command, caller,
-                         warn=warn, hide=hide, env=env, timeout=timeout, callback=callback)
+                         warn=warn, hide=hide, out_stream=out_stream, err_stream=err_stream,
+                         env=env, timeout=timeout, callback=callback)
 
     def sudo(self, command: str,
-             warn: bool = False, hide: bool = True,
+             warn: bool = False, hide: bool = True, out_stream: TextIO = None, err_stream: TextIO = None,
              env: Dict[str, str] = None, timeout: int = None,
              callback: Callback = None) -> GROUP_RUN_TYPE:
         caller: Optional[Dict[str, object]] = None
@@ -320,7 +321,8 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
             # fetching of the caller info should be at the earliest point
             caller = log.caller_info(self.cluster.log)
         return self._run("sudo", command, caller,
-                         warn=warn, hide=hide, env=env, timeout=timeout, callback=callback)
+                         warn=warn, hide=hide, out_stream=out_stream, err_stream=err_stream,
+                         env=env, timeout=timeout, callback=callback)
 
     @abstractmethod
     def _run(self, do_type: str, command: str, caller: Optional[Dict[str, object]],
@@ -664,14 +666,20 @@ class NodeGroup(AbstractGroup[RunnersGroupResult]):
         """
         The method should be called directly from run & sudo without any extra wrappers.
         """
-        do_stream = not kwargs['hide']
-        if do_stream and len(self.nodes) > 1:
+        logging_stream = not kwargs['hide']
+        custom_stream = kwargs['out_stream'] is not None or kwargs['err_stream'] is not None
+        if logging_stream and custom_stream:
+            raise ValueError("Ambiguous streaming configuration detected")
+        if (logging_stream or custom_stream) and len(self.nodes) > 1:
             raise ValueError("Streaming of output is supported only for the single node")
 
-        if do_stream and caller is not None:
+        if logging_stream and caller is not None:
             logger = self.cluster.log
             kwargs['out_stream'] = log.LoggerWriter(logger, caller, '\t')
             kwargs['err_stream'] = log.LoggerWriter(logger, caller, '\t')
+
+        # `out_stream` and `err_stream` have precedence over `hide` property. By default, hide both streams.
+        kwargs['hide'] = True
 
         results = self._do_exec(do_type, command, **kwargs)
         return self._unsafe_make_runners_result(results)
@@ -736,8 +744,9 @@ class DeferredGroup(AbstractGroup[Token]):
         self._do_queue("get", remote_file, local_file)
 
     def _run(self, do_type: str, command: str, caller: Optional[Dict[str, object]], **kwargs: object) -> Token:
-        do_stream = not kwargs['hide']
-        if do_stream:
+        logging_stream = not kwargs['hide']
+        custom_stream = kwargs['out_stream'] is not None or kwargs['err_stream'] is not None
+        if logging_stream or custom_stream:
             # To support streaming of output with use of RemoteExecutor in deferred mode, it is necessary to:
             # 1) Make sure that no two commands are executed with streaming in parallel to avoid mess in output
             # 2) Do not print output twice if error occurred.

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -196,6 +196,7 @@ class DynamicResources:
                 light_cluster = self._new_cluster_instance(deepcopy(self.context))
                 light_cluster.enrich(custom_enrichment_fns=light_cluster.get_facts_enrichment_fns())
                 self._nodes_context = light_cluster.detect_nodes_context()
+                light_cluster.connection_pool.close()
 
         return self._nodes_context
 

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -15,6 +15,7 @@ import hashlib
 import io
 import json
 import os
+import re
 import shutil
 import sys
 import time
@@ -495,10 +496,24 @@ def parse_aligned_table(table_text: str) -> List[Dict[str, str]]:
     :return: List of rows
     """
     rows = table_text.strip().split('\n')
-    headers = rows[0].split()
-    headers_num = len(headers)
-    headers_pos = [rows[0].index(h) for h in headers]
 
+    # Parse headers and their positions. No leading or trailing spaces are expected in the line.
+    headers_line = rows[0]
+    headers = []
+    headers_pos = []
+    pos = 0
+    for match in re.finditer(r'\s+', headers_line):
+        headers_pos.append(pos)
+        span = match.span()
+        headers.append(headers_line[pos:span[0]])
+        pos = span[1]
+
+    headers_pos.append(pos)
+    headers.append(headers_line[pos:len(headers_line)])
+
+    # Parse each row in the table,
+    # provided that the columns start at the same positions as the headers
+    headers_num = len(headers)
     data = []
     for row_text in rows[1:]:
         row = {}

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -20,7 +20,7 @@ import sys
 import time
 import tarfile
 
-from typing import Tuple, Callable, List, TextIO, cast, Union, TypeVar
+from typing import Tuple, Callable, List, TextIO, cast, Union, TypeVar, Dict
 
 import yaml
 import ruamel.yaml
@@ -484,6 +484,35 @@ def _test_version(version: str, numbers_amount: int) -> List[int]:
 
     expected_pattern = 'v' + '.'.join('N+' for _ in range(numbers_amount))
     raise ValueError(f'Incorrect version \"{version}\" format, expected version pattern is \"{expected_pattern}\"')
+
+
+def parse_aligned_table(table_text: str) -> List[Dict[str, str]]:
+    """
+    Parse aligned table into the list of {header: cell} map.
+    The text with table can be initially produced, for example, by https://pkg.go.dev/text/tabwriter.
+
+    :param table_text: aligned table as string
+    :return: List of rows
+    """
+    rows = table_text.strip().split('\n')
+    headers = rows[0].split()
+    headers_num = len(headers)
+    headers_pos = [rows[0].index(h) for h in headers]
+
+    data = []
+    for row_text in rows[1:]:
+        row = {}
+        for i, header in enumerate(headers):
+            if i == headers_num - 1:
+                cell = row_text[headers_pos[i]:]
+            else:
+                cell = row_text[headers_pos[i]:headers_pos[i+1]]
+
+            row[header] = cell.strip()
+
+        data.append(row)
+
+    return data
 
 
 class ClusterStorage:

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -176,8 +176,8 @@ class FakeKubernetesCluster(KubernetesCluster):
         self.fake_fs = kwargs.pop("fake_fs", FakeFS())
         super().__init__(*args, **kwargs)
 
-    def create_connection_pool(self) -> ConnectionPool:
-        return FakeConnectionPool(self.inventory, self.fake_shell, self.fake_fs)
+    def create_connection_pool(self, hosts: List[str]) -> ConnectionPool:
+        return FakeConnectionPool(self.inventory, hosts, self.fake_shell, self.fake_fs)
 
     def make_group(self, ips: Iterable[_AnyConnectionTypes]) -> FakeNodeGroup:
         return FakeNodeGroup(ips, self)
@@ -357,10 +357,10 @@ class FakeDeferredGroup(DeferredGroup, FakeAbstractGroup[Token]):
 
 
 class FakeConnectionPool(connections.ConnectionPool):
-    def __init__(self, inventory: dict, fake_shell: FakeShell, fake_fs: FakeFS):
-        super().__init__(inventory)
+    def __init__(self, inventory: dict, hosts: List[str], fake_shell: FakeShell, fake_fs: FakeFS):
         self.fake_shell = fake_shell
         self.fake_fs = fake_fs
+        super().__init__(inventory, hosts)
 
     def _create_connection_from_details(self, ip: str, conn_details: dict,
                                         gateway: fabric.connection.Connection = None,

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -263,10 +263,8 @@ class FakeConnection(fabric.connection.Connection):  # type: ignore[misc]
         # start fake execution of commands
         commands, sep_symbol, command_sep = self._split_command(do_type, original_command)
 
-        hide = invoke.runners.normalize_hide(  # type: ignore[no-untyped-call]
-            kwargs['hide'], kwargs['out_stream'], kwargs['err_stream'])
         final_res = fabric.runners.Result(stdout="", stderr="", exited=None,
-                                          connection=self, command=original_command, hide=hide)
+                                          connection=self, command=original_command)
         prev_exited = None
         i = 0
         for command in commands:
@@ -552,7 +550,7 @@ def create_hosts_result(hosts: List[str], stdout: str = '', stderr: str = '',
 
 def create_result(stdout: str = '', stderr: str = '', code: int = 0, timeout: int = None) -> GenericResult:
     # command and 'hide' option will be later replaced with actual
-    result = RunnersResult(["fake command"], [code], stdout=stdout, stderr=stderr, hide=tuple())
+    result = RunnersResult(["fake command"], [code], stdout=stdout, stderr=stderr)
     if timeout is None:
         return result
 

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -263,8 +263,10 @@ class FakeConnection(fabric.connection.Connection):  # type: ignore[misc]
         # start fake execution of commands
         commands, sep_symbol, command_sep = self._split_command(do_type, original_command)
 
+        hide = invoke.runners.normalize_hide(  # type: ignore[no-untyped-call]
+            kwargs['hide'], kwargs['out_stream'], kwargs['err_stream'])
         final_res = fabric.runners.Result(stdout="", stderr="", exited=None,
-                                          connection=self, command=original_command)
+                                          connection=self, command=original_command, hide=hide)
         prev_exited = None
         i = 0
         for command in commands:
@@ -550,7 +552,7 @@ def create_hosts_result(hosts: List[str], stdout: str = '', stderr: str = '',
 
 def create_result(stdout: str = '', stderr: str = '', code: int = 0, timeout: int = None) -> GenericResult:
     # command and 'hide' option will be later replaced with actual
-    result = RunnersResult(["fake command"], [code], stdout=stdout, stderr=stderr)
+    result = RunnersResult(["fake command"], [code], stdout=stdout, stderr=stderr, hide=tuple())
     if timeout is None:
         return result
 

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -176,12 +176,8 @@ class FakeKubernetesCluster(KubernetesCluster):
         self.fake_fs = kwargs.pop("fake_fs", FakeFS())
         super().__init__(*args, **kwargs)
 
-    @property
-    def connection_pool(self) -> ConnectionPool:
-        if self._connection_pool is None:
-            self._connection_pool = FakeConnectionPool(self.inventory, self.fake_shell, self.fake_fs)
-
-        return self._connection_pool
+    def create_connection_pool(self) -> ConnectionPool:
+        return FakeConnectionPool(self.inventory, self.fake_shell, self.fake_fs)
 
     def make_group(self, ips: Iterable[_AnyConnectionTypes]) -> FakeNodeGroup:
         return FakeNodeGroup(ips, self)

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -537,11 +537,13 @@ class ExportKubernetesDownloader:
         namespace = task.namespace
         temp_remote_filepath = f"/tmp/{os.path.basename(temp_local_filepath)}"
 
-        cmd = f'kubectl{"" if namespace is None else (" -n " + namespace)} get --ignore-not-found ' \
+        cmd = f'(set -o pipefail && sudo kubectl ' \
+              f'{"" if namespace is None else ("-n " + namespace + " ")}' \
+              f'get --ignore-not-found ' \
               f'{",".join(r for r in task.resources)} ' \
-              f'-o yaml | gzip -c > {temp_remote_filepath}'
+              f'-o yaml | gzip -c) > {temp_remote_filepath}'
 
-        self.control_plane.sudo(cmd)
+        self.control_plane.run(cmd)
         self.control_plane.get(temp_remote_filepath, temp_local_filepath)
         self.control_plane.sudo(f'rm {temp_remote_filepath}')
         self.control_plane.flush()

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -500,13 +500,13 @@ class ExportKubernetesDownloader:
     def __init__(self,
                  backup_directory: str,
                  control_plane: NodeGroup,
-                 connection_pool: ConnectionPool,
+                 cluster: KubernetesCluster,
                  tasks_queue: Iterator[DownloaderPayload],
                  parser: ExportKubernetesParser,
                  ):
         self.backup_directory = backup_directory
         self.control_plane = control_plane
-        self.connection_pool = connection_pool
+        self.connection_pool = cluster.create_connection_pool()
         self.tasks_queue = tasks_queue
         self.parser = parser
         self.elapsed: float = 0
@@ -589,8 +589,7 @@ def export_kubernetes(cluster: KubernetesCluster) -> None:
                                     control_planes.nodes_amount() * downloaders_per_control_plane)
     downloader_queue = DownloaderTasksQueue(namespaces, namespaced_resources, nonnamespaced_resources)
     downloaders = [
-        ExportKubernetesDownloader(backup_directory, control_plane,
-                                   cluster.create_connection_pool(),
+        ExportKubernetesDownloader(backup_directory, control_plane, cluster,
                                    downloader_queue, parser)
         for _ in range(downloaders_per_control_plane)
         for control_plane in control_planes.get_ordered_members_list()

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -34,7 +34,8 @@ import yaml
 from kubemarine.core import utils, flow, log
 from kubemarine.core.action import Action
 from kubemarine.core.cluster import KubernetesCluster
-from kubemarine.core.group import NodeGroup
+from kubemarine.core.connections import ConnectionPool
+from kubemarine.core.group import NodeGroup, RemoteExecutor
 from kubemarine.core.resources import DynamicResources
 
 
@@ -499,11 +500,13 @@ class ExportKubernetesDownloader:
     def __init__(self,
                  backup_directory: str,
                  control_plane: NodeGroup,
+                 connection_pool: ConnectionPool,
                  tasks_queue: Iterator[DownloaderPayload],
                  parser: ExportKubernetesParser,
                  ):
         self.backup_directory = backup_directory
-        self.control_plane = control_plane.new_defer()
+        self.control_plane = control_plane
+        self.connection_pool = connection_pool
         self.tasks_queue = tasks_queue
         self.parser = parser
         self.elapsed: float = 0
@@ -532,6 +535,7 @@ class ExportKubernetesDownloader:
             self.parser.finish(graceful=True)
         finally:
             self.elapsed = time.time() - start
+            self.connection_pool.close()
 
     def _download(self, task: DownloaderPayload, temp_local_filepath: str) -> None:
         namespace = task.namespace
@@ -543,10 +547,12 @@ class ExportKubernetesDownloader:
               f'{",".join(r for r in task.resources)} ' \
               f'-o yaml | gzip -c) > {temp_remote_filepath}'
 
-        self.control_plane.run(cmd)
-        self.control_plane.get(temp_remote_filepath, temp_local_filepath)
-        self.control_plane.sudo(f'rm {temp_remote_filepath}')
-        self.control_plane.flush()
+        # Use own connection instance to run commands
+        with RemoteExecutor(self.control_plane, self.connection_pool) as exe:
+            group = exe.group
+            group.run(cmd)
+            group.get(temp_remote_filepath, temp_local_filepath)
+            group.sudo(f'rm {temp_remote_filepath}')
 
 
 def export_kubernetes(cluster: KubernetesCluster) -> None:
@@ -575,13 +581,18 @@ def export_kubernetes(cluster: KubernetesCluster) -> None:
 
     # Processing of the particular resource includes
     # 1. downloading of the `kubectl` result (mostly IO)
-    # 2. parsing and splitting it into files (mostly CPU)
+    # 2. parsing and splitting it into files (can potentially consume CPU)
     control_planes = cluster.nodes['control-plane']
+    downloaders_per_control_plane = 2
+
     parser = ExportKubernetesParser(logger, backup_directory, namespaced_resources, nonnamespaced_resources,
-                                    control_planes.nodes_amount())
+                                    control_planes.nodes_amount() * downloaders_per_control_plane)
     downloader_queue = DownloaderTasksQueue(namespaces, namespaced_resources, nonnamespaced_resources)
     downloaders = [
-        ExportKubernetesDownloader(backup_directory, control_plane, downloader_queue, parser)
+        ExportKubernetesDownloader(backup_directory, control_plane,
+                                   cluster.create_connection_pool(),
+                                   downloader_queue, parser)
+        for _ in range(downloaders_per_control_plane)
         for control_plane in control_planes.get_ordered_members_list()
     ]
 

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -506,7 +506,7 @@ class ExportKubernetesDownloader:
                  ):
         self.backup_directory = backup_directory
         self.control_plane = control_plane
-        self.connection_pool = cluster.create_connection_pool()
+        self.connection_pool = cluster.create_connection_pool(control_plane.get_hosts())
         self.tasks_queue = tasks_queue
         self.parser = parser
         self.elapsed: float = 0

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -388,7 +388,7 @@ logging:
       format: "%(asctime)s %(levelname)s %(message)s"
     dump:
       level: verbose
-      format: "%(asctime)s %(levelname)s [%(module)s.%(funcName)s] %(message)s"
+      format: "%(asctime)s %(thread)s %(levelname)s [%(module)s.%(funcName)s] %(message)s"
       colorize: False
       correct_newlines: True
 

--- a/test/unit/test_backup.py
+++ b/test/unit/test_backup.py
@@ -1,0 +1,239 @@
+import gzip
+import logging
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from textwrap import dedent
+from typing import Optional
+from unittest import mock
+
+from kubemarine import demo
+from kubemarine.core import flow, utils, log
+from kubemarine.procedures import backup
+
+
+class TestBackupTasks(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.inventory = demo.generate_inventory(**demo.FULLHA_KEEPALIVED)
+        self.hosts = [node['address'] for node in self.inventory['nodes']]
+
+        self.context = backup.create_context(['fake.yaml'])
+        self.context['preserve_inventory'] = False
+
+        self.args = self.context['execution_arguments']
+        del self.args['ansible_inventory_location']
+        self.args['disable_dump'] = False
+        self.args['dump_location'] = self.tmpdir.name
+        utils.prepare_dump_directory(self.args['dump_location'])
+
+        self.fake_shell = demo.FakeShell()
+        self.resources: Optional[demo.FakeResources] = None
+
+    def tearDown(self):
+        logger = logging.getLogger("k8s.fake.local")
+        for h in logger.handlers:
+            if isinstance(h, log.FileHandlerWithHeader):
+                h.close()
+        self.tmpdir.cleanup()
+
+    def _run(self):
+        self.resources = demo.FakeResources(self.context, self.inventory,
+                                            procedure_inventory={},
+                                            nodes_context=demo.generate_nodes_context(self.inventory),
+                                            fake_shell=self.fake_shell)
+
+        flow.run_actions(self.resources, [backup.BackupAction()])
+
+    def test_export_kubernetes(self):
+        self.args['tasks'] = 'export.kubernetes'
+        self._stub_load_namespaces()
+        self._stub_load_resources()
+        with self._mock_manifest_processor_enrich():
+            self._run()
+
+        descriptor = self.resources.last_cluster.context['backup_descriptor']['kubernetes']['resources']
+        self.assertEqual({'kube-system': ['configmaps', 'roles.rbac.authorization.k8s.io']},
+                         descriptor.get('namespaced'),
+                         "Not expected resulting list of namespaced resources")
+        self.assertEqual(['nodes'], descriptor.get('nonnamespaced'),
+                         "Not expected resulting list of non-namespaced resources")
+
+        resources_path = Path(self.tmpdir.name) / 'dump' / 'backup' / 'kubernetes_resources'
+        actual_files = {str(p.relative_to(resources_path)) for p in resources_path.glob("**/*.yaml")}
+        expected_files = {str(Path(p)) for p in ['nodes.yaml', 'kube-system/configmaps.yaml',
+                                                 'kube-system/roles.rbac.authorization.k8s.io.yaml']}
+        self.assertEqual(expected_files, actual_files, "Not expected list of files")
+
+        expected_context = self._parse_yaml(dedent(
+            '''\
+            apiVersion: v1
+            items:
+            - apiVersion: v1
+              kind: Node
+              metadata:
+                name: control-plane-1
+            kind: List
+            metadata:
+              resourceVersion: ""
+            '''
+        ))
+        actual_content = self._parse_yaml(utils.read_internal(str(resources_path / 'nodes.yaml')))
+        self.assertEqual(expected_context, actual_content,
+                         f"Data in file 'nodes.yaml' is not expected")
+
+        expected_context = self._parse_yaml(dedent(
+            '''\
+            apiVersion: v1
+            items:
+            - apiVersion: v1
+              data:
+                key: =
+              kind: ConfigMap
+              metadata:
+                name: calico-config
+            - apiVersion: v1
+              data:
+                Corefile: |
+                  .:53 {
+                  }
+                Hosts: |
+                  127.0.0.1 localhost localhost.localdomain
+            
+                  10.101.2.1  k8s.fake.local control-plain
+              kind: ConfigMap
+              metadata:
+                name: coredns
+            kind: List
+            metadata:
+              resourceVersion: ""
+            '''
+        ))
+        actual_content = self._parse_yaml(utils.read_internal(str(resources_path / 'kube-system/configmaps.yaml')))
+        expected_special_symbol = expected_context['items'][0]['data'].pop('key')
+        actual_special_symbol = actual_content['items'][0]['data'].pop('key')
+        self.assertEqual(expected_special_symbol.value, actual_special_symbol.value,
+                         "Failed to compare special TaggedScalar")
+        self.assertEqual(expected_context, actual_content,
+                         f"Data in file 'kube-system/configmaps.yaml' is not expected")
+
+        expected_context = self._parse_yaml(dedent(
+            '''\
+            apiVersion: v1
+            items:
+            - apiVersion: rbac.authorization.k8s.io/v1
+              kind: Role
+              metadata:
+                name: kube-proxy
+              rules: []
+            kind: List
+            metadata:
+              resourceVersion: ""
+            '''
+        ))
+        actual_content = self._parse_yaml(utils.read_internal(str(resources_path / 'kube-system/roles.rbac.authorization.k8s.io.yaml')))
+        self.assertEqual(expected_context, actual_content,
+                         f"Data in file 'kube-system/roles.rbac.authorization.k8s.io.yaml' is not expected")
+
+    def _parse_yaml(self, data: str):
+        return utils.yaml_structure_preserver().load(data)
+
+    def _stub_load_namespaces(self):
+        results = demo.create_hosts_result(self.hosts, stdout='\n'.join(['default', 'kube-system']))
+        self.fake_shell.add(results, 'sudo',
+                            ['kubectl get ns -o jsonpath=\'{range .items[*]}{.metadata.name}{"\\n"}{end}\''])
+
+    def _stub_load_resources(self):
+        results = demo.create_hosts_result(self.hosts, stdout=dedent(
+            '''\
+            NAME         SHORTNAMES   APIVERSION                     NAMESPACED   KIND
+            configmaps   cm           v1                             true         ConfigMap
+            events       ev           v1                             true         Event
+            events       ev           events.k8s.io/v1               true         Event
+            roles                     rbac.authorization.k8s.io/v1   true         Role
+            '''
+        ))
+        self.fake_shell.add(results, 'sudo',
+                            ['kubectl api-resources --verbs=list --sort-by=name --namespaced'])
+
+        results = demo.create_hosts_result(self.hosts, stdout=dedent(
+            '''\
+            NAME         SHORTNAMES   APIVERSION   NAMESPACED   KIND
+            namespaces   ns           v1           false        Namespace
+            nodes        no           v1           false        Node
+            '''
+        ))
+        self.fake_shell.add(results, 'sudo',
+                            ['kubectl api-resources --verbs=list --sort-by=name --namespaced=false'])
+
+    @contextmanager
+    def _mock_manifest_processor_enrich(self):
+        download_orig = backup.ExportKubernetesDownloader._download
+
+        def download_stub(location: str, data: str):
+            with gzip.open(location, 'wt', encoding='utf-8') as f:
+                f.write(data)
+
+        def download_mocked(_, task: backup.DownloaderPayload, temp_local_filepath: str) -> None:
+            namespace = task.namespace
+            resources = task.resources
+            if namespace == 'kube-system' and resources == ['configmaps', 'roles.rbac.authorization.k8s.io']:
+                download_stub(temp_local_filepath, dedent(
+                    '''\
+                    apiVersion: v1
+                    items:
+                    - apiVersion: v1
+                      data:
+                        key: =
+                      kind: ConfigMap
+                      metadata:
+                        name: calico-config
+                    - apiVersion: v1
+                      data:
+                        Corefile: |
+                          .:53 {
+                          }
+                        Hosts: |
+                          127.0.0.1 localhost localhost.localdomain
+                    
+                          10.101.2.1  k8s.fake.local control-plain
+                      kind: ConfigMap
+                      metadata:
+                        name: coredns
+                    - apiVersion: rbac.authorization.k8s.io/v1
+                      kind: Role
+                      metadata:
+                        name: kube-proxy
+                      rules: []
+                    kind: List
+                    metadata:
+                      resourceVersion: ""
+                    '''
+                ))
+            elif namespace == 'default' and resources == ['configmaps', 'roles.rbac.authorization.k8s.io']:
+                download_stub(temp_local_filepath, '')
+            elif namespace is None and resources == ['namespaces', 'nodes']:
+                download_stub(temp_local_filepath, dedent(
+                    '''\
+                    apiVersion: v1
+                    items:
+                    - apiVersion: v1
+                      kind: Node
+                      metadata:
+                        name: control-plane-1
+                    kind: List
+                    metadata:
+                      resourceVersion: ""
+                    '''
+                ))
+            else:
+                raise Exception(f"Unexpected resources {resources} to download for namespace {namespace}")
+
+        with mock.patch.object(backup.ExportKubernetesDownloader, download_orig.__name__,
+                               new=download_mocked):
+            yield
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_backup.py
+++ b/test/unit/test_backup.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2023 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import gzip
 import logging
 import tempfile

--- a/test/unit/test_backup.py
+++ b/test/unit/test_backup.py
@@ -68,7 +68,7 @@ class TestBackupTasks(unittest.TestCase):
             self._run()
 
         descriptor = self.resources.last_cluster.context['backup_descriptor']['kubernetes']['resources']
-        self.assertEqual({'kube-system': ['configmaps', 'roles.rbac.authorization.k8s.io']},
+        self.assertEqual({'kube-system': ['configmaps', 'configmaps.example.com', 'roles.rbac.authorization.k8s.io']},
                          descriptor.get('namespaced'),
                          "Not expected resulting list of namespaced resources")
         self.assertEqual(['nodes'], descriptor.get('nonnamespaced'),
@@ -77,6 +77,7 @@ class TestBackupTasks(unittest.TestCase):
         resources_path = Path(self.tmpdir.name) / 'dump' / 'backup' / 'kubernetes_resources'
         actual_files = {str(p.relative_to(resources_path)) for p in resources_path.glob("**/*.yaml")}
         expected_files = {str(Path(p)) for p in ['nodes.yaml', 'kube-system/configmaps.yaml',
+                                                 'kube-system/configmaps.example.com.yaml',
                                                  'kube-system/roles.rbac.authorization.k8s.io.yaml']}
         self.assertEqual(expected_files, actual_files, "Not expected list of files")
 
@@ -93,7 +94,7 @@ class TestBackupTasks(unittest.TestCase):
               resourceVersion: ""
             '''
         ))
-        actual_content = self._parse_yaml(utils.read_internal(str(resources_path / 'nodes.yaml')))
+        actual_content = self._parse_yaml(utils.read_external(str(resources_path / 'nodes.yaml')))
         self.assertEqual(expected_context, actual_content,
                          f"Data in file 'nodes.yaml' is not expected")
 
@@ -124,13 +125,33 @@ class TestBackupTasks(unittest.TestCase):
               resourceVersion: ""
             '''
         ))
-        actual_content = self._parse_yaml(utils.read_internal(str(resources_path / 'kube-system/configmaps.yaml')))
+        actual_content = self._parse_yaml(utils.read_external(str(resources_path / 'kube-system/configmaps.yaml')))
         expected_special_symbol = expected_context['items'][0]['data'].pop('key')
         actual_special_symbol = actual_content['items'][0]['data'].pop('key')
         self.assertEqual(expected_special_symbol.value, actual_special_symbol.value,
                          "Failed to compare special TaggedScalar")
         self.assertEqual(expected_context, actual_content,
                          f"Data in file 'kube-system/configmaps.yaml' is not expected")
+
+        expected_context = self._parse_yaml(dedent(
+            '''\
+            apiVersion: v1
+            items:
+            - apiVersion: example.com/v1
+              data:
+                key: value
+              kind: ConfigMap
+              metadata:
+                name: example-configmap
+            kind: List
+            metadata:
+              resourceVersion: ""
+            '''
+        ))
+        actual_content = self._parse_yaml(utils.read_external(
+            str(resources_path / 'kube-system/configmaps.example.com.yaml')))
+        self.assertEqual(expected_context, actual_content,
+                         f"Data in file 'kube-system/configmaps.example.com.yaml' is not expected")
 
         expected_context = self._parse_yaml(dedent(
             '''\
@@ -146,7 +167,8 @@ class TestBackupTasks(unittest.TestCase):
               resourceVersion: ""
             '''
         ))
-        actual_content = self._parse_yaml(utils.read_internal(str(resources_path / 'kube-system/roles.rbac.authorization.k8s.io.yaml')))
+        actual_content = self._parse_yaml(utils.read_external(
+            str(resources_path / 'kube-system/roles.rbac.authorization.k8s.io.yaml')))
         self.assertEqual(expected_context, actual_content,
                          f"Data in file 'kube-system/roles.rbac.authorization.k8s.io.yaml' is not expected")
 
@@ -163,6 +185,7 @@ class TestBackupTasks(unittest.TestCase):
             '''\
             NAME         SHORTNAMES   APIVERSION                     NAMESPACED   KIND
             configmaps   cm           v1                             true         ConfigMap
+            configmaps                example.com/v1                 true         ConfigMap
             events       ev           v1                             true         Event
             events       ev           events.k8s.io/v1               true         Event
             roles                     rbac.authorization.k8s.io/v1   true         Role
@@ -192,7 +215,8 @@ class TestBackupTasks(unittest.TestCase):
         def download_mocked(_, task: backup.DownloaderPayload, temp_local_filepath: str) -> None:
             namespace = task.namespace
             resources = task.resources
-            if namespace == 'kube-system' and resources == ['configmaps', 'roles.rbac.authorization.k8s.io']:
+            if namespace == 'kube-system' and resources == ['configmaps', 'configmaps.example.com',
+                                                            'roles.rbac.authorization.k8s.io']:
                 download_stub(temp_local_filepath, dedent(
                     '''\
                     apiVersion: v1
@@ -215,6 +239,12 @@ class TestBackupTasks(unittest.TestCase):
                       kind: ConfigMap
                       metadata:
                         name: coredns
+                    - apiVersion: example.com/v1
+                      data:
+                        key: value
+                      kind: ConfigMap
+                      metadata:
+                        name: example-configmap
                     - apiVersion: rbac.authorization.k8s.io/v1
                       kind: Role
                       metadata:
@@ -225,7 +255,8 @@ class TestBackupTasks(unittest.TestCase):
                       resourceVersion: ""
                     '''
                 ))
-            elif namespace == 'default' and resources == ['configmaps', 'roles.rbac.authorization.k8s.io']:
+            elif namespace == 'default' and resources == ['configmaps', 'configmaps.example.com',
+                                                          'roles.rbac.authorization.k8s.io']:
                 download_stub(temp_local_filepath, '')
             elif namespace is None and resources == ['namespaces', 'nodes']:
                 download_stub(temp_local_filepath, dedent(


### PR DESCRIPTION
### Description
* `export.kubernetes` task of `backup` procedure works long.

### Solution
* Use one `kubectl` invocation to get all resources for the particular namespace, instead of multiple `kubectl && kubectl` invocations.
    * Implement custom parsing of the resulting yaml list to split resources of different kinds into different files.
* Use 2 background tasks for all available control planes to invoke few `kubectl` commands in parallel.
* Use `gzip` to compress data before sending through the network.
* Use dedicated parsing background task to ensure that only one thread loads the data in memory.

### Test Cases

**TestCase 1**

1. Run `backup` or `backup --tasks export.kubernetes,pack` on large cluster

ER: elapsed time for the `export.kubernetes` task decreases 10 times or more.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_backup.py - added test for `export.kubernetes` task.