### PR TITLE
Add proxy protocol issue in troubleshooting guide

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -75,6 +75,17 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: kubemarine check_paas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_paas_dump/
+      - name: Check ingress connectivity
+        run: |
+          sudo echo "172.17.0.1 dashboard.test-local-k8s.com" | sudo tee -a /etc/hosts
+          http_code=$(curl -s -o /dev/null -I -w "%{http_code}" -k https://dashboard.test-local-k8s.com)
+          echo "Dashboard status code: $http_code"
+          if [[ $http_code == "200" ]]; then
+            echo "Connectivity check passed"
+          else
+            echo "Connectivity check failed"
+          exit 1
+          fi
       - name: Collect journalctl logs
         if: failure()
         run: |

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -134,6 +134,16 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: kubemarine check_paas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_paas_dump/
+      - name: Check ingress connectivity
+        run: |
+          http_code=$(curl -s -o /dev/null -I -w "%{http_code}" -k https://dashboard.test-local-k8s.com)
+          echo "Dashboard status code: $http_code"
+          if [[ $http_code == "200" ]]; then
+            echo "Connectivity check passed"
+          else
+            echo "Connectivity check failed"
+          exit 1
+          fi
       - name: Get events kubectl
         if: failure()
         run: kubectl get events --sort-by='.metadata.creationTimestamp' -A

--- a/ci/default_cluster.yaml
+++ b/ci/default_cluster.yaml
@@ -21,6 +21,8 @@ plugins:
 
   nginx-ingress-controller:
     install: true
+    config_map:
+      use-proxy-protocol: "false"
 
   kubernetes-dashboard:
     install: true

--- a/ci/extended_cluster.yaml
+++ b/ci/extended_cluster.yaml
@@ -30,6 +30,8 @@ plugins:
     install: true
   nginx-ingress-controller:
     install: true
+    config_map:
+      use-proxy-protocol: "false"
     controller:
       nodeSelector:
         test-label: label

--- a/ci/extended_cluster.yaml
+++ b/ci/extended_cluster.yaml
@@ -21,6 +21,9 @@ services:
     - ethtool
     - ebtables
     - socat
+  etc_hosts:
+    172.17.1.1:
+      - dashboard.test-local-k8s.com
 
 plugins:
   kubernetes-dashboard:

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -715,6 +715,26 @@ and restart etcd:
 
 13. If necessary, remove backup files create at the step 3.
 
+## Ingress Doesn't Work with proxy
+
+**Symptoms**: 
+  * Requests using ingresses fails with `Empty reply from server` error for http or SSL error for https. Using `--haproxy-protocol` option in curl tool fixes your problem;
+  * Following errors exists in ingress-nginx-controller pod logs: `broken header: "<...>" while reading PROXY protocol, client: <...>, server: <...>`
+
+**Root cause**: `ingress-nginx-controller` works in proxy mode, but incoming requests don't apply it. Proxy protocol is applied to requests in load-balancers. For this reason such issue may occur in the following cases:
+  * You don't use balancers and take requests directly to some node (e.g. all-in-one setup);
+  * You use external load-balancers, that don't apply proxy protocol;
+  * You have balancer node, which `balancer` role is combined with others and your request don't pass through HAProxy. It will be fixed in KubeMarine soon.
+
+**Solution**: Redeploy `ingress-nginx-controller` plugin with disabled proxy-protocol:
+```yaml
+plugins:
+  nginx-ingress-controller:
+    install: true
+    config_map:
+      use-proxy-protocol: "false"
+```
+Or, if you use external load-balancer, you can enable proxy protocol from its site.
 
 ## HTTPS Ingress Doesn't Work
 


### PR DESCRIPTION
### Description
According issue https://github.com/Netcracker/KubeMarine/issues/496, in some cases, proxy protocol should be disabled.

Fixes # (issue)


### Solution
* Added section in troubleshooting guide with proxy protocol section. There are described a possible cases, when such problem can appear, and possible solutions.
* Added connectivity checks to default and extended ci installation, to handle ingresses problem in future;
* To make connectivity check work, added proxy protocol disabling in tests;



### Test Cases

**TestCase 1**

Test Configuration: 

- Hardware: 
- OS: 
- Inventory: all-in-one without balancers;

Steps:

1. Run `kubemarine install`;

Results:

| with proxy protocol enabled | with proxy protocol disabled |
| ------ | ------ |
| ingress connectivity failed | ingress connectivity passed |

**TestCase 2**

Test Configuration: 

- Hardware: 
- OS: 
- Inventory: miniha scheme (balancer, combined with other roles);

Steps:

1. Run `kubemarine install`;

Results:

| with proxy protocol enabled | with proxy protocol disabled |
| ------ | ------ |
| ingress connectivity failed | ingress connectivity passed |

**TestCase 3**

Test Configuration: 

- Hardware: 
- OS: 
- Inventory: fullha scheme (separate balancers);

Steps:

1. Run `kubemarine install`;

Results:

| with proxy protocol enabled | with proxy protocol disabled |
| ------ | ------ |
| ingress connectivity passed | ingress connectivity failed |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


