### PR TITLE
[CPDEV-91748][CPDEV-91752] Fix procedure install and delete PSS for Kubernetes v1.28

### DIFF
--- a/kubemarine/admission.py
+++ b/kubemarine/admission.py
@@ -696,7 +696,7 @@ def update_kubeapi_config_pss(control_planes: NodeGroup, features_list: str) -> 
 
     for control_plane in control_planes.get_ordered_members_list():
         result = control_plane.sudo("cat /etc/kubernetes/manifests/kube-apiserver.yaml")
-        minor_version = int(result.cluster.inventory['services']['kubeadm']['kubernetesVersion'].split('.')[1])
+        minor_version = int(control_plane.cluster.inventory['services']['kubeadm']['kubernetesVersion'].split('.')[1])
         # update kube-apiserver config with updated features list or delete '--feature-gates' and '--admission-control-config-file'
         conf = yaml.load(list(result.values())[0].stdout)
         new_command = [cmd for cmd in conf["spec"]["containers"][0]["command"]]

--- a/kubemarine/admission.py
+++ b/kubemarine/admission.py
@@ -787,15 +787,6 @@ def update_kubeadm_configmap_pss(first_control_plane: NodeGroup, target_state: s
             else:
                 del cluster_config["apiServer"]["extraArgs"]["admission-control-config-file"]
 
-
-
-
-
-
-
-
-
-
     buf = io.StringIO()
     yaml.dump(cluster_config, buf)
     kubeadm_cm["data"]["ClusterConfiguration"] = buf.getvalue()

--- a/kubemarine/admission.py
+++ b/kubemarine/admission.py
@@ -696,16 +696,19 @@ def update_kubeapi_config_pss(control_planes: NodeGroup, features_list: str) -> 
 
     for control_plane in control_planes.get_ordered_members_list():
         result = control_plane.sudo("cat /etc/kubernetes/manifests/kube-apiserver.yaml")
-
+        minor_version = int(result.cluster.inventory['services']['kubeadm']['kubernetesVersion'].split('.')[1])
         # update kube-apiserver config with updated features list or delete '--feature-gates' and '--admission-control-config-file'
         conf = yaml.load(list(result.values())[0].stdout)
         new_command = [cmd for cmd in conf["spec"]["containers"][0]["command"]]
         if len(features_list) != 0:
-            if 'PodSecurity=true' in features_list:
-                new_command.append("--admission-control-config-file=%s" % admission_path)
+            if minor_version <= 27:
+                if 'PodSecurity=true' in features_list:
+                    new_command.append("--admission-control-config-file=%s" % admission_path)
+                else:
+                    new_command.append("--admission-control-config-file=''")
+                new_command.append("--feature-gates=%s" % features_list)
             else:
-                new_command.append("--admission-control-config-file=''")
-            new_command.append("--feature-gates=%s" % features_list)
+                new_command.append("--admission-control-config-file=%s" % admission_path)
         else:
             for item in conf["spec"]["containers"][0]["command"]:
                 if item.startswith("--"):
@@ -765,14 +768,33 @@ def update_kubeadm_configmap_pss(first_control_plane: NodeGroup, target_state: s
             cluster_config["apiServer"]["extraArgs"]["admission-control-config-file"] = admission_path
             final_feature_list = "PodSecurity deprecated in %s" % cluster_config['kubernetesVersion']
     elif target_state == "disabled":
-        feature_list = cluster_config["apiServer"]["extraArgs"]["feature-gates"].replace("PodSecurity=true", "")
-        final_feature_list = feature_list.replace(",,", ",")
-        if len(final_feature_list) == 0:
-            del cluster_config["apiServer"]["extraArgs"]["feature-gates"]
-            del cluster_config["apiServer"]["extraArgs"]["admission-control-config-file"]
+        if minor_version <= 27:
+            feature_list = cluster_config["apiServer"]["extraArgs"]["feature-gates"].replace("PodSecurity=true", "")
+            final_feature_list = feature_list.replace(",,", ",")
+            if len(final_feature_list) == 0:
+                del cluster_config["apiServer"]["extraArgs"]["feature-gates"]
+                del cluster_config["apiServer"]["extraArgs"]["admission-control-config-file"]
+            else:
+                cluster_config["apiServer"]["extraArgs"]["feature-gates"] = final_feature_list
+                del cluster_config["apiServer"]["extraArgs"]["admission-control-config-file"]
         else:
-            cluster_config["apiServer"]["extraArgs"]["feature-gates"] = final_feature_list
-            del cluster_config["apiServer"]["extraArgs"]["admission-control-config-file"]
+            if cluster_config["apiServer"]["extraArgs"].get("feature-gates"):
+                if len(cluster_config["apiServer"]["extraArgs"]["feature-gates"]) == 0:
+                    del cluster_config["apiServer"]["extraArgs"]["feature-gates"]
+                    del cluster_config["apiServer"]["extraArgs"]["admission-control-config-file"]
+                else:
+                    del cluster_config["apiServer"]["extraArgs"]["admission-control-config-file"]
+            else:
+                del cluster_config["apiServer"]["extraArgs"]["admission-control-config-file"]
+
+
+
+
+
+
+
+
+
 
     buf = io.StringIO()
     yaml.dump(cluster_config, buf)


### PR DESCRIPTION
### Description
* After adding a new version of kubernetes 1.28, it is necessary to correct the operation of the `manager_pss` procedure for the correct operation of the new version of kubernetes, since the `PODsecurity` argument for `kube-apiserver` was set in the new version of kubernetes.
* More information about this problem in https://github.com/kubernetes/kubernetes/pull/114068 or https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md

Fixes # (issue)
CPDEV-91748
CPDEV-91752

### Solution
* The procedure for installing and removing PSS for a cluster on kubernetes 1.28 has been redesigned

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


