### PR TITLE
Kubelet server certificate improvement

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -1856,9 +1856,9 @@ These settings enforce `kubelet` on each node of the cluster to request certific
 
 ```
 # kubectl get csr
-NAME        AGE     SIGNERNAME                                    REQUESTOR            REQUESTEDDURATION   CONDITION
-csr-2z6rv   12m     kubernetes.io/kubelet-serving                 system:node:nodename-1   <none>              Pending
-csr-424qg   89m     kubernetes.io/kubelet-serving                 system:node:nodename-2   <none>              Pending
+NAME        AGE     SIGNERNAME                          REQUESTOR                 REQUESTEDDURATION    CONDITION
+csr-2z6rv   12m     kubernetes.io/kubelet-serving       system:node:nodename-1    <none>               Pending
+csr-424qg   89m     kubernetes.io/kubelet-serving       system:node:nodename-2    <none>               Pending
 ```
 
 Approve the particular request:

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -1121,11 +1121,13 @@ For Kubernetes, most of the internal certificates could be updated, specifically
 Certificate used by `kubelet.conf` by default is updated automatically by Kubernetes, 
 link to Kubernetes docs regarding `kubelet.conf` rotation: https://kubernetes.io/docs/tasks/tls/certificate-rotation/#understanding-the-certificate-rotation-configuration.
 
-**Note**: Serving kubelet certificate `kubelet.crt` is updated forcefully by this procedure each time it runs.
+**Note**: Serving kubelet certificate `kubelet.crt` on control plane node is updated forcefully by this procedure each time it runs.
 
 **Note**: Each time you run this procedure, kubelet and all control plane containers are restarted.
 
 **Note**: CA certificates cannot be updated automatically and should be updated manually after 10 years.
+
+**Note**: The `cert_renew` procedure doesn't renew `kubelet` server certificate on workers. To avoid it, implement the changes from maintenance guide: [Kubelet server certificate approval](#kubelet-server-certificate-approval)
 
 For nginx-ingress-controller, the config map along with the default certificate is updated with a new certificate and key. The config map update is performed by plugin re-installation.
 
@@ -1874,7 +1876,7 @@ These commands might be automated in several ways.
 
 Basically, `CronJob` runs the approval command above for every CSR according to some schedule.
 
-### Auto approval serice
+### Auto approval service
 
 It's possible to install the service: [kubelet-csr-approver](https://github.com/postfinance/kubelet-csr-approver). That service approves CSR automatically when CSR is created according to the several settings. It's better to restrict nodes IP addresses(`providerIpPrefixes` option) and nodes FQDN templates(providerRegex). More information in official documentation.
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -27,7 +27,7 @@ This section describes the features and steps for performing maintenance procedu
     - [Changing Calico Settings](#changing-calico-settings)
     - [Data Encryption in Kubernetes](#data-encryption-in-kubernetes)
     - [Changing Cluster CIDR](#changing-cluster-cidr)
-    - [Kubelet server certificate approval](#kubelet-server-certificate-approval)
+    - [Kubelet Server Certificate Approval](#kubelet-server-certificate-approval)
 - [Common Practice](#common-practice)
 
 # Prerequisites
@@ -1125,7 +1125,7 @@ link to Kubernetes docs regarding `kubelet.conf` rotation: https://kubernetes.io
 
 **Note**: CA certificates cannot be updated automatically and should be updated manually after 10 years.
 
-**Note**: The `cert_renew` procedure doesn't renew `kubelet` server certificate. To avoid it, implement the changes from maintenance guide: [Kubelet server certificate approval](#kubelet-server-certificate-approval)
+**Note**: The `cert_renew` procedure does not renew the `kubelet` server certificate. To avoid this, implement the changes mentioned in the [Kubelet Server Certificate Approval](#kubelet-server-certificate-approval) section.
 
 For nginx-ingress-controller, the config map along with the default certificate is updated with a new certificate and key. The config map update is performed by plugin re-installation.
 
@@ -1836,9 +1836,9 @@ data:
 
 11. Check that everything works properly and remove the old ippool if necessary.
 
-## Kubelet server certificate approval
+## Kubelet Server Certificate Approval
 
-The `kubelet` server certificate is self-signed by default, usually it's stored in `/var/lib/kubelet/pki/kubelet.crt` file. To avoid using self-signed `kubelet` server certificate one should change `cluster.yaml` in the following way:
+The `kubelet` server certificate is self-signed by default, and is usually stored in the `/var/lib/kubelet/pki/kubelet.crt` file. To avoid using the self-signed `kubelet` server certificate, alter the `cluster.yaml` file in the following way:
 
 ```yaml
 ...
@@ -1853,7 +1853,7 @@ services:
 ...
 ```
 
-These settings enforce `kubelet` on each node of the cluster to request certificate appoval (for `kubelet` server part) from the default Kubernetes CA and rotate certificate in the future. The `kube-apiserver` machinery does not approve certificate requests for `kubelet` automatically. They might be approved manually by the following commans. Get the list of certificate requests:
+These settings enforce `kubelet` on each node of the cluster to request certificate approval (for `kubelet` server part) from the default Kubernetes CA and rotate certificate in the future. The `kube-apiserver` machinery does not approve certificate requests for `kubelet` automatically. They might be approved manually by the following commans. Get the list of certificate requests:
 
 ```
 # kubectl get csr
@@ -1870,13 +1870,13 @@ kubectl certificate approve csr-424qg
 
 These commands might be automated in several ways.
 
-### Auto approval CronJob
+### Auto Approval CronJob
 
 Basically, `CronJob` runs the approval command above for every CSR according to some schedule.
 
-### Auto approval service
+### Auto Approval Service
 
-It's possible to install the service: [kubelet-csr-approver](https://github.com/postfinance/kubelet-csr-approver). That service approves CSR automatically when CSR is created according to the several settings. It's better to restrict nodes IP addresses(`providerIpPrefixes` option) and nodes FQDN templates(providerRegex). More information in official documentation.
+It is possible to install the kubelet-csr-approver service. For more information, refer to [[kubelet-csr-approver](https://github.com/postfinance/kubelet-csr-approver)](https://github.com/postfinance/kubelet-csr-approver). This service approves CSR automatically when a CSR is created according to several settings. It is better to restrict nodes' IP addresses (`providerIpPrefixes` option) and FQDN templates (providerRegex). For more information, refer to the official documentation.
 
 # Common Practice
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -1838,7 +1838,7 @@ data:
 
 ## Kubelet server certificate approval
 
-The `kubelet` server certificate is self-signed by default. To avoid that one should change `cluster.yaml` in the following way:
+The `kubelet` server certificate is self-signed by default, usually it's stored in `/var/lib/kubelet/pki/kubelet.crt` file. To avoid using self-signed `kubelet` server certificate one should change `cluster.yaml` in the following way:
 
 ```yaml
 ...

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -27,6 +27,7 @@ This section describes the features and steps for performing maintenance procedu
     - [Changing Calico Settings](#changing-calico-settings)
     - [Data Encryption in Kubernetes](#data-encryption-in-kubernetes)
     - [Changing Cluster CIDR](#changing-cluster-cidr)
+    - [Kubelet server certificate approval](#kubelet-server-certificate-approval)
 - [Common Practice](#common-practice)
 
 # Prerequisites

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -1121,13 +1121,11 @@ For Kubernetes, most of the internal certificates could be updated, specifically
 Certificate used by `kubelet.conf` by default is updated automatically by Kubernetes, 
 link to Kubernetes docs regarding `kubelet.conf` rotation: https://kubernetes.io/docs/tasks/tls/certificate-rotation/#understanding-the-certificate-rotation-configuration.
 
-**Note**: Serving kubelet certificate `kubelet.crt` on control plane node is updated forcefully by this procedure each time it runs.
-
 **Note**: Each time you run this procedure, kubelet and all control plane containers are restarted.
 
 **Note**: CA certificates cannot be updated automatically and should be updated manually after 10 years.
 
-**Note**: The `cert_renew` procedure doesn't renew `kubelet` server certificate on workers. To avoid it, implement the changes from maintenance guide: [Kubelet server certificate approval](#kubelet-server-certificate-approval)
+**Note**: The `cert_renew` procedure doesn't renew `kubelet` server certificate. To avoid it, implement the changes from maintenance guide: [Kubelet server certificate approval](#kubelet-server-certificate-approval)
 
 For nginx-ingress-controller, the config map along with the default certificate is updated with a new certificate and key. The config map update is performed by plugin re-installation.
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -1867,7 +1867,15 @@ Approve the particular request:
 kubectl certificate approve csr-424qg
 ```
 
-These commands might be automated by `CronJob` or the service similar the following: [kubelet-csr-approver](https://github.com/postfinance/kubelet-csr-approver)
+These commands might be automated in several ways.
+
+### Auto approval CronJob
+
+Basically, `CronJob` runs the approval command above for every CSR according to some schedule.
+
+### Auto approval serice
+
+It's possible to install the service: [kubelet-csr-approver](https://github.com/postfinance/kubelet-csr-approver). That service approves CSR automatically when CSR is created according to the several settings. It's better to restrict nodes IP addresses(`providerIpPrefixes` option) and nodes FQDN templates(providerRegex). More information in official documentation.
 
 # Common Practice
 

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -1198,3 +1198,24 @@ The user can analyze these files and try to find the reason for the failed insta
 sudo systemctl stop kubepods-burstable.slice
 sudo systemctl restart containerd
 ```
+
+## `kubectl logs` and `kubectl exec` fail
+
+**Symptoms**:
+
+The attempt to get pod logs and execute command inside container fail with the following errors:
+
+```
+$ kubectl -n my-namespace logs my-pod
+Error from server: Get "https://192.168.1.1:10250/containerLogs/my-namespace/my-pod/controller": remote error: tls: internal error
+```
+
+```
+$ kubectl -n my-namespace exec my-pod -- id
+Error from server: error dialing backend: remote error: tls: internal error
+```
+
+**Root cause**:
+`kubelet` server certificate is not approved whereas cluster has been configured not to use self-signed certificates for `kubelet` server.
+
+**Solution**: Perform CSR approval steps from maintenance guide: [Kubelet server certificate approval](https://github.com/Netcracker/KubeMarine/blob/main/documentation/Maintenance.md#kubelet-server-certificate-approval)

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -1202,7 +1202,7 @@ sudo systemctl restart containerd
 
 ## kubectl logs and kubectl exec fail
 
-**Symptoms**: The attempt to get pod logs and execute command inside container fail with the following errors:
+**Symptoms**: The attempt to get pod logs and execute a command inside the container fails with the following errors:
 
 ```
 $ kubectl -n my-namespace logs my-pod
@@ -1214,6 +1214,6 @@ $ kubectl -n my-namespace exec my-pod -- id
 Error from server: error dialing backend: remote error: tls: internal error
 ```
 
-**Root cause**: `kubelet` server certificate is not approved whereas cluster has been configured not to use self-signed certificates for `kubelet` server.
+**Root cause**: The `kubelet` server certificate is not approved, whereas the cluster has been configured not to use self-signed certificates for the `kubelet` server.
 
-**Solution**: Perform CSR approval steps from maintenance guide: [Kubelet server certificate approval](https://github.com/Netcracker/KubeMarine/blob/main/documentation/Maintenance.md#kubelet-server-certificate-approval)
+**Solution**: Perform CSR approval steps from the maintenance guide. Refer to the [Kubelet Server Certificate Approval](https://github.com/Netcracker/KubeMarine/blob/main/documentation/Maintenance.md#kubelet-server-certificate-approval) section for details.

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -1201,9 +1201,7 @@ sudo systemctl restart containerd
 
 ## `kubectl logs` and `kubectl exec` fail
 
-**Symptoms**:
-
-The attempt to get pod logs and execute command inside container fail with the following errors:
+**Symptoms**: The attempt to get pod logs and execute command inside container fail with the following errors:
 
 ```
 $ kubectl -n my-namespace logs my-pod
@@ -1215,7 +1213,6 @@ $ kubectl -n my-namespace exec my-pod -- id
 Error from server: error dialing backend: remote error: tls: internal error
 ```
 
-**Root cause**:
-`kubelet` server certificate is not approved whereas cluster has been configured not to use self-signed certificates for `kubelet` server.
+**Root cause**: `kubelet` server certificate is not approved whereas cluster has been configured not to use self-signed certificates for `kubelet` server.
 
 **Solution**: Perform CSR approval steps from maintenance guide: [Kubelet server certificate approval](https://github.com/Netcracker/KubeMarine/blob/main/documentation/Maintenance.md#kubelet-server-certificate-approval)

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -36,6 +36,7 @@ This section provides troubleshooting information for Kubemarine and Kubernetes 
   - [Failure During Installation on Ubuntu OS With Cloud-init](#failure-during-installation-on-ubuntu-os-with-cloud-init)
   - [Troubleshooting an Installation That Ended Incorrectly](#troubleshooting-an-installation-that-ended-incorrectly)
   - [Kubelet Has Conflict With Kubepods-burstable.slice and Kube-proxy Pods Stick in ContainerCreating Status](#kubelet-has-conflict-with-kubepods-burstableslice-and-kube-proxy-pods-stick-in-containercreating-status)
+  - [kubectl logs and kubectl exec fail](#kubectl-logs-and-kubectl-exec-fail)
 
 # Kubemarine Errors
 
@@ -1199,7 +1200,7 @@ sudo systemctl stop kubepods-burstable.slice
 sudo systemctl restart containerd
 ```
 
-## `kubectl logs` and `kubectl exec` fail
+## kubectl logs and kubectl exec fail
 
 **Symptoms**: The attempt to get pod logs and execute command inside container fail with the following errors:
 


### PR DESCRIPTION
### Description
*  `kubelet` server uses self-signed certificate by default


### Solution
* It needs to describe how to use default Kubernetes cluster CA to sign the `kubelet` server certificates within the cluster


### How to apply
Not applicable


### Test Cases

**TestCase 1**
Check if the installation procedure finishes successfully with the settings from the article

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 22.04
- Inventory: AllinOne

Steps:

1. Add to `cluster.yaml` the following part:
```
services:
  kubeadm_kubelet:
    serverTLSBootstrap: true
    rotateCertificates: true
  kubeadm:
    apiServer:
      extraArgs:
        kubelet-certificate-authority: /etc/kubernetes/pki/ca.crt
```
2. Run installation

Results:

| Before | After |
| ------ | ------ |
| Success | Success |

**TestCase 2**
Check if the `cert_renew` procedure finishes successfully with the settings from the article

Test Configuration:

- Hardware: 4CPU/4BG
- OS: Ubuntu 22.04
- Inventory: AllinOne

Steps:

1. Add to `cluster.yaml` the following part:
```
services:
  kubeadm_kubelet:
    serverTLSBootstrap: true
    rotateCertificates: true
  kubeadm:
    apiServer:
      extraArgs:
        kubelet-certificate-authority: /etc/kubernetes/pki/ca.crt
```
2. Run `cert_renew`

Results:

| Before | After |
| ------ | ------ |
| Success | Success |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts



