### PR TITLE
[CPDEV-91646] Fixes and improvements of Kubernetes audit policy maintenance

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -5239,7 +5239,7 @@ The following is the installation tasks tree:
     * **install** - Configures Kubernetes service in the file `/etc/systemd/system/kubelet.service`
     * **prepull_images** - Prepulls Kubernetes images on all nodes using parameters from the inventory.
     * **init** - Initializes Kubernetes nodes via kubeadm with config files: `/etc/kubernetes/init-config.yaml` and `/etc/kubernetes/join-config.yaml`. For more information about parameters for this task, see [kubeadm](#kubeadm). Also apply PSS if it is enabled. For more information about PPS, see [Admission pss](#admission-pss).
-    * **audit** - Configures Kubernetes audit rules. For more information about parameters for this task, see [audit-Kubernetes Policy](#audit-Kubernetes-Policy)
+    * **audit** - Configures Kubernetes audit rules. For more information about parameters for this task, see [audit-Kubernetes Policy](#audit-Kubernetes-Policy).
   * **admission** - Applies OOB and custom pod security policies. For more information about the parameters for this task, see [Admission psp](#admission-psp).
   * **coredns** - Configures CoreDNS service with [coredns](#coredns) inventory settings.
   * **plugins** - Applies plugin installation procedures. For more information about parameters for this task, see [Plugins](#plugins).

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2502,7 +2502,7 @@ services:
 
 ##### Audit Kubernetes Policy
 
-*Installation task*: `prepare.system.audit.configure_policy`
+*Installation task*: `deploy.kubernetes.audit`
 
 *Can cause reboot*: No
 
@@ -2593,7 +2593,7 @@ services:
 
 *Installation tasks*:
 * `prepare.system.audit.install`
-* `prepare.system.audit.configure_daemon`
+* `prepare.system.audit.configure`
 
 *Can cause reboot*: No
 
@@ -5220,9 +5220,7 @@ The following is the installation tasks tree:
     * **sysctl** - Configures Linux Kernel parameters. For more information about parameters for this task, see [sysctl](#sysctl).
     * **audit**
       * **install** - Installs auditd daemon on nodes.
-      * **configure_daemon** - Configures Linux audit rules. For more information about parameters for this task, see [audit-daemon](#audit-daemon).
-      * **configure_policy** - Configures Kubernetes audit rules. For more information about parameters for this task, see [audit-Kubernetes Policy](#audit-Kubernetes-Policy)
-      
+      * **configure** - Configures Linux audit rules. For more information about parameters for this task, see [audit-daemon](#audit-daemon).
 
   * **cri**
     * **install** - Installs the container runtime. For more information about parameters for this task, see [CRI](#cri).
@@ -5241,6 +5239,7 @@ The following is the installation tasks tree:
     * **install** - Configures Kubernetes service in the file `/etc/systemd/system/kubelet.service`
     * **prepull_images** - Prepulls Kubernetes images on all nodes using parameters from the inventory.
     * **init** - Initializes Kubernetes nodes via kubeadm with config files: `/etc/kubernetes/init-config.yaml` and `/etc/kubernetes/join-config.yaml`. For more information about parameters for this task, see [kubeadm](#kubeadm). Also apply PSS if it is enabled. For more information about PPS, see [Admission pss](#admission-pss).
+    * **audit** - Configures Kubernetes audit rules. For more information about parameters for this task, see [audit-Kubernetes Policy](#audit-Kubernetes-Policy)
   * **admission** - Applies OOB and custom pod security policies. For more information about the parameters for this task, see [Admission psp](#admission-psp).
   * **coredns** - Configures CoreDNS service with [coredns](#coredns) inventory settings.
   * **plugins** - Applies plugin installation procedures. For more information about parameters for this task, see [Plugins](#plugins).

--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -54,6 +54,7 @@ This section provides information about the Kubecheck functionality.
       - [211 Nodes Condition - DiskPressure](#211-nodes-condition---diskpressure)
       - [211 Nodes Condition - PIDPressure](#211-nodes-condition---pidpressure)
       - [211 Nodes Condition - Ready](#211-nodes-condition---ready)
+    - [212 Thirdparties Hashes](#212-thirdparties-hashes)
     - [213 Selinux security policy](#213-selinux-security-policy)
     - [214 Selinux configuration](#214-selinux-configuration)
     - [215 Firewalld status](#215-firewalld-status)
@@ -70,6 +71,7 @@ This section provides information about the Kubecheck functionality.
     - [226 Geo connectivity status](#226-geo-connectivity-status)
     - [227 Apparmor status](#227-apparmor-status)
     - [228 Apparmor configuration](#228-apparmor-configuration)
+    - [229 Audit policy configuration](#229-audit-policy-configuration)
 - [Report File Generation](#report-file-generation)
   - [HTML Report](#html-report)
   - [CSV Report](#csv-report)
@@ -387,6 +389,8 @@ The task tree is as follows:
       * disk
       * pid
       * ready
+  * audit
+    * policy
   * admission
 * etcd
   * health_status
@@ -666,6 +670,13 @@ The test checks the status of AppArmor. It should be `enabled` by default.
 *Task*: `services.security.apparmor.config`
 
 The test checks the AppArmor configuration. It has several modes: `enforce`, `complain`, and `disable`. The profiles (resources) stick to one of the modes. The `cluster.yaml` may incude only part of the profiles.
+
+###### 229 Audit policy configuration
+
+*Task*: `kubernetes.audit.policy`
+
+This test checks that the configuration of Kubernetes audit policy is actual
+and matches the effectively resolved configuration from the inventory.
 
 ### Report File Generation
 

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -24,10 +24,12 @@ from typing import List
 from kubemarine.core.patch import Patch
 from kubemarine.patches.p1_replace_podman_to_ctr import ReplacePodmanToCtr
 from kubemarine.patches.p2_inventory_plugins_resources import PluginsResourcesPatch
+from kubemarine.patches.p4_reconfigure_audit_policy import ReconfigureAuditPolicy
 
 patches: List[Patch] = [
   ReplacePodmanToCtr(),
   PluginsResourcesPatch(),
+  ReconfigureAuditPolicy(),
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/p4_reconfigure_audit_policy.py
+++ b/kubemarine/patches/p4_reconfigure_audit_policy.py
@@ -1,0 +1,35 @@
+from textwrap import dedent
+
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine.procedures import install
+
+
+class TheAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Reconfigure Kubernetes audit policy")
+
+    def run(self, res: DynamicResources) -> None:
+        install.run_tasks(res, ['deploy.kubernetes.audit'])
+
+
+class ReconfigureAuditPolicy(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("reconfigure_audit_policy")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            Reconfigure Kubernetes audit policy.
+            To find new default target configuration, refer to kubemarine/resources/configurations/defaults.yaml
+            - services.kubeadm.apiServer.extraArgs.audit-*
+            - services.audit.cluster_policy
+            The patch is equivalent to `kubemarine install --tasks deploy.kubernetes.audit`.
+            """.rstrip()
+        )

--- a/kubemarine/patches/p4_reconfigure_audit_policy.py
+++ b/kubemarine/patches/p4_reconfigure_audit_policy.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2023 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from textwrap import dedent
 
 from kubemarine.core.action import Action

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -156,7 +156,6 @@ tasks = OrderedDict({
     "verify_upgrade_versions": kubernetes.verify_upgrade_versions,
     "thirdparties": system_prepare_thirdparties,
     "prepull_images": prepull_images,
-    "configure_policy": install.system_prepare_policy,
     "kubernetes": kubernetes_upgrade,
     "kubernetes_cleanup": kubernetes_cleanup_nodes_versions,
     "packages": upgrade_packages,


### PR DESCRIPTION
### Description
* We use not recommended `--config` option during kubeadm upgrade. This leads to incorrect upgrade in some cases when etcd, kube-apiserver become bound to incorrect IP.
* `prepare.system.audit.configure_policy` installation task reconfigures api-server and goes before Kubernetes reset. This makes it impossible to re-install the cluster over the existing one in some cases, because api-server cannot start.
* `configure_policy` task of upgrade procedure is redundant as the audit configuration does not depend on the Kubernetes version. It also performs partial upgrade of api-server component only that leads to undefined behaviour in some cases.

Fixes #456
Fixes #213

### Solution
* Do not change audit policy configuration during the upgrade. Instead, create patch that will configure audit policy once to install historical changes in Kubemarine defaults.
* Do not use `--config` option during upgrade.
* Move  `prepare.system.audit.configure_policy` installation task to `deploy.kubernetes.audit` that goes after `deploy.kubernetes.init`. If called during cluster installation, it just does nothing as the policy is already configured during the `init`. If called separately using `install --tasks deploy.kubernetes.audit` it reconfigures the policy and restarts the api-server.
* Implement PaaS check of Kubernetes audit policy configuration.

### How to apply
Run `kubemarine migrate_kubemarine --force-apply reconfigure_audit_policy`.

### Test Cases

**TestCase 1**

Upgrade public cluster with few networks.

1. Create VM using VirtualBox and two network adapters: NAT and Host-only.
2. Install Kubernetes v1.24.2 in All-in-one scheme (master and worker only), and internal_address = IP from Host-only adapter.

ER=AR: etcd and kube-apiserver are bound to IP from Host-only adapter.

3. Upgrade to v1.25.2

| Before | After |
| ------ | ------ |
| etcd and kube-apiserver try to bind to IP from NAT and upgrade fails. | Upgrade succeeds. |

**TestCase 2**

Re-installation with different api-server configuration.

1. Install Kubernetes v1.24.2 with disabled PSS
2. Enable PSS in the inventory and install the cluster again.

| Before | After |
| ------ | ------ |
| `prepare.system.audit.configure_policy` because reconfigured api-server refers to not yet existing admission.yaml. | The cluster is re-installed. |

**TestCase 3**

Regression testing and migration of old clusters.

1. Install Kubernetes v1.23.1 using old Kubemarine **0.1.12**

Now use only **new** Kubemarine.

2. Run `check_paas`

ER: Task `kubernetes.audit.policy` fails.

3. Run `kubemarine migrate_kubemarine --force-apply reconfigure_audit_policy`
4. Run `check_paas`

ER: Task `kubernetes.audit.policy` succeeds.

5. Upgrade to v1.24.2.

ER: Upgrade succeeds.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
