### PR TITLE
[CPDEV-93091] Add dashboard ingress check to check_paas dashboard test

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -75,17 +75,6 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: kubemarine check_paas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_paas_dump/
-      - name: Check ingress connectivity
-        run: |
-          sudo echo "172.17.0.1 dashboard.test-local-k8s.com" | sudo tee -a /etc/hosts
-          http_code=$(curl -s -o /dev/null -I -w "%{http_code}" -k https://dashboard.test-local-k8s.com)
-          echo "Dashboard status code: $http_code"
-          if [[ $http_code == "200" ]]; then
-            echo "Connectivity check passed"
-          else
-            echo "Connectivity check failed"
-          exit 1
-          fi
       - name: Collect journalctl logs
         if: failure()
         run: |
@@ -145,16 +134,6 @@ jobs:
       - name: Check paas
         id: test_check_paas
         run: kubemarine check_paas -c ${{ env.cluster_yaml_file }} --dump-location ./results/check_paas_dump/
-      - name: Check ingress connectivity
-        run: |
-          http_code=$(curl -s -o /dev/null -I -w "%{http_code}" -k https://dashboard.test-local-k8s.com)
-          echo "Dashboard status code: $http_code"
-          if [[ $http_code == "200" ]]; then
-            echo "Connectivity check passed"
-          else
-            echo "Connectivity check failed"
-          exit 1
-          fi
       - name: Get events kubectl
         if: failure()
         run: kubectl get events --sort-by='.metadata.creationTimestamp' -A


### PR DESCRIPTION
### Description
During `check_paas` tests it would be useful to check not only `kubernetes-dashboard` service, but also `kubernetes-dashboard` ingress.

Fixes # (issue)
CPDEV-93091

### Solution
`kubernetes_dashboard_status` function is updated with the check of the ingress similar way as it was done for the service.
The ingress is being checked only after successful check of the service.

To make the ingress check possible in an environment without proper DNS settings, the curl's `--resolve` flag is used.
The ingress name is being resolved to the cluster.inventory['control_plain']['internal'] and the check is running from one of master nodes.

### How to apply
Not applicable

### Test Cases
1. Deploy a cluster with `kubernetes-dashboard` plugin. Run `check_paas` procedure with `--tasks=kubernetes.plugins.dashboard` flag.

ER: The test is successful, debug output show 2 sub-checks: one of the service and one of the ingress.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests


