### PR TITLE
[CPDEV-94061] Restore resolv.conf before restoring of thirdparties

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -711,6 +711,8 @@ The `restore` procedure executes the following sequence of tasks:
 * prepare
   * stop_cluster
 * restore
+  * dns
+    * resolv_conf
   * thirdparties
 * import
   * nodes

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -45,6 +45,7 @@ DEFAULT_ENRICHMENT_FNS = [
     "kubemarine.packages.enrich_upgrade_inventory",
     "kubemarine.packages.enrich_inventory_apply_defaults",
     "kubemarine.thirdparties.enrich_upgrade_inventory",
+    "kubemarine.thirdparties.enrich_restore_inventory",
     "kubemarine.admission.manage_enrichment",
     "kubemarine.procedures.migrate_cri.enrich_inventory",
     "kubemarine.core.defaults.apply_registry",

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -183,6 +183,7 @@ def get_final_inventory(c: object, initial_inventory: dict = None) -> dict:
         remove_node.remove_node_finalize_inventory,
         kubernetes.restore_finalize_inventory,
         kubernetes.upgrade_finalize_inventory,
+        thirdparties.restore_finalize_inventory,
         thirdparties.upgrade_finalize_inventory,
         plugins.upgrade_finalize_inventory,
         packages.upgrade_finalize_inventory,

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -115,13 +115,6 @@ def stop_cluster(cluster: KubernetesCluster) -> None:
 
 
 def restore_thirdparties(cluster: KubernetesCluster) -> None:
-    custom_thirdparties = cluster.procedure_inventory.get('restore_plan', {}).get('thirdparties', {})
-    if custom_thirdparties:
-        for name, value in custom_thirdparties.items():
-            cluster.inventory['services']['thirdparties'][name]['source'] = value['source']
-            if value.get('sha1'):
-                cluster.inventory['services']['thirdparties'][name]['sha1'] = value['sha1']
-
     install.system_prepare_thirdparties(cluster)
 
 


### PR DESCRIPTION
### Description
* We need to restore dns configuration before working with internet resources, i. e. do it before restore.thirdparties task.
* `restore_plan.thirdparties` are not present in final inventory.

Fixes #482

### Solution
* Add new task `restore.dns.resolv_conf` that restores the resolv.conf, and that is run before `restore.thirdparties`.
* Move enrichment of thirdparties from `restore.thirdparties` task to enrichment procedures.

### Test Cases

**TestCase 1**

Restore resolv.conf before thirdparties.

Steps:

1. Configure cluster.yaml in private environment with `services.resolv.conf` section, and install the cluster.
2. Take backup
3. Truncate /etc/resolv.conf
4. Restore from backup.

Results:

| Before | After |
| ------ | ------ |
| `restore.thirdparties` task failed | Restore is successful  |

**TestCase 2**

Enrich `restore_plan.thirdparties` in final inventory.

Steps:

1. Restore cluster with `restore_plan.thirdparties` in procedure inventory.
2. Check the resulting cluster.yaml

Results:

| Before | After |
| ------ | ------ |
| `services.thirdparties` are old | `services.thirdparties` contain the thirdparties from `restore_plan.thirdparties`.  |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_restore.py - added tests to cover enrichment of thirdparties.
