### PR TITLE
[CPDEV-91476] Insert license only to protected branches

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,11 +9,12 @@ env:
 jobs:
   license:
      runs-on: ubuntu-latest
+     if: github.ref_name == 'main' || endsWith(github.ref_name, '_branch')
      steps:
        - uses: actions/checkout@v3
+         with:
+           token: ${{ secrets.NCCLPLCI_PAT }}
        - run: docker run -v "${PWD}:/src" -i ghcr.io/google/addlicense -v -c "${{ env.COPYRIGHT_COMPANY }}" -y "${{ env.COPYRIGHT_YEAR }}" $(find . -type f -name "*.py" | xargs echo)
-       # This currently not works for protected branches,
-       # but all pushes to them should be done through PRs that already contain inserted license.
        - uses: stefanzweifel/git-auto-commit-action@v4
          with:
            commit_message: Auto-update license header


### PR DESCRIPTION
### Description
* If license is inserted as the last commit of PR, the PR has no workflow run. This does not allow to apply status checks to pass before merging.

Fixes #422

### Solution
* Insert license only main and other protected branches.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
