### PR TITLE
[CPDEV-93723] Restore from backup holding another Kubernetes version

### DIFF
--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -36,6 +36,7 @@ DEFAULT_ENRICHMENT_FNS = [
     "kubemarine.controlplane.controlplane_node_enrichment",
     "kubemarine.core.defaults.append_controlplain",
     "kubemarine.kubernetes.enrich_upgrade_inventory",
+    "kubemarine.kubernetes.enrich_restore_inventory",
     "kubemarine.core.defaults.compile_inventory",
     "kubemarine.core.defaults.manage_true_false_values",
     "kubemarine.plugins.enrich_upgrade_inventory",

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -180,6 +180,7 @@ def get_final_inventory(c: object, initial_inventory: dict = None) -> dict:
     inventory_finalize_functions = {
         add_node.add_node_finalize_inventory,
         remove_node.remove_node_finalize_inventory,
+        kubernetes.restore_finalize_inventory,
         kubernetes.upgrade_finalize_inventory,
         thirdparties.upgrade_finalize_inventory,
         plugins.upgrade_finalize_inventory,

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -106,7 +106,7 @@ def enrich_restore_inventory(inventory: dict, cluster: KubernetesCluster) -> dic
     initial_kubernetes_version = get_initial_kubernetes_version(inventory)
     backup_kubernetes_version = kubernetes_descriptor.get('version')
     if not backup_kubernetes_version:
-        logger.debug("Not possible to verify Kubernetes version, as descriptor does not contain 'kubernetes.version'")
+        logger.warning("Not possible to verify Kubernetes version, as descriptor does not contain 'kubernetes.version'")
         backup_kubernetes_version = initial_kubernetes_version
 
     if backup_kubernetes_version != initial_kubernetes_version:

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -97,6 +97,35 @@ def generic_upgrade_inventory(cluster: KubernetesCluster, inventory: dict) -> di
     return inventory
 
 
+def enrich_restore_inventory(inventory: dict, cluster: KubernetesCluster) -> dict:
+    if cluster.context.get("initial_procedure") != "restore":
+        return inventory
+
+    logger = cluster.log
+    kubernetes_descriptor = cluster.context['backup_descriptor'].setdefault('kubernetes', {})
+    initial_kubernetes_version = get_initial_kubernetes_version(inventory)
+    backup_kubernetes_version = kubernetes_descriptor.get('version')
+    if not backup_kubernetes_version:
+        logger.debug("Not possible to verify Kubernetes version, as descriptor does not contain 'kubernetes.version'")
+        backup_kubernetes_version = initial_kubernetes_version
+
+    if backup_kubernetes_version != initial_kubernetes_version:
+        logger.warning('Installed kubernetes version does not match version from backup')
+        verify_allowed_version(backup_kubernetes_version)
+
+    kubernetes_descriptor['version'] = backup_kubernetes_version
+    return restore_finalize_inventory(cluster, inventory)
+
+
+def restore_finalize_inventory(cluster: KubernetesCluster, inventory: dict) -> dict:
+    if cluster.context.get("initial_procedure") != "restore":
+        return inventory
+
+    target_kubernetes_version = cluster.context['backup_descriptor']['kubernetes']['version']
+    inventory.setdefault("services", {}).setdefault("kubeadm", {})['kubernetesVersion'] = target_kubernetes_version
+    return inventory
+
+
 def enrich_inventory(inventory: dict, _: KubernetesCluster) -> dict:
     kubeadm = inventory['services']['kubeadm']
     kubeadm['dns'].setdefault('imageRepository', f"{kubeadm['imageRepository']}/coredns")

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -24,7 +24,7 @@ from typing import List
 
 import yaml
 
-from kubemarine.core import utils, flow, defaults
+from kubemarine.core import utils, flow
 from kubemarine.core.action import Action
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.resources import DynamicResources
@@ -58,9 +58,11 @@ def replace_config_from_backup_if_needed(procedure_inventory_filepath: str, conf
             tar.close()
 
 
-def unpack_data(cluster: KubernetesCluster) -> None:
-    backup_tmp_directory = backup.prepare_backup_tmpdir(cluster)
-    backup_file_source = cluster.procedure_inventory.get('backup_location')
+def unpack_data(resources: DynamicResources) -> None:
+    logger = resources.logger()
+    context = resources.context
+    backup_tmp_directory = backup.prepare_backup_tmpdir(logger, context)
+    backup_file_source = resources.procedure_inventory().get('backup_location')
 
     if not backup_file_source:
         raise Exception('Backup source not specified in procedure')
@@ -69,13 +71,13 @@ def unpack_data(cluster: KubernetesCluster) -> None:
     if not os.path.isfile(backup_file_source):
         raise FileNotFoundError('Backup file "%s" not found' % backup_file_source)
 
-    cluster.log.debug('Unpacking all data...')
+    logger.debug('Unpacking all data...')
     with tarfile.open(backup_file_source, 'r:gz') as tar:
         for member in tar:
             if member.isdir():
                 continue
             fname = os.path.join(backup_tmp_directory, member.name)
-            cluster.log.debug(fname)
+            logger.debug(fname)
             fname_parts = fname.split('/')
             if len(fname_parts) > 1:
                 fname_dir = "/".join(fname_parts[:-1])
@@ -89,25 +91,7 @@ def unpack_data(cluster: KubernetesCluster) -> None:
         raise FileNotFoundError('Descriptor not found in backup file')
 
     with utils.open_external(descriptor_filepath, 'r') as stream:
-        cluster.context['backup_descriptor'] = yaml.safe_load(stream)
-
-
-def verify_backup_data(cluster: KubernetesCluster) -> None:
-    if not cluster.context['backup_descriptor'].get('kubernetes', {}).get('version'):
-        cluster.log.debug('Not possible to verify Kubernetes version, because descriptor do not contain such information')
-        return
-
-    if cluster.context['backup_descriptor']['kubernetes']['version'] != cluster.inventory['services']['kubeadm']['kubernetesVersion']:
-        cluster.log.warning('Installed kubernetes versions do not match version from backup')
-        cluster.log.verbose('Cluster re-parse required')
-        if not cluster.raw_inventory.get('services'):
-            cluster.raw_inventory['services'] = {}
-        if not cluster.raw_inventory['services'].get('kubeadm'):
-            cluster.raw_inventory['services']['kubeadm'] = {}
-        cluster.raw_inventory['services']['kubeadm']['kubernetesVersion'] = cluster.context['backup_descriptor']['kubernetes']['version']
-        cluster._inventory = defaults.enrich_inventory(cluster, cluster.raw_inventory)
-    else:
-        cluster.log.debug('Kubernetes version from backup is correct')
+        context['backup_descriptor'] = yaml.safe_load(stream)
 
 
 def stop_cluster(cluster: KubernetesCluster) -> None:
@@ -278,8 +262,6 @@ def reboot(cluster: KubernetesCluster) -> None:
 
 tasks = OrderedDict({
     "prepare": {
-        "unpack": unpack_data,
-        "verify_backup_data": verify_backup_data,
         "stop_cluster": stop_cluster,
     },
     "restore": {
@@ -293,12 +275,19 @@ tasks = OrderedDict({
 })
 
 
+class RestoreFlow(flow.Flow):
+    def _run(self, resources: DynamicResources) -> None:
+        unpack_data(resources)
+        flow.run_actions(resources, [RestoreAction()])
+
+
 class RestoreAction(Action):
     def __init__(self) -> None:
-        super().__init__('restore')
+        super().__init__('restore', recreate_inventory=True)
 
     def run(self, res: DynamicResources) -> None:
         flow.run_tasks(res, tasks)
+        res.make_final_inventory()
 
 
 def main(cli_arguments: List[str] = None) -> None:
@@ -316,7 +305,7 @@ def main(cli_arguments: List[str] = None) -> None:
 
     replace_config_from_backup_if_needed(args['procedure_config'], args['config'])
 
-    flow.ActionsFlow([RestoreAction()]).run_flow(context)
+    RestoreFlow().run_flow(context)
 
 
 if __name__ == '__main__':

--- a/test/unit/core/test_schema.py
+++ b/test/unit/core/test_schema.py
@@ -107,6 +107,8 @@ class TestValidExamples(unittest.TestCase):
                 self.fail(f"Unknown procedure for inventory {relpath}")
 
             context = demo.create_silent_context(procedure=procedure)
+            if procedure == 'restore':
+                context['backup_descriptor'] = {}
             inventory = demo.generate_inventory(**demo.MINIHA)
 
             # check that enrichment is successful and the inventory is valid against the schema

--- a/test/unit/test_restore.py
+++ b/test/unit/test_restore.py
@@ -1,0 +1,73 @@
+import logging
+import os
+import tempfile
+import unittest
+
+import yaml
+
+from kubemarine import demo
+from kubemarine.core import utils, flow, log
+from kubemarine.procedures import restore, backup
+from test.unit import utils as test_utils
+
+
+class RestoreEnrichmentTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.inventory = demo.generate_inventory(**demo.FULLHA_KEEPALIVED)
+
+        self.context = demo.create_silent_context(['fake_path.yaml', '--without-act'], procedure='restore',
+                                                  parser=flow.new_procedure_parser("Help text"))
+
+        args = self.context['execution_arguments']
+        args['disable_dump'] = False
+        args['dump_location'] = self.tmpdir.name
+        utils.prepare_dump_directory(args['dump_location'])
+
+        self.restore_tmpdir = os.path.join(self.tmpdir.name, 'restore_test')
+        os.mkdir(self.restore_tmpdir)
+
+        self.backup_location = os.path.join(self.tmpdir.name, 'backup.tar.gz')
+        self.restore = {'backup_location': self.backup_location}
+
+    def tearDown(self):
+        logger = logging.getLogger("k8s.fake.local")
+        for h in logger.handlers:
+            if isinstance(h, log.FileHandlerWithHeader):
+                h.close()
+        self.tmpdir.cleanup()
+
+    def _run(self) -> demo.FakeResources:
+        resources = demo.FakeResources(self.context, self.inventory,
+                                       procedure_inventory=self.restore,
+                                       nodes_context=demo.generate_nodes_context(self.inventory))
+
+        restore.RestoreFlow()._run(resources)
+        return resources
+
+    def _pack_descriptor(self, backup_descriptor: dict):
+        with utils.open_external(os.path.join(self.restore_tmpdir, 'descriptor.yaml'), 'w') as output:
+            output.write(yaml.dump(backup_descriptor))
+
+    def _pack_data(self):
+        backup.pack_to_tgz(self.backup_location, self.restore_tmpdir)
+
+    def test_enrich_and_finalize_inventory(self):
+        self.inventory['services'].setdefault('kubeadm', {})['kubernetesVersion'] = 'v1.28.0'
+        descriptor = {'kubernetes': {'version': 'v1.27.4'}}
+        self._pack_descriptor(descriptor)
+        self._pack_data()
+
+        resources = self._run()
+        cluster = resources.last_cluster
+
+        self.assertEqual('v1.27.4', cluster.inventory['services']['kubeadm']['kubernetesVersion'],
+                         "Kubernetes version was not restored from backup")
+
+        test_utils.stub_associations_packages(cluster, {})
+        finalized_inventory = cluster.make_finalized_inventory()
+        self.assertEqual('v1.27.4', finalized_inventory['services']['kubeadm']['kubernetesVersion'],
+                         "Kubernetes version was not restored from backup")
+
+        self.assertEqual('v1.27.4', resources.stored_inventory['services']['kubeadm']['kubernetesVersion'],
+                         "Kubernetes version was not restored from backup")

--- a/test/unit/test_restore.py
+++ b/test/unit/test_restore.py
@@ -1,3 +1,17 @@
+# Copyright 2021-2023 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 import tempfile


### PR DESCRIPTION
### Description
* If backup.tar.gz for restore procedure holds different Kubernetes version, it is not reflected in final cluster.yaml.

### Solution
* `prepare.verify_backup_data` task is now always done during enrichment, so Kubernetes version is always enriched.
* `prepare.unpack` task is now always done before enrichment.
* Recreate inventory with the version that is restored from backup.

### Test Cases

**TestCase 1**

Backup and restore to the previous Kubernetes version. Check final inventory.

Steps:

1. Install kubernetes and make backup.
2. Upgrade to new version.
3. Restore using the backup archive.

ER: thirdparties are installed for old version. Old version is restored.

4. Check the resulting cluster.yaml.

Results:

| Before | After |
| ------ | ------ |
| Still holds new Kubernetes version | Holds old Kubernetes version |

**TestCase 2**

Restore only specific resources.

Steps:

1. Prepare backup and run restore --tasks import.nodes.

Results:

| Before | After |
| ------ | ------ |
| KeyError: 'backup_tmpdir' | The task is run successfully. |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_restore.py - added tests to cover enrichment.
