### PR TITLE
CPDEV-93439 Cannot enable PSS without calico-apiserver

### DIFF
--- a/kubemarine/plugins/calico.py
+++ b/kubemarine/plugins/calico.py
@@ -418,12 +418,11 @@ class CalicoApiServerManifestProcessor(Processor):
             self.enrich_clusterrole_calico_crds,
         ]
 
+    def get_namespace_to_necessary_pss_profiles(self) -> Dict[str, str]:
+        return {'calico-apiserver': 'baseline'}
+
     def enrich_namespace_calico_apiserver(self, manifest: Manifest) -> None:
-        key = "Namespace_calico-apiserver"
-        rbac = self.inventory['rbac']
-        if rbac['admission'] == 'pss' and rbac['pss']['pod-security'] == 'enabled' \
-                and rbac['pss']['defaults']['enforce'] == 'restricted':
-            self.assign_default_pss_labels(manifest, key, 'baseline')
+        self.assign_default_pss_labels(manifest, 'calico-apiserver')
 
     def enrich_deployment_calico_apiserver(self, manifest: Manifest) -> None:
         key = "Deployment_calico-apiserver"

--- a/kubemarine/plugins/kubernetes_dashboard.py
+++ b/kubemarine/plugins/kubernetes_dashboard.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 from kubemarine.core import summary, utils, log
 from kubemarine.core.cluster import KubernetesCluster
@@ -70,12 +70,11 @@ class DashboardManifestProcessor(Processor):
             self.enrich_deployment_dashboard_metrics_scraper,
         ]
 
+    def get_namespace_to_necessary_pss_profiles(self) -> Dict[str, str]:
+        return {'kubernetes-dashboard': 'baseline'}
+
     def enrich_namespace_kubernetes_dashboard(self, manifest: Manifest) -> None:
-        key = "Namespace_kubernetes-dashboard"
-        rbac = self.inventory['rbac']
-        if rbac['admission'] == 'pss' and rbac['pss']['pod-security'] == 'enabled' \
-                and rbac['pss']['defaults']['enforce'] == 'restricted':
-            self.assign_default_pss_labels(manifest, key, 'baseline')
+        self.assign_default_pss_labels(manifest, 'kubernetes-dashboard')
 
     def enrich_deployment_kubernetes_dashboard(self, manifest: Manifest) -> None:
         key = "Deployment_kubernetes-dashboard"

--- a/kubemarine/plugins/local_path_provisioner.py
+++ b/kubemarine/plugins/local_path_provisioner.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from textwrap import dedent
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 import yaml
 
@@ -59,12 +59,11 @@ class LocalPathProvisionerManifestProcessor(Processor):
             self.enrich_configmap_local_path_config,
         ]
 
+    def get_namespace_to_necessary_pss_profiles(self) -> Dict[str, str]:
+        return {'local-path-storage': 'privileged'}
+
     def enrich_namespace_local_path_storage(self, manifest: Manifest) -> None:
-        key = "Namespace_local-path-storage"
-        rbac = self.inventory['rbac']
-        if rbac['admission'] == 'pss' and rbac['pss']['pod-security'] == 'enabled' \
-                and rbac['pss']['defaults']['enforce'] != 'privileged':
-            self.assign_default_pss_labels(manifest, key, 'privileged')
+        self.assign_default_pss_labels(manifest, 'local-path-storage')
 
     def add_clusterrolebinding_local_path_provisioner_privileged_psp(self, manifest: Manifest) -> None:
         # TODO add only if psp is enabled?

--- a/kubemarine/plugins/nginx_ingress.py
+++ b/kubemarine/plugins/nginx_ingress.py
@@ -14,7 +14,7 @@
 
 import io
 import ipaddress
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 from kubemarine.core import utils, log
 from kubemarine.core.cluster import KubernetesCluster
@@ -216,12 +216,11 @@ class IngressNginxManifestProcessor(Processor):
             self.enrich_service_ingress_nginx_controller,
         ]
 
+    def get_namespace_to_necessary_pss_profiles(self) -> Dict[str, str]:
+        return {'ingress-nginx': 'privileged'}
+
     def enrich_namespace_ingress_nginx(self, manifest: Manifest) -> None:
-        key = "Namespace_ingress-nginx"
-        rbac = self.inventory['rbac']
-        if rbac['admission'] == 'pss' and rbac['pss']['pod-security'] == 'enabled' \
-                and rbac['pss']['defaults']['enforce'] != 'privileged':
-            self.assign_default_pss_labels(manifest, key, 'privileged')
+        self.assign_default_pss_labels(manifest, 'ingress-nginx')
 
     def enrich_configmap_ingress_nginx_controller(self, manifest: Manifest) -> None:
         key = "ConfigMap_ingress-nginx-controller"


### PR DESCRIPTION
### Description
* Facing `Error from server (NotFound): namespaces "calico-apiserver" not found` when trying to enable PSS if Calico API server is not installed.

### Solution
* `admission.label_namespace_pss` now takes into account if some namespaces from some manifests are not installed.
* Additional improvement: `admission.label_namespace_pss` now follows the plugins installation procedure and does not set labels when they are not necessary. It also removes unnecessary labels if less restrictive PSS profile is installed.

### Test Cases

**TestCase 1**

Enable PSS when Calico API server is not installed.

1. Install cluster with `rbac.pss.pod-security=disabled`.
2. Enable PSS using `manage_pss`.

Results:

| Before | After |
| ------ | ------ |
| Error from server (NotFound): namespaces "calico-apiserver" not found | PSS is enabled |

**TestCase 2**

Do not install unnecessary labels.

1. Install cluster with `rbac.pss.pod-security=disabled`.
2. Enable PSS using `manage_pss` using default profiles.
3. Run `kubectl get ns kubernetes-dashboard -o yaml`

Results:

| Before | After |
| ------ | ------ |
| The namespace contains labels for `baseline` profile | The namespace does not contain PSS labels |

**TestCase 3**

Delete no longer necessary labels.

1. Install cluster with all OOB plugins enabled, `rbac.pss.pod-security=enabled` and `rbac.pss.defaults.(enforce|audit|warn): restricted`.

ER: calico-apiserver, kubernetes-dashboard, and local-path-storage namespaces have `baseline` PSS labels.

2. Run `manage_pss` with `rbac.pss.defaults.(enforce|audit|warn): baseline`.

| Before | After |
| ------ | ------ |
| calico-apiserver, kubernetes-dashboard, and local-path-storage namespaces contain labels for `baseline` profile | The namespaces do not contain PSS labels |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
