### PR TITLE
[CPDEV-94111] - fix ctr flags for new containerd format

### DIFF
--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -171,7 +171,8 @@ def apply_registry(inventory: dict, cluster: KubernetesCluster) -> dict:
             containerd_endpoints = ["%s://%s" % (protocol, registry_mirror_address)]
 
         old_format_result, _ = contains_old_format_properties(inventory)
-        if old_format_result:
+        # todo remove p3_reconfigure_registries after next release
+        if old_format_result or (cluster and not cluster.context.get('p3_reconfigure_registries', True)):
             # Add registry info in old format
             registry_section = f'plugins."io.containerd.grpc.v1.cri".registry.mirrors."{registry_mirror_address}"'
             containerd_config = inventory['services']['cri']['containerdConfig']

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -172,7 +172,7 @@ def apply_registry(inventory: dict, cluster: KubernetesCluster) -> dict:
 
         old_format_result, _ = contains_old_format_properties(inventory)
         # todo remove p3_reconfigure_registries after next release
-        if old_format_result or (cluster and not cluster.context.get('p3_reconfigure_registries', True)):
+        if old_format_result or not cluster.context.get('p3_reconfigure_registries', True):
             # Add registry info in old format
             registry_section = f'plugins."io.containerd.grpc.v1.cri".registry.mirrors."{registry_mirror_address}"'
             containerd_config = inventory['services']['cri']['containerdConfig']

--- a/kubemarine/cri/containerd.py
+++ b/kubemarine/cri/containerd.py
@@ -277,7 +277,7 @@ def configure_crictl(group: NodeGroup) -> None:
 
 
 def get_config_path(inventory: dict) -> Optional[str]:
-    config_path: Optional[str] = inventory.get('containerdConfig', {}) \
+    config_path: Optional[str] = inventory.get('services', {}).get('cri', {}).get('containerdConfig', {}) \
         .get('plugins."io.containerd.grpc.v1.cri".registry', {}).get('config_path')
     return config_path
 

--- a/kubemarine/cri/containerd.py
+++ b/kubemarine/cri/containerd.py
@@ -256,10 +256,11 @@ def configure_ctr_flags(group: NodeGroup) -> None:
         elif registry_auth.get('username'):
             options.append(f'--user {registry_auth["username"]}' +
                            f':{registry_auth["password"]}' if registry_auth.get("password") else '')
-        # Add hosts-dir, if it's presented
-        if config_path:
-            options.append(f'--hosts-dir {config_path}')
         ctr_pull_options_str += f'{registry_name}={" ".join(options)}\n'
+
+    # Add hosts-dir, if it's presented
+    if config_path:
+        ctr_pull_options_str += f'*=--hosts-dir {config_path}\n'
 
     # Save ctr pull options
     log.debug("Uploading ctr flags configuration...")

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -25,11 +25,13 @@ from kubemarine.core.patch import Patch
 from kubemarine.patches.p1_enable_calico_audit import EnableCalicoAudit
 from kubemarine.patches.p2_calico_typha_metrics import EnableCalicoTyphaMetrics
 from kubemarine.patches.p3_reconfigure_registries import ReconfigureRegistries
+from kubemarine.patches.p4_reinstall_etcdctl_thirdparty import ReinstallEtcdctl
 
 patches: List[Patch] = [
     EnableCalicoAudit(),
     EnableCalicoTyphaMetrics(),
-    ReconfigureRegistries()
+    ReconfigureRegistries(),
+    ReinstallEtcdctl()
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/resources/scripts/etcdctl.sh
+++ b/kubemarine/resources/scripts/etcdctl.sh
@@ -73,9 +73,10 @@ if [ -n "${ETCD_POD_CONFIG}" ]; then
 
   if [ "$CONT_RUNTIME" == "ctr" ]; then
     ETCD_REGISTRY=$(echo ${ETCD_IMAGE} | cut -d "/" -f1)
+    ctr_default_pull_opts=$(cat /etc/ctr/kubemarine_ctr_flags.conf |  grep "^*=" | sed "s/^*=//;")
     ctr_pull_opts=$(cat /etc/ctr/kubemarine_ctr_flags.conf |  grep "^${ETCD_REGISTRY}=" | sed "s/^${ETCD_REGISTRY}=//;")
     container_name="etcdctl-$(cat /proc/sys/kernel/random/uuid | sed 's/[-]//g' | head -c 20; echo;)"
-    ctr image pull ${ctr_pull_opts} ${ETCD_IMAGE} > /dev/null 2&>1
+    ctr image pull ${ctr_default_pull_opts} ${ctr_pull_opts} ${ETCD_IMAGE} > /dev/null 2&>1
     ctr run --net-host --rm ${ETCD_MOUNTS} --env ETCDCTL_API=3 ${ETCD_IMAGE} $container_name \
 	    etcdctl --cert=${ETCD_CERT} --key=${ETCD_KEY} --cacert=${ETCD_CA} "${USER_ARGS[@]}"
   else


### PR DESCRIPTION
### Description
This PR fixes the bug, related to PR https://github.com/Netcracker/KubeMarine/pull/523:
If user specifies only new format configuration (without credentials), `hosts-dir` flag is not applied for ctr commands.
Example of configuration:
```yaml
services:
  kubeadm:
    imageRepository: registry.example:9090
  cri:
    containerdRegistriesConfig:
      registry.example:9090:
        host."http://registry.example:9090":
          capabilities: [ "pull", "resolve" ]
          skip_verify: true
```
As result ctr fails with pulling problem like:
```
failed to do request: Head \"https://registry.example:9090/v2/pause/manifests/3.9\": http: server gave HTTP response to HTTPS client" host="registry.example:9090"
ctr: failed to resolve reference "registry.example:9090/pause:3.9": failed to do request: Head "https://registry.example:9090/v2/pause/manifests/3.9": http: server gave HTTP response to HTTPS client
```
The root cause in ctr_flags.conf that saves ctr options per registry in old format, but --hosts-dir should be applied for any registry, if the new format is used. 

Fixes # (issue)


### Solution
* Added `*` rule in ctr_flags.conf, that means, that options should be applied for any registry;
* Fixed `etcdctl`, that can parse '*' rules in ctr_flags.conf;
* If `config-path` is enabled, `*=--hosts-dir <config_path>` is added to  ctr_flags.conf;
* Added patch to reinstall etcdctl;
* Fixed reconfigure_registry patch using deviated_cluster, because it's more safe way to compare configuration differences when `raw_inventory`;


### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: containerd configuration like from description above

Steps:

1. Kubemarine install
2. Kubemarine check_paas

Results:

| Before | After |
| ------ | ------ |
| `etcd.health_status` failed with error: ctr: image "registry.example:9090/etcd:3.5.6-0": not found | `etcd.health_status` task works correctly |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


