### PR TITLE
[PSUPCLPL-13705] Certificates_not_updated_on_workers_nodes

### DIFF
--- a/kubemarine/procedures/cert_renew.py
+++ b/kubemarine/procedures/cert_renew.py
@@ -57,6 +57,7 @@ def k8s_certs_renew_task(cluster: KubernetesCluster) -> None:
 
     cluster.log.debug("Starting certificate renewal for kubernetes")
     cluster.nodes['control-plane'].call(k8s_certs.renew_apply)
+    cluster.nodes['worker'].call(k8s_certs.force_renew_kubelet_serving_certs)
 
 
 def k8s_certs_overview_task(cluster: KubernetesCluster) -> None:


### PR DESCRIPTION
### Description
Modify the k8s_certs_renew_task function to perform certificate renewal on both control plane nodes and worker nodes when required.

Fixes # (issue)
The primary fix in this change is to ensure that both control plane and worker nodes have their certificates kubelet.crt renewed.

### Solution
The function k8s_certs.force_renew_kubelet_serving_certs is called on the worker nodes. This function focuses on renewing the kubelet serving certificates on worker nodes.


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Steps:

1. Run kubemarine cert_renew on a k8s cluster

Results:

| Before | After |
| ------ | ------ |
| kubelet.crt & kubelet.key was updated only on master nodes | kubelet.crt & kubelet.key updated on all nodes |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts



