### PR TITLE
[CPDEV-91812] Upgrade to 1.28.0 procedure fails - KeyError: 'feature-gates'

### DIFF
--- a/kubemarine/admission.py
+++ b/kubemarine/admission.py
@@ -713,7 +713,8 @@ def update_kubeapi_config_pss(control_planes: NodeGroup, features_list: str) -> 
             else:
                 new_command.append("--admission-control-config-file=%s" % admission_path)
                 if control_plane.cluster.context['initial_procedure'] == 'upgrade':
-                    new_command.remove("--feature-gates=PodSecurity=true")
+                    if any(argument in "--feature-gates=PodSecurity=true" for argument in new_command):
+                        new_command.remove("--feature-gates=PodSecurity=true")
         else:
             for item in conf["spec"]["containers"][0]["command"]:
                 if item.startswith("--"):
@@ -775,7 +776,8 @@ def update_kubeadm_configmap_pss(first_control_plane: NodeGroup, target_state: s
         else:
             cluster_config["apiServer"]["extraArgs"]["admission-control-config-file"] = admission_path
             if first_control_plane.cluster.context['initial_procedure'] == 'upgrade':
-                del cluster_config["apiServer"]["extraArgs"]["feature-gates"]
+                if cluster_config["apiServer"]["extraArgs"].get("feature-gates"):
+                    del cluster_config["apiServer"]["extraArgs"]["feature-gates"]
             final_feature_list = "PodSecurity deprecated in %s" % cluster_config['kubernetesVersion']
     elif target_state == "disabled":
         if minor_version <= 27:

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -51,7 +51,7 @@ def kubernetes_upgrade(cluster: KubernetesCluster) -> None:
     minor_version = int(cluster.context['upgrade_version'].split('.')[1])
 
     upgrade_group = kubernetes.get_group_for_upgrade(cluster)
-    if minor_version >= 28:
+    if minor_version >= 28 and cluster.inventory['rbac']['pss']['pod-security'] == 'enabled':
         first_control_plane = cluster.nodes["control-plane"].get_first_member()
 
         cluster.log.debug("Updating kubeadm config map")


### PR DESCRIPTION
### Description
* In the new version of kubernetes(1.28), the `PODsecurity` argument for kube-apiserver has been deprecated and removed in new versions.
* More information about this problem in https://github.com/kubernetes/kubernetes/pull/114068 or https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md
* When updating from kubernetes version 1.27 to version 1.28 with the feature-gates argument removed, the update failed with the error `"KeyError: 'feature-gates'"`.
* It is necessary to add a check for the presence of this argument before the update procedure.

Fixes # (issue)
[CPDEV-91812]

### Solution
* Added a new check for the presence of the feature-gates parameter before upgrading to kubernetes version 1.28

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


