### PR TITLE
[CPDEV-92550] - add patch for proxy protocol enabling

### DIFF
--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -22,8 +22,10 @@ The whole directory is automatically cleared and reset after new version of Kube
 from typing import List
 
 from kubemarine.core.patch import Patch
+from kubemarine.patches.p1_enable_proxy_protocol import EnableProxyProtocol
 
 patches: List[Patch] = [
+    EnableProxyProtocol()
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/p1_enable_proxy_protocol.py
+++ b/kubemarine/patches/p1_enable_proxy_protocol.py
@@ -1,0 +1,58 @@
+# Copyright 2021-2023 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from textwrap import dedent
+
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine.procedures.install import deploy_loadbalancer_haproxy_configure
+from kubemarine import plugins
+
+
+class TheAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Enable proxy protocol")
+
+    def run(self, res: DynamicResources) -> None:
+        cluster = res.cluster()
+        cluster.log.info("Reconfigure haproxy")
+        deploy_loadbalancer_haproxy_configure(cluster)
+
+        ingress_nginx_plugin = cluster.inventory['plugins']['nginx-ingress-controller']
+        if not ingress_nginx_plugin.get('install', False) \
+                or ingress_nginx_plugin.get('installation', {}).get('procedures') is None:
+            cluster.log.info("nginx-ingress-controller plugin is disabled or its procedures aren't defined")
+            return
+
+        cluster.log.info(f"nginx-ingress-controller will be reinstalled")
+        plugins.install_plugin(cluster, 'nginx-ingress-controller', ingress_nginx_plugin['installation']['procedures'])
+
+
+class EnableProxyProtocol(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("enable_proxy_protocol")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            This patch enables proxy protocol and ingress-nginx and haproxy (by default it's enabled by kubemarine):
+            1. Reconfigure HAProxy
+            2. Redeploy ingress-nginx patch
+            """.rstrip()
+        )


### PR DESCRIPTION
### Description
On PR https://github.com/Netcracker/KubeMarine/pull/479/files we forgot to provide a patch to reconfigure haproxy.
As result, when ingress-nginx-controller is redeployed for some reason (e.g. during upgrade procedure), it starts waiting proxy-protocol in requests, but haproxy continues working without proxy, and requests fail.

### Solution
Added missed patch


### How to apply
* Install old kubemarine version, where proxy-protocol is disabled (e.g. v0.19.0).
* Redeploy ingress-nginx-controller with new kubemarine version.


### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: fullha +proxy-protocol is not disabled in cluster.yaml

Steps:

1. `kubemarine install` v1.26.3 kuber version using old kubemarine version, where proxy-protocol is disabled (e.g. v0.19.0);
2. `kubemarine migrate_kubemarine` to migrate to the newest kubemarine version;
3. `kubemarine upgrade` to v1.26.4 kuber version (to reinstall ingress-nginx-controller);
4. Do curl request to some ingress endpoint (e.g. to kubernetes-dashboard);

Results:

| Before | After |
| ------ | ------ |
| curl request works only with `--haproxy-protocol` option (like miniha case) | curl request works without `--haproxy-protocol` |
| no `send-proxy` options in haproxy configuration | haproxy reconfigured with `send-proxy` for backend 80/443 ports |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


