### PR TITLE
CPDEV-91439 Work around broken pip installation on GitHub macos11 VM

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,17 @@ jobs:
           name: package
           path: ./dist
 
+      - name: Fix broken pip installation
+        if: ${{ matrix.target.os == 'macos-11' }}
+        run: |
+          SITE_PACKAGES="/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages"
+          PIP_VERSION=$(cat $SITE_PACKAGES/pip/__init__.py | grep __version__ | sed 's/["=]//g' | awk '{print $2}')
+          for dist_info in $(find $SITE_PACKAGES -name 'pip-*.dist-info'); do
+              if [[ $(basename "$dist_info") != "pip-$PIP_VERSION.dist-info" ]]; then
+                  echo "Removing broken pip installation $dist_info"
+                  rm -rf $dist_info
+              fi
+          done
       - name: Build
         run: ${{ matrix.build_cmd }}
       - name: Run Selftest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,7 @@ jobs:
           name: package
           path: ./dist
 
+      # Remove the step after https://github.com/actions/setup-python/issues/713 is solved
       - name: Fix broken pip installation
         if: ${{ matrix.target.os == 'macos-11' }}
         run: |


### PR DESCRIPTION
### Description
* Binary build on macos11 sometimes fails with `AssertionError: The script relies on internal implementation of pip and was tested on pip==23.0. To support pip==23.2.1, the script should be manually adopted.`, but we have explicit installation of `pip install pip==23.0` one step before.
* Root cause is in incorrect pip installation. `find /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages -name 'pip-*.dist-info'` shows two versions of the package:
    ```
    /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pip-23.1.2.dist-info
    /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pip-23.2.1.dist-info
    ```
    https://github.com/actions/setup-python/issues/713

### Solution
* Add step to remove orphaned installation.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
