### PR TITLE
[CPDEV-84690] Improvement and fixes in Keepalived installation and removing balancers

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -730,10 +730,10 @@ The procedure works as shown in the following table:
 
 |Case|Expected Result|Important Note|
 |---|---|---|
-|Add load balancer|A new load balancer is configured. If `vrrp_ip` is present, then all the Keepalived nodes are reconfigured and restarted.|Kubernetes and Keepalived installations should not start.|
+|Add load balancer|A new load balancer is configured. If `vrrp_ip` is present, then all the Keepalived nodes are reconfigured and restarted.|Kubernetes installation should not start. Keepalived installation should start only if `vrrp_ip` is present.|
 |Add load balancer + Keepalived|A new load balancer is configured. Keepalived is installed and configured on all the load balancers.|Kubernetes installation should not start.|
-|Add control-plane|Kubernetes is installed only on a new node. A new control-plane is added to the Kubernetes cluster, and all Haproxy nodes are reconfigured and restarted.|Haproxy installation should not start.|
-|Add worker|Kubernetes is installed only on a new node. A new worker is added to the Kubernetes cluster, and all Haproxy nodes are reconfigured and restarted.|Haproxy installation should not start.|
+|Add control-plane|Kubernetes is installed only on a new node. A new control-plane is added to the Kubernetes cluster, and all Haproxy nodes are reconfigured and restarted.|Haproxy and Keepalived installation should not start.|
+|Add worker|Kubernetes is installed only on a new node. A new worker is added to the Kubernetes cluster, and all Haproxy nodes are reconfigured and restarted.|Haproxy and Keepalived installation should not start.|
 
 Also pay attention to the following:
 
@@ -773,7 +773,10 @@ nodes:
 **Note**:
 
 * The connection information for new nodes can be used from defaults as described in the [Kubemarine Inventory Node Defaults](Installation.md#nodedefaults) section in _Kubemarine Installation Procedure_. If the connection information is not present by default, define the information in each new node configuration.
-* You can add the `vrrp_ips` section to **procedure.yaml** if you intend to add the new `balancer` node and have previously not configured the `vrrp_ips` section.
+* If you intend to add the new `balancer` node with VRRP IP, and have previously not configured the `vrrp_ips` section, you need to do the following preliminarily:
+  * And the section to the main `cluster.yaml`.
+  * If you already have balancers without VRRP IPs, reconfigure the balancers and DNS,
+    for example, using `kubemarine install --tasks prepare.dns.etc_hosts,deploy.loadbalancer.haproxy.configure,deploy.loadbalancer.keepalived,deploy.coredns`
 
 ### Add Node Tasks Tree
 
@@ -842,7 +845,9 @@ The procedure works as follows:
 
 Also pay attention to the following:
 
-* If `vrrp_ip` is not used by any node after nodes removal, then the `vrrp_ip` is removed from **cluster.yaml**.
+* The `vrrp_ips` section is not touched.
+  If it specifies some hosts to enable the Keepalived on, and some of these hosts no longer exist,
+  such hosts are ignored with warnings.
 * The file `/etc/hosts` is updated and uploaded to all remaining nodes in the cluster. The control plane address may change.
 * This procedure only removes nodes and does not restore nodes to their original state. Packages, configurations, and Thirdparties are also not deleted.
 

--- a/kubemarine/controlplane.py
+++ b/kubemarine/controlplane.py
@@ -20,7 +20,7 @@ def controlplane_node_enrichment(inventory: dict, cluster: KubernetesCluster) ->
     The 'control-plane' role is used instead of 'master' role since Kubernetes v1.24
     """
     for node in inventory["nodes"]:
-        node_info = node.get('name', cluster.get_access_address_from_node(node))
+        node_info = node['name']
         if "master" in node["roles"] and "control-plane" not in node["roles"]:
             cluster.log.debug(f"The 'control-plane' role will be added for {node_info}")
             cluster.log.warning(f"Node {node_info} has legacy role 'master'. "
@@ -40,7 +40,7 @@ def controlplane_finalize_inventory(cluster: KubernetesCluster, inventory: dict)
     # remove 'master' role from inventory before dump
     for node in inventory["nodes"]:
         if 'master' in node["roles"]:
-            node_info = node.get('name', cluster.get_access_address_from_node(node))
+            node_info = node['name']
             cluster.log.debug(f"The 'master' role will be removed for {node_info} node before saving")
             node["roles"].remove("master")
 

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -51,7 +51,7 @@ class KubernetesCluster(Environment):
         make_dumps = custom_enrichment_fns is None
         from kubemarine.core import defaults
         self._inventory = defaults.enrich_inventory(
-            self, self.raw_inventory, make_dumps=make_dumps, enrichment_functions=custom_enrichment_fns)
+            self, deepcopy(self.raw_inventory), make_dumps=make_dumps, enrichment_functions=custom_enrichment_fns)
 
         self._connection_pool = self.create_connection_pool(self.ips['all'])
 
@@ -77,7 +77,7 @@ class KubernetesCluster(Environment):
     def make_group(self, ips: Iterable[_AnyConnectionTypes]) -> NodeGroup:
         return NodeGroup(ips, self)
 
-    def get_access_address_from_node(self, node: dict) -> str:
+    def get_access_address_from_node(self, node: NodeConfig) -> str:
         """
         Returns address which should be used to connect to the node via Fabric.
         The address also can be used as unique identifier of the node.
@@ -148,11 +148,11 @@ class KubernetesCluster(Environment):
             "kubemarine.core.defaults.merge_defaults",
             "kubemarine.kubernetes.verify_initial_version",
             "kubemarine.kubernetes.add_node_enrichment",
+            "kubemarine.core.defaults.calculate_node_names",
             "kubemarine.kubernetes.remove_node_enrichment",
             "kubemarine.controlplane.controlplane_node_enrichment",
             "kubemarine.core.defaults.append_controlplain",
             "kubemarine.core.defaults.compile_inventory",
-            "kubemarine.core.defaults.calculate_node_names",
             "kubemarine.core.defaults.verify_node_names",
             "kubemarine.core.defaults.apply_defaults",
             "kubemarine.core.defaults.calculate_nodegroups"

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -63,7 +63,16 @@ class DynamicResources:
         return self._logger
 
     def raw_inventory(self) -> dict:
-        """Returns raw inventory, which does not preserve formatting and which should be read only."""
+        """
+        Returns raw inventory, that does not preserve formatting and which should be read only.
+
+        This inventory should be passed to the cluster instance.
+        It can also be used to check the user-supplied sections and values before running of the enrichment.
+
+        Note that this inventory is not compiled, so its values should be checked with care.
+
+        :return: raw inventory
+        """
         if self._raw_inventory is None:
             self._load_inventory()
 

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -175,11 +175,13 @@ def get_final_inventory(c: object, initial_inventory: dict = None) -> dict:
         inventory = deepcopy(initial_inventory)
 
     from kubemarine import admission, cri, kubernetes, packages, plugins, thirdparties
+    from kubemarine.core import defaults
     from kubemarine.plugins import nginx_ingress
     from kubemarine.procedures import add_node, remove_node, migrate_cri
 
-    inventory_finalize_functions = {
+    inventory_finalize_functions = [
         add_node.add_node_finalize_inventory,
+        lambda cluster, inventory: defaults.calculate_node_names(inventory, cluster),
         remove_node.remove_node_finalize_inventory,
         kubernetes.restore_finalize_inventory,
         kubernetes.upgrade_finalize_inventory,
@@ -191,7 +193,7 @@ def get_final_inventory(c: object, initial_inventory: dict = None) -> dict:
         nginx_ingress.finalize_inventory,
         migrate_cri.migrate_cri_finalize_inventory,
         cri.upgrade_finalize_inventory,
-    }
+    ]
 
     for finalize_fn in inventory_finalize_functions:
         inventory = finalize_fn(cluster, inventory)
@@ -200,6 +202,11 @@ def get_final_inventory(c: object, initial_inventory: dict = None) -> dict:
 
 
 def merge_vrrp_ips(procedure_inventory: dict, inventory: dict) -> None:
+    # This method is currently unused.
+    # If it is ever supported when adding and removing node,
+    # it will be necessary to more accurately install and reconfigure the keepalived on existing nodes.
+    # Also, it is desirable to change the section format, for example, as for etc_hosts.
+
     if "vrrp_ips" in inventory and len(inventory["vrrp_ips"]) > 0:
         raise Exception("vrrp_ips section already defined, merging not supported yet")
     else:

--- a/kubemarine/keepalived.py
+++ b/kubemarine/keepalived.py
@@ -88,9 +88,7 @@ def enrich_inventory_apply_defaults(inventory: dict, cluster: KubernetesCluster)
         if item.get('hosts') is None:
             # Assign default list of all the balancer names. It can be an empty list.
             # Assigning of initial balancers is necessary to property calculate 'keepalived' NodeGroup.
-            # TODO assign list(initial_balancers) copy to avoid inline modification of initial_balancers list.
-            #  https://github.com/Netcracker/KubeMarine/issues/248
-            item['hosts'] = initial_balancers
+            item['hosts'] = list(initial_balancers)
             default_hosts = True
 
         for j, record in enumerate(item['hosts']):

--- a/kubemarine/keepalived.py
+++ b/kubemarine/keepalived.py
@@ -23,20 +23,17 @@ from jinja2 import Template
 from kubemarine import system, packages
 from kubemarine.core import utils, static
 from kubemarine.core.cluster import KubernetesCluster
-from kubemarine.core.group import NodeGroup, NodeConfig, RunnersGroupResult
+from kubemarine.core.group import NodeGroup, NodeConfig, RunnersGroupResult, CollectorCallback, DeferredGroup
 
 
-def autodetect_interface(cluster: KubernetesCluster, name: str) -> Optional[str]:
-    for node in cluster.inventory['nodes']:
-        if node['name'] == name:
-            address = cluster.get_access_address_from_node(node)
-            interface: str = cluster.context['nodes'].get(address, {})['active_interface']
-            if interface:
-                return interface
-    if cluster.context['initial_procedure'] == 'remove_node':
-        for node_to_remove in cluster.procedure_inventory['nodes']:
-            if node_to_remove['name'] == name:
-                return None
+def autodetect_interface(cluster: KubernetesCluster, name: str) -> str:
+    node = cluster.get_node_by_name(name)
+    if node is not None:
+        address = cluster.get_access_address_from_node(node)
+        interface: Optional[str] = cluster.context['nodes'].get(address, {}).get('active_interface')
+        if interface is not None:
+            return interface
+
     raise Exception('Failed to autodetect active interface for %s' % name)
 
 
@@ -45,11 +42,14 @@ def enrich_inventory_apply_defaults(inventory: dict, cluster: KubernetesCluster)
     if not inventory['vrrp_ips']:
         return inventory
 
-    default_names = get_default_node_names(inventory)
+    logger = cluster.log
 
-    cluster.log.verbose("Detected default keepalived hosts: %s" % default_names)
-    if not default_names:
-        cluster.log.verbose("WARNING: Default keepalived hosts are empty: something can go wrong!")
+    initial_balancers = get_all_balancer_names(inventory, final=False)
+    final_balancers = get_all_balancer_names(inventory, final=True)
+
+    logger.verbose("Detected default keepalived hosts: %s" % initial_balancers)
+    if not final_balancers:
+        logger.warning("VRRP IPs are specified, but there are no final balancers. Keepalived will not be configured.")
 
     # iterate over each vrrp_ips item and check if any hosts defined to be used in it
     for i, item in enumerate(inventory['vrrp_ips']):
@@ -84,39 +84,48 @@ def enrich_inventory_apply_defaults(inventory: dict, cluster: KubernetesCluster)
             item['password'] = ("%032x" % random.getrandbits(128))[:password_size]
 
         # if nothing defined then use default names
+        default_hosts = False
         if item.get('hosts') is None:
-            # is there default names found?
-            if not default_names:
-                raise Exception('Section #%s in vrrp_ips has no hosts, but default names can\'t be found.' % i)
-            # ok, default names found, and can be used
-            inventory['vrrp_ips'][i]['hosts'] = default_names
+            # Assign default list of all the balancer names. It can be an empty list.
+            # Assigning of initial balancers is necessary to property calculate 'keepalived' NodeGroup.
+            # TODO assign list(initial_balancers) copy to avoid inline modification of initial_balancers list.
+            #  https://github.com/Netcracker/KubeMarine/issues/248
+            item['hosts'] = initial_balancers
+            default_hosts = True
 
         for j, record in enumerate(item['hosts']):
             if isinstance(record, str):
-                item['hosts'][j] = {
+                item['hosts'][j] = record = {
                     'name': record
                 }
-            if not item['hosts'][j].get('priority'):
-                item['hosts'][j]['priority'] = cluster.globals['keepalived']['defaults']['priority']['max_value'] - \
-                                               (j + cluster.globals['keepalived']['defaults']['priority']['step'])
-            if not item['hosts'][j].get('interface') and item.get('interface'):
-                item['hosts'][j]['interface'] = item['interface']
-            if item['hosts'][j].get('interface', 'auto') == 'auto':
-                item['hosts'][j]['interface'] = autodetect_interface(cluster, item['hosts'][j]['name'])
+            if record['name'] not in final_balancers:
+                # If default hosts are assigned,
+                # the temporarily assigned host to be removed will be removed later from finalized inventory.
+                # See remove_node.remove_node_finalize_inventory().
+                if not default_hosts:
+                    cluster.log.warning(f"Host {record['name']!r} for VRRP IP {item['ip']} is not among the balancers. "
+                                        f"This VRRP IP will not be installed on this host.")
+                continue
+            if not record.get('priority'):
+                priority_settings = static.GLOBALS['keepalived']['defaults']['priority']
+                record['priority'] = priority_settings['max_value'] - (j + priority_settings['step'])
+            if not record.get('interface') and item.get('interface'):
+                record['interface'] = item['interface']
+            if record.get('interface', 'auto') == 'auto':
+                record['interface'] = autodetect_interface(cluster, record['name'])
 
     return inventory
 
 
-def get_default_node_names(inventory: dict) -> List[str]:
+def get_all_balancer_names(inventory: dict, *, final: bool = True) -> List[str]:
     default_names = []
 
     # well, vrrp_ips is not empty, let's find balancers defined in config-file
     for i, node in enumerate(inventory['nodes']):
-        if 'balancer' in node['roles']:
+        if 'balancer' in node['roles'] and (not final or 'remove_node' not in node['roles']):
             default_names.append(node['name'])
 
-    # just in case, we remove duplicates
-    return list(set(default_names))
+    return default_names
 
 
 def enrich_inventory_calculate_nodegroup(inventory: dict, cluster: KubernetesCluster) -> dict:
@@ -134,8 +143,8 @@ def enrich_inventory_calculate_nodegroup(inventory: dict, cluster: KubernetesClu
     # it is important to remove duplicates
     names = list(set(names))
 
-    # create new group where keepalived will be installed
-    cluster.nodes['keepalived'] = cluster.nodes['all'].new_group(apply_filter={
+    # Create new group from balancers with Keepalived (to be) on them. This includes nodes to be removed.
+    cluster.nodes['keepalived'] = cluster.make_group_from_roles(['balancer']).new_group(apply_filter={
         'name': names
     })
 
@@ -152,35 +161,39 @@ def install(group: NodeGroup) -> RunnersGroupResult:
     cluster: KubernetesCluster = group.cluster
     log = cluster.log
 
-    # todo why check and try to install all keepalives but finally filter out only new nodes?
-    group = group.get_new_nodes_or_self()
-    # todo consider probably different associations for nodes with different OS families
-    any_host = group.get_first_member().get_host()
-    package_associations = cluster.get_associations_for_node(any_host, 'keepalived')
+    defer = group.new_defer()
+    collector = CollectorCallback(cluster)
+    for node in defer.get_ordered_members_list():
+        executable_name = cluster.get_package_association_for_node(
+            node.get_host(), 'keepalived', 'executable_name')
+        node.sudo("%s -v" % executable_name, warn=True, callback=collector)
 
-    keepalived_version = group.sudo("%s -v" % package_associations['executable_name'], warn=True)
-    keepalived_installed = True
+    defer.flush()
 
-    for connection, result in keepalived_version.items():
-        if result.exited != 0:
-            keepalived_installed = False
-
-    if keepalived_installed:
+    if not collector.result.is_any_failed():
         log.debug("Keepalived already installed, nothing to install")
-        installation_result = keepalived_version
     else:
-        installation_result = packages.install(group, include=package_associations['package_name'])
+        collector = CollectorCallback(cluster)
+        for node in defer.get_ordered_members_list():
+            package_name = cluster.get_package_association_for_node(
+                node.get_host(), 'keepalived', 'package_name')
+            packages.install(node, include=package_name, callback=collector)
 
-    service_name = package_associations['service_name']
-    patch_path = "./resources/drop_ins/keepalived.conf"
-    group.call(system.patch_systemd_service, service_name=service_name, patch_source=patch_path)
-    group.call(install_haproxy_check_script)
-    enable(group)
+        defer.flush()
 
-    return installation_result
+    for node in defer.get_ordered_members_list():
+        service_name = cluster.get_package_association_for_node(
+            node.get_host(), 'keepalived', 'service_name')
+        patch_path = "./resources/drop_ins/keepalived.conf"
+        node.call(system.patch_systemd_service, service_name=service_name, patch_source=patch_path)
+        node.call(install_haproxy_check_script)
+        enable(node)
+
+    defer.flush()
+    return collector.result
 
 
-def install_haproxy_check_script(group: NodeGroup) -> None:
+def install_haproxy_check_script(group: DeferredGroup) -> None:
     script = utils.read_internal("./resources/scripts/check_haproxy.sh")
     group.put(io.StringIO(script), "/usr/local/bin/check_haproxy.sh", sudo=True)
     group.sudo("chmod +x /usr/local/bin/check_haproxy.sh")
@@ -203,12 +216,11 @@ def restart(group: NodeGroup) -> None:
     time.sleep(static.GLOBALS['keepalived']['restart_wait'])
 
 
-def enable(group: NodeGroup) -> None:
-    with group.new_executor() as exe:
-        for node in exe.group.get_ordered_members_list():
-            service_name = exe.cluster.get_package_association_for_node(
-                node.get_host(), 'keepalived', 'service_name')
-            system.enable_service(node, name=service_name, now=True)
+def enable(node: DeferredGroup) -> None:
+    # currently it is invoked only for single node
+    service_name = node.cluster.get_package_association_for_node(
+        node.get_host(), 'keepalived', 'service_name')
+    system.enable_service(node, name=service_name, now=True)
 
 
 def disable(group: NodeGroup) -> None:
@@ -219,9 +231,10 @@ def disable(group: NodeGroup) -> None:
             system.disable_service(node, name=service_name)
 
 
-def generate_config(inventory: dict, node: NodeConfig) -> str:
+def generate_config(cluster: KubernetesCluster, node: NodeConfig) -> str:
     config = ''
 
+    inventory = cluster.inventory
     for i, item in enumerate(inventory['vrrp_ips']):
 
         if i > 0:
@@ -233,16 +246,18 @@ def generate_config(inventory: dict, node: NodeConfig) -> str:
             'peers': []
         }
 
-        priority = 100
-        interface = 'eth0'
-        # todo Probably skip the VRRP if it not defined for this node?
-        #  Currently behaviour does not correspond to documentation.
         for record in item['hosts']:
             if record['name'] == node['name']:
                 priority = record['priority']
                 interface = record['interface']
+                break
+        else:
+            # This VRRP IP should not be configured on this node.
+            # There is still at least one VRRP IP to configure on this node
+            # due to the way how 'keepalived' group is calculated.
+            continue
 
-        for i_node in inventory['nodes']:
+        for i_node in cluster.nodes['keepalived'].get_final_nodes().get_ordered_members_configs_list():
             for record in item['hosts']:
                 if i_node['name'] == record['name'] and i_node['internal_address'] != ips['source']:
                     ips['peers'].append(i_node['internal_address'])
@@ -259,23 +274,35 @@ def configure(group: NodeGroup) -> RunnersGroupResult:
     cluster: KubernetesCluster = group.cluster
     log = cluster.log
 
+    collector = CollectorCallback(cluster)
     with group.new_executor() as exe:
         for node in exe.group.get_ordered_members_list():
             node_name = node.get_node_name()
             log.debug("Configuring keepalived on '%s'..." % node_name)
 
-            package_associations = cluster.get_associations_for_node(node.get_host(), 'keepalived')
-            configs_directory = '/'.join(package_associations['config_location'].split('/')[:-1])
+            config_location = cluster.get_package_association_for_node(
+                node.get_host(), 'keepalived', 'config_location')
 
-            exe.group.sudo('mkdir -p %s' % configs_directory)
-
-            config = generate_config(cluster.inventory, node.get_config())
+            config = generate_config(cluster, node.get_config())
             utils.dump_file(cluster, config, 'keepalived_%s.conf' % node_name)
 
-            node.put(io.StringIO(config), package_associations['config_location'], sudo=True)
+            node.put(io.StringIO(config), config_location, sudo=True, mkdir=True)
+            node.sudo('ls -la %s' % config_location, callback=collector)
 
-    log.debug(group.sudo('ls -la %s' % package_associations['config_location']))
+    log.debug(collector.result)
 
     restart(group)
 
-    return group.sudo('systemctl status %s' % package_associations['service_name'], warn=True)
+    return status(group)
+
+
+def status(group: NodeGroup) -> RunnersGroupResult:
+    cluster: KubernetesCluster = group.cluster
+    collector = CollectorCallback(cluster)
+    with group.new_executor() as exe:
+        for node in exe.group.get_ordered_members_list():
+            service_name = cluster.get_package_association_for_node(
+                node.get_host(), 'keepalived', 'service_name')
+            system.service_status(node, name=service_name, callback=collector)
+
+    return collector.result

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -22,8 +22,11 @@ The whole directory is automatically cleared and reset after new version of Kube
 from typing import List
 
 from kubemarine.core.patch import Patch
+from kubemarine.patches.p0_bind_vrrp_ips_interfaces import FixVRRP_IPsInterfaces
 
 patches: List[Patch] = [
+    # FixVRRP_IPsInterfaces should be the first RegularPatch.
+    FixVRRP_IPsInterfaces(),
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/p0_bind_vrrp_ips_interfaces.py
+++ b/kubemarine/patches/p0_bind_vrrp_ips_interfaces.py
@@ -1,0 +1,68 @@
+from textwrap import dedent
+from typing import Optional
+
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+
+
+class TheAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Set previously resolved interfaces for VRRP IPs")
+
+    def run(self, res: DynamicResources) -> None:
+        logger = res.logger()
+        cluster = res.cluster()
+
+        if cluster.make_group_from_roles(['keepalived']).is_empty():
+            return logger.info("Skipping the patch as Keepalived is not configured.")
+
+        first_resolved_interface: Optional[str] = None
+        for i, raw_item in enumerate(cluster.raw_inventory['vrrp_ips']):
+            # If hosts are not specified, they are resolved by new algorithm.
+            if isinstance(raw_item, str) or 'hosts' not in raw_item:
+                item = cluster.inventory['vrrp_ips'][i]
+                # There is at least one balancer that produced at least one host for VRRP IP
+                resolved_interface = item['hosts'][0]['interface']
+                if first_resolved_interface is None:
+                    first_resolved_interface = resolved_interface
+                    continue
+
+                # The further VRRP IPs without hosts previously was enriched with 'first_resolved_interface'
+                # Let's compare it with how it is resolved now.
+                if resolved_interface != first_resolved_interface:
+                    logger.info(f"Changing vrrp_ips[{i}].interface to {first_resolved_interface} "
+                                f"to preserve the backward compatibility.")
+                    formatted_item = res.formatted_inventory()['vrrp_ips'][i]
+                    if isinstance(raw_item, str):
+                        res.formatted_inventory()['vrrp_ips'][i] = formatted_item = {
+                            'ip': formatted_item
+                        }
+
+                    formatted_item['interface'] = first_resolved_interface
+                    item['interface'] = first_resolved_interface
+                    for record in item['hosts']:
+                        record['interface'] = first_resolved_interface
+
+                    self.recreate_inventory = True
+
+        if not self.recreate_inventory:
+            logger.info("Skipping the patch as interfaces for `vrrp_ips` were not changed.")
+
+
+class FixVRRP_IPsInterfaces(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("fix_vrrp_ips_interfaces")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            The patch sets previously resolved interfaces for the VRRP IPs
+            in the inventory to preserve the backward compatibility.
+            """.rstrip()
+        )

--- a/kubemarine/resources/schemas/add_node.json
+++ b/kubemarine/resources/schemas/add_node.json
@@ -10,13 +10,6 @@
         "$ref": "definitions/node.json"
       }
     },
-    "vrrp_ips": {
-      "type": "array",
-      "description": "List of VRRP IPs to be assigned to balancers. The VRRP IPs redefine the vrrp_ips section of cluster.yaml. Each item can be either a simple address string or a dictionary with the address and additional parameters.",
-      "items": {
-        "$ref": "definitions/vrrp_ip.json"
-      }
-    },
     "prepull_group_size": {"$ref": "definitions/procedures.json#/definitions/PrepullGroupSize"}
   },
   "required": ["nodes"],

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -219,6 +219,10 @@ def update_etc_hosts(group: NodeGroup, config: str) -> None:
     group.put(io.StringIO(config), "/etc/hosts", backup=True, sudo=True)
 
 
+def service_status(group: AbstractGroup[GROUP_RUN_TYPE], name: str, callback: Callback = None) -> GROUP_RUN_TYPE:
+    return group.sudo('systemctl status %s' % name, warn=True, callback=callback)
+
+
 def stop_service(group: AbstractGroup[GROUP_RUN_TYPE], name: str, callback: Callback = None) -> GROUP_RUN_TYPE:
     return group.sudo('systemctl stop %s' % name, callback=callback)
 

--- a/test/unit/core/test_flow.py
+++ b/test/unit/core/test_flow.py
@@ -332,15 +332,14 @@ class FlowTest(unittest.TestCase):
         self.assertIsInstance(exc, errors.FailException, msg="Exception should be raised")
         self.assertTrue(f"['{offline}'] are not reachable." in str(exc.reason))
 
-    def test_removed_node_can_be_offline(self):
-        inventory = demo.generate_inventory(**demo.FULLHA)
+    def test_any_removed_node_can_be_offline(self):
+        inventory = demo.generate_inventory(**demo.FULLHA_KEEPALIVED)
         online_hosts = [node["address"] for node in inventory["nodes"]]
-        masters = [i for i, node in enumerate(inventory["nodes"]) if 'master' in node['roles']]
 
-        i = random.randrange(len(masters))
-        online_hosts.pop(masters[i])
+        i = random.randrange(len(inventory["nodes"]))
+        online_hosts.pop(i)
         procedure_inventory = demo.generate_procedure_inventory('remove_node')
-        procedure_inventory["nodes"] = [{"name": inventory["nodes"][masters[i]]["name"]}]
+        procedure_inventory["nodes"] = [{"name": inventory["nodes"][i]["name"]}]
 
         self._stub_detect_nodes_context(inventory, online_hosts, [])
         context = demo.create_silent_context(['fake_path.yaml'], procedure='remove_node')

--- a/test/unit/test_coredns.py
+++ b/test/unit/test_coredns.py
@@ -195,3 +195,7 @@ data:
         self.assertNotIn('hosts /etc/coredns/Hosts', config)
         self.assertIn('template IN A k8s.fake.local', config)
         self.assertNotIn('forward . /etc/resolv.conf', config)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_keepalived.py
+++ b/test/unit/test_keepalived.py
@@ -259,6 +259,23 @@ class TestKeepalivedDefaultsEnrichment(unittest.TestCase):
         flow.ActionsFlow([add_node.AddNodeAction()]).run_flow(resources)
         return resources
 
+    def test_two_vrrp_different_interfaces(self):
+        scheme = demo.new_scheme(demo.ALLINONE, 'keepalived', 2)
+        inventory = demo.generate_inventory(**scheme)
+        inventory['vrrp_ips'][0] = {
+            'ip': inventory['vrrp_ips'][0],
+            'interface': 'inf1'
+        }
+        inventory['vrrp_ips'][1] = {
+            'ip': inventory['vrrp_ips'][1],
+            'interface': 'inf2'
+        }
+
+        cluster = demo.new_cluster(inventory)
+
+        self.assertEqual(cluster.inventory.get('vrrp_ips')[0]['hosts'][0]['interface'], 'inf1')
+        self.assertEqual(cluster.inventory.get('vrrp_ips')[1]['hosts'][0]['interface'], 'inf2')
+
     def test_password_enrich_exponential_float(self):
         # Make sure to execute global patches of environment / libraries
         from kubemarine import __main__

--- a/test/unit/test_keepalived.py
+++ b/test/unit/test_keepalived.py
@@ -15,10 +15,13 @@
 
 
 import unittest
+from typing import List
 
 import yaml
 
 from kubemarine import demo, keepalived, yum
+from kubemarine.core import flow
+from kubemarine.procedures import remove_node, add_node
 from test.unit import utils
 
 
@@ -129,10 +132,132 @@ class TestKeepalivedDefaultsEnrichment(unittest.TestCase):
         self.assertIn(balancer_1_ip, self.cluster.nodes['keepalived'].get_hosts())
 
     def test_vrrp_defined_no_hosts_and_balancers(self):
-        # vrrp_ip defined, but hosts for it is not defined + no balancers to auto determine -> then raise exception
+        # vrrp_ip defined, but hosts for it is not defined + no balancers to auto determine
         inventory = demo.generate_inventory(balancer=0, master=3, worker=3, keepalived=1)
-        with self.assertRaises(Exception):
-            demo.new_cluster(inventory)
+        # Cluster is enriched with warnings, and the VRRP IP is not taken into account.
+        cluster = demo.new_cluster(inventory)
+
+        self.assertTrue(cluster.make_group_from_roles(['keepalived']).is_empty())
+
+        utils.stub_associations_packages(cluster, {})
+        finalized_inventory = cluster.make_finalized_inventory()
+
+        self.assertEqual(1, len(finalized_inventory['vrrp_ips']))
+        self.assertEqual([], finalized_inventory['vrrp_ips'][0]['hosts'])
+
+    def test_vrrp_assigned_not_balancer(self):
+        inventory = demo.generate_inventory(master=3, worker=3, balancer=1, keepalived=1)
+        first_control_plane = next(node for node in inventory['nodes'] if 'master' in node['roles'])
+        inventory['vrrp_ips'][0] = {
+            'ip': inventory['vrrp_ips'][0],
+            'hosts': [first_control_plane['name']]
+        }
+
+        cluster = demo.new_cluster(inventory)
+
+        self.assertTrue(cluster.make_group_from_roles(['keepalived']).is_empty())
+
+        utils.stub_associations_packages(cluster, {})
+        finalized_inventory = cluster.make_finalized_inventory()
+
+        self.assertEqual(1, len(finalized_inventory['vrrp_ips']))
+        self.assertEqual(1, len(finalized_inventory['vrrp_ips'][0]['hosts']))
+        self.assertEqual(first_control_plane['name'], finalized_inventory['vrrp_ips'][0]['hosts'][0]['name'])
+
+    def test_vrrp_remove_only_balancer_enrich_group_finalized_hosts_empty(self):
+        inventory = demo.generate_inventory(master=3, worker=3, balancer=1, keepalived=1)
+        balancer = next(node for node in inventory['nodes'] if 'balancer' in node['roles'])
+
+        resources = self._run_remove_node(inventory, [balancer])
+        cluster = resources.last_cluster
+
+        self.assertEqual([balancer['name']], cluster.nodes['all'].get_nodes_for_removal().get_nodes_names(),
+                         "Unexpected nodes for removal")
+        self.assertEqual([balancer['name']], cluster.make_group_from_roles(['keepalived']).get_nodes_names(),
+                         "Node for removal should present among 'keepalived' group")
+
+        utils.stub_associations_packages(cluster, {})
+        finalized_inventory = cluster.make_finalized_inventory()
+
+        self.assertEqual(1, len(finalized_inventory['vrrp_ips']))
+        self.assertEqual([], finalized_inventory['vrrp_ips'][0]['hosts'])
+
+        self.assertEqual(1, len(resources.stored_inventory['vrrp_ips']))
+        self.assertEqual(inventory['vrrp_ips'], resources.stored_inventory['vrrp_ips'])
+
+    def test_vrrp_assigned_to_removed_balancer(self):
+        inventory = demo.generate_inventory(master=3, worker=3, balancer=2, keepalived=2)
+        balancers = [node for node in inventory['nodes'] if 'balancer' in node['roles']]
+        inventory['vrrp_ips'][0] = {
+            'ip': inventory['vrrp_ips'][0],
+            'hosts': [balancers[0]['name']],
+            'floating_ip': '1.1.1.1'
+        }
+        inventory['vrrp_ips'][1] = {
+            'ip': inventory['vrrp_ips'][1],
+            'floating_ip': '2.2.2.2'
+        }
+
+        resources = self._run_remove_node(inventory, [balancers[0]])
+        cluster = resources.last_cluster
+
+        self.assertEqual([balancers[0]['name']], cluster.nodes['all'].get_nodes_for_removal().get_nodes_names(),
+                         "Unexpected nodes for removal")
+        self.assertEqual([balancers[0]['name'], balancers[1]['name']], cluster.make_group_from_roles(['keepalived']).get_nodes_names(),
+                         "Node for removal should be present among 'keepalived' group")
+
+        utils.stub_associations_packages(cluster, {})
+        finalized_inventory = cluster.make_finalized_inventory()
+
+        self.assertEqual(2, len(finalized_inventory['vrrp_ips']))
+        self.assertEqual(1, len(finalized_inventory['vrrp_ips'][0]['hosts']))
+        self.assertEqual(balancers[0]['name'], finalized_inventory['vrrp_ips'][0]['hosts'][0]['name'])
+        self.assertEqual(1, len(finalized_inventory['vrrp_ips'][1]['hosts']))
+        self.assertEqual(balancers[1]['name'], finalized_inventory['vrrp_ips'][1]['hosts'][0]['name'])
+
+        self.assertEqual(2, len(resources.stored_inventory['vrrp_ips']))
+        self.assertEqual(inventory['vrrp_ips'], resources.stored_inventory['vrrp_ips'])
+
+    def test_remove_and_add_only_balancer(self):
+        inventory = demo.generate_inventory(master=3, worker=3, balancer=1, keepalived=1)
+        nodes_context = demo.generate_nodes_context(inventory)
+        balancer = next(node for node in inventory['nodes'] if 'balancer' in node['roles'])
+
+        resources = self._run_remove_node(inventory, [balancer], nodes_context=nodes_context)
+        cluster = resources.last_cluster
+
+        self.assertEqual([balancer['name']], cluster.make_group_from_roles(['keepalived']).get_nodes_names(),
+                         "Node for removal should present among 'keepalived' group")
+
+        resources = self._run_add_node(resources.stored_inventory, [balancer], nodes_context=nodes_context)
+        cluster = resources.last_cluster
+
+        self.assertEqual([balancer['name']], cluster.make_group_from_roles(['keepalived']).get_nodes_names(),
+                         "New nodes should present among 'keepalived' group")
+
+    def _run_remove_node(self, inventory: dict, nodes: List[dict], nodes_context = None) -> demo.FakeResources:
+        if nodes_context is None:
+            nodes_context = demo.generate_nodes_context(inventory)
+
+        context = demo.create_silent_context(['fake.yaml', '--without-act'], procedure='remove_node')
+        procedure_inventory = demo.generate_procedure_inventory('remove_node')
+        procedure_inventory['nodes'] = nodes
+        resources = demo.FakeResources(context, inventory, procedure_inventory=procedure_inventory,
+                                       nodes_context=nodes_context)
+        flow.ActionsFlow([remove_node.RemoveNodeAction()]).run_flow(resources)
+        return resources
+
+    def _run_add_node(self, inventory: dict, nodes: List[dict], nodes_context = None) -> demo.FakeResources:
+        if nodes_context is None:
+            nodes_context = demo.generate_nodes_context(inventory)
+
+        context = demo.create_silent_context(['fake.yaml', '--without-act'], procedure='add_node')
+        procedure_inventory = demo.generate_procedure_inventory('add_node')
+        procedure_inventory['nodes'] = nodes
+        resources = demo.FakeResources(context, inventory, procedure_inventory=procedure_inventory,
+                                       nodes_context=nodes_context)
+        flow.ActionsFlow([add_node.AddNodeAction()]).run_flow(resources)
+        return resources
 
     def test_password_enrich_exponential_float(self):
         # Make sure to execute global patches of environment / libraries
@@ -241,9 +366,49 @@ class TestKeepalivedInstallation(unittest.TestCase):
 
 class TestKeepalivedConfigGeneration(unittest.TestCase):
 
-    def test_(self):
-        # TODO: add test, where keepalived config generated, parsed and verified
-        pass
+    def test_skip_vrrp_not_assigned(self):
+        inventory = demo.generate_inventory(master=3, worker=3, balancer=2, keepalived=2)
+        first_balancer = next(node for node in inventory['nodes'] if 'balancer' in node['roles'])
+        inventory['vrrp_ips'][0] = {
+            'ip': inventory['vrrp_ips'][0],
+            'hosts': [first_balancer['name']],
+        }
+
+        cluster = demo.new_cluster(inventory)
+        enriched_vrrp_ips = cluster.inventory['vrrp_ips']
+
+        balancers = cluster.nodes['balancer'].get_ordered_members_configs_list()
+
+        config_1 = keepalived.generate_config(cluster, balancers[0])
+        self.assertIn(f"vrrp_instance balancer_{enriched_vrrp_ips[0]['id']}", config_1)
+        self.assertIn(f"vrrp_instance balancer_{enriched_vrrp_ips[1]['id']}", config_1)
+
+        config_2 = keepalived.generate_config(cluster, balancers[1])
+        self.assertNotIn(f"vrrp_instance balancer_{enriched_vrrp_ips[0]['id']}", config_2)
+        self.assertIn(f"vrrp_instance balancer_{enriched_vrrp_ips[1]['id']}", config_2)
+
+    def test_skip_removed_peers(self):
+        inventory = demo.generate_inventory(master=3, worker=3, balancer=3, keepalived=1)
+        first_balancer = next(node for node in inventory['nodes'] if 'balancer' in node['roles'])
+
+        context = demo.create_silent_context(['fake.yaml'], procedure='remove_node')
+        remove_node = demo.generate_procedure_inventory('remove_node')
+        remove_node['nodes'] = [first_balancer]
+
+        cluster = demo.new_cluster(inventory, procedure_inventory=remove_node, context=context)
+
+        balancers = cluster.nodes['balancer'].get_ordered_members_configs_list()
+
+        only_left_peer_template = """\
+    unicast_peer {{
+        {peer}
+    }}"""
+
+        config_2 = keepalived.generate_config(cluster, balancers[1])
+        self.assertIn(only_left_peer_template.format(peer=balancers[2]['internal_address']), config_2)
+
+        config_3 = keepalived.generate_config(cluster, balancers[2])
+        self.assertIn(only_left_peer_template.format(peer=balancers[1]['internal_address']), config_3)
 
 
 class TestKeepalivedConfigApply(unittest.TestCase):
@@ -253,7 +418,7 @@ class TestKeepalivedConfigApply(unittest.TestCase):
         cluster = demo.new_cluster(inventory)
 
         node = cluster.nodes['keepalived'].get_first_member()
-        expected_config = keepalived.generate_config(cluster.inventory, node.get_config())
+        expected_config = keepalived.generate_config(cluster, node.get_config())
 
         package_associations = cluster.inventory['services']['packages']['associations']['rhel']['keepalived']
         configs_directory = '/'.join(package_associations['config_location'].split('/')[:-1])

--- a/test/unit/test_remove_node.py
+++ b/test/unit/test_remove_node.py
@@ -1,0 +1,141 @@
+import json
+import os
+import tempfile
+import unittest
+from typing import List, Dict
+
+from kubemarine import demo
+from kubemarine.core import flow, utils
+from kubemarine.procedures import remove_node
+from test.unit import utils as test_utils
+
+
+class EnrichmentAndFinalization(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.context = demo.create_silent_context(['fake_path.yaml', '--without-act'], procedure='remove_node')
+
+        self.nodes_context = {}
+        self.inventory = {}
+        self.remove_node = demo.generate_procedure_inventory('remove_node')
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def _generate_inventory(self, scheme: Dict[str, demo._ROLE_SPEC]) -> dict:
+        self.inventory = demo.generate_inventory(**scheme)
+        self.nodes_context = demo.generate_nodes_context(self.inventory)
+        return self.inventory
+
+    def _run(self) -> demo.FakeResources:
+        resources = demo.FakeResources(self.context, self.inventory,
+                                       procedure_inventory=self.remove_node,
+                                       nodes_context=self.nodes_context)
+        flow.ActionsFlow([remove_node.RemoveNodeAction()]).run_flow(resources)
+        return resources
+
+    def test_allow_omitted_name(self):
+        self._generate_inventory(demo.MINIHA_KEEPALIVED)
+        for node in self.inventory['nodes']:
+            del node['name']
+        self.remove_node['nodes'] = [{'name': 'control-plane-2'}]
+
+        resources = self._run()
+        cluster = resources.last_cluster
+
+        nodes_for_removal = cluster.nodes['all'].get_nodes_for_removal()
+        self.assertEqual(['control-plane-2'], nodes_for_removal.get_nodes_names())
+
+        test_utils.stub_associations_packages(cluster, {})
+        finalized_inventory = cluster.make_finalized_inventory()
+
+        self.assertEqual(['control-plane-1', 'control-plane-3'], [node['name'] for node in finalized_inventory['nodes']])
+
+        self.assertEqual(['control-plane-1', 'control-plane-3'], [node['name'] for node in resources.stored_inventory['nodes']])
+
+    def test_ansible_inventory_no_removed_node(self):
+        args = self.context['execution_arguments']
+        ansible_inventory_location = os.path.join(self.tmpdir.name, 'ansible-inventory.ini')
+        args['ansible_inventory_location'] = ansible_inventory_location
+
+        self._generate_inventory(demo.MINIHA_KEEPALIVED)
+        node_name_remove = self.inventory['nodes'][0]['name']
+        self.remove_node['nodes'] = [{'name': node_name_remove}]
+
+        self._run()
+        self.assertTrue(os.path.exists(ansible_inventory_location),
+                        "Ansible inventory was not created")
+
+        ansible_inventory = utils.read_external(ansible_inventory_location)
+        for node in self.inventory['nodes']:
+            should_present = node['name'] != node_name_remove
+            self.assertEqual(should_present, node['name'] in ansible_inventory)
+
+    def test_remove_turned_off_balancer_maintenance_mode(self):
+        scheme = {'balancer': 3, 'master': 3, 'worker': 3, 'keepalived': 1, 'haproxy_mntc': 1}
+        self._generate_inventory(scheme)
+
+        balancers = [node for node in self.inventory['nodes'] if 'balancer' in node['roles']]
+        balancer_names = [node['name'] for node in balancers]
+        self.nodes_context[balancers[0]['address']] = {'access': {
+            'online': False,
+            'accessible': False,
+            'sudo': 'No'
+        }}
+        self.remove_node['nodes'] = [balancers[0], balancers[1]]
+        removed_balancer_names = [node['name'] for node in self.remove_node['nodes']]
+        online_balancer_names = [balancers[1]['name']]
+
+        cluster = self._run().last_cluster
+
+        self.assertEqual(removed_balancer_names, cluster.nodes['all'].get_nodes_for_removal().get_nodes_names(),
+                         "Unexpected nodes for removal")
+
+        for role in ('balancer', 'keepalived'):
+            self.assertEqual(balancer_names, cluster.make_group_from_roles([role]).get_nodes_names(),
+                             f"Node for removal should be present among {role!r} group")
+
+            self.assertEqual(online_balancer_names, remove_node.get_active_nodes(role, cluster).get_nodes_names(),
+                             f"Node for removal should be present among {role!r} group")
+
+    def test_enrich_certsans_with_custom(self):
+        args = self.context['execution_arguments']
+        ansible_inventory_location = os.path.join(self.tmpdir.name, 'ansible-inventory.ini')
+        args['ansible_inventory_location'] = ansible_inventory_location
+
+        self._generate_inventory(demo.MINIHA_KEEPALIVED)
+        self.remove_node['nodes'] = [self.inventory['nodes'][0], self.inventory['nodes'][1]]
+        self.inventory['services'].setdefault('kubeadm', {}).setdefault('apiServer', {})['certSANs'] = [
+            self.remove_node['nodes'][0]['name'], 'custom'
+        ]
+
+        def check_enriched_certsans(certsans: List[str]):
+            self.assertIn(self.inventory['nodes'][0]['name'], certsans)
+            self.assertNotIn(self.inventory['nodes'][1]['name'], certsans)
+            self.assertIn(self.inventory['nodes'][2]['name'], certsans)
+            self.assertIn('custom', certsans)
+
+        resources = self._run()
+        cluster = resources.last_cluster
+        certsans = cluster.inventory["services"]["kubeadm"]['apiServer']['certSANs']
+        check_enriched_certsans(certsans)
+
+        test_utils.stub_associations_packages(cluster, {})
+        finalized_inventory = cluster.make_finalized_inventory()
+        certsans = finalized_inventory["services"]["kubeadm"]['apiServer']['certSANs']
+        check_enriched_certsans(certsans)
+
+        certsans = resources.stored_inventory["services"]["kubeadm"]['apiServer']['certSANs']
+        self.assertIn(self.inventory['nodes'][0]['name'], certsans)
+        self.assertNotIn(self.inventory['nodes'][1]['name'], certsans)
+        self.assertNotIn(self.inventory['nodes'][2]['name'], certsans)
+        self.assertIn('custom', certsans)
+
+        ansible_inventory = utils.read_external(ansible_inventory_location)
+        kubeadm_apiserver = next(filter(lambda l: 'kubeadm_apiServer=' in l, ansible_inventory.split('\n')))
+        certsans = json.loads(kubeadm_apiserver[len('kubeadm_apiServer='):])['certSANs']
+        check_enriched_certsans(certsans)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_thirdparties.py
+++ b/test/unit/test_thirdparties.py
@@ -94,3 +94,5 @@ class SHACalculationTest(unittest.TestCase):
                          cluster.inventory['services']['thirdparties']["custom/thirdparty/with/sha"]['sha1'])
 
 
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
1. Incorrect calculation of `control_plain` section based on VRRP IPs.
1. Keepalived can be installed on not balancer, but not working due to dependency on HAProxy.
1. Incorrect configuration of VRRP IP on nodes on which it is not assigned to.
1. VRRP IPs should not be touched in user inventory to make remove_node & add_node procedures reversible.
1. If `vrrp_ips.interface` is explicitly specified, it does not work for few VRRP IPs.
1. Removing of offline balancers does not work.
1. Removing of nameless nodes does not work.
1. certSANs are duplicated in enriched inventory and incorrectly handled in cluster_finalized.yaml

Fixes #248

### Solution
1. Removed or absent hosts should not be taken into account during calculation of `control_plain` by VRRP IPs.
1. Keepalived can be installed only on balancers now.
1. VRRP IP is skipped in `keepalived.generate_config` if not assigned to the host.
1. `remove_node.remove_node_finalize_inventory` removes only the by-default enriched hosts.
1. Solved #248
1. Removed (offline) balancers no longer participate in enrichment of haproxy and keepalived configs.
1. Rearranged enrichment procedures to calculate node names at the earliest point.
1. certSANs are always checked for duplication. They should not be touched in the user inventory.
   certSANs for removed nodes should be absent in cluster_finalized.yaml if they are enriched by default.

### How to apply
Run `kubemarine migrate_kubemarine --force-apply fix_vrrp_ips_interfaces`.

### Test Cases

**TestCase 1**

No longer install Keepalived on not balancer. Raise WARNING instead and skip the installation.

Steps:

1. Configure inventory (required properties are skipped for clarity).
   ```yaml
   vrrp_ips:
     - hosts:
       - node-2

   nodes:
     - name: node-1
       roles: [balancer]
     - name: node-2
       roles: [control-plane, worker]
   ```
2. Run installation.

Results:

| Before | After |
| ------ | ------ |
| The cluster is installed, but it is not working as Keepalived failed to start due to haproxy check script | The cluster is installed and working, Keepalived is not installed on node-2 and is not taken into account |

**TestCase 2**

Remove the only turned off balancer with some vrrp_ips in maintenance mode.

Steps:

1. Configure inventory (required properties are skipped for clarity) and install the cluster.
   ```yaml
   vrrp_ips:
     - params: {maintenance-type: "not bind"}
     - {}

   nodes:
     - name: balancer-1
       roles: [balancer]
     - name: control-plane-1
       roles: [control-plane, worker]
   ```

ER: Cluster is installed and working.

2. Shutdown `balancer-1`
3. Remove node `balancer-1` through `kubemarine remove_node` procedure.

Results:

| Before | After |
| ------ | ------ |
| Remove node failed | The cluster is installed and working, control plane traffic goes through `control-plane-1` node. |

**TestCase 3**

Do not configure VRRP IP on hosts to which it is not assigned.

Test Configuration:

- OS: Ubuntu 20.04

Steps:

1. Configure inventory (required properties are skipped for clarity) and install the cluster.
   ```yaml
   vrrp_ips:
     - hosts: [node-1, node-2]
     - hosts: [node-2]

   nodes:
     - name: node-1
       roles: [control-plane, worker, balancer]
     - name: node-2
       roles: [control-plane, worker, balancer]
   ```
2. Check `systemctl status keepalived` and `journalctl --unit=keepalived.service -n 100 --no-pager` on nodes.

Results:

| Before | After |
| ------ | ------ |
| Keepalived tries to assign the 2nd VRRP IP to eth0 on `node-1` and fails to start. | The cluster is installed and working, Keeapalived is started on all nodes. The 2nd VRRP IP is not configured on `node-1`. |

**TestCase 4**

Reversible remove & add nodes

Steps:

1. Configure inventory (required properties are skipped for clarity) and install the cluster.
   ```yaml
   vrrp_ips:
     - {}

   nodes:
     - name: node-1
       roles: [balancer]
     - name: node-2
       roles: [control-plane, worker]
   ```
  
ER: Cluster is installed and working, control plane traffic goes through VRRP IP.

2. Remove `node-1` using `kubemarine remove_node`.
3. Add the same node back using `kubemarine add_node`.

Results:

| Before | After |
| ------ | ------ |
| Keepalived is not enabled, control plane traffic goes through the balancer. | Keepalived is installed and enabled, control plane traffic goes through VRRP IP. |

**TestCase 5**

Remove node from inventory without names.

Steps:

1. Configure inventory **without names** (required properties are skipped for clarity) and install the cluster.
   ```yaml
   vrrp_ips:
     - {}

   nodes:
     - roles: [control-plane, worker, balancer]
     - roles: [control-plane, worker, balancer]
     - roles: [control-plane, worker, balancer]
   ```

ER: Cluster is installed and working. Node names are generated as `control-plane-1`, `control-plane-2`, `control-plane-3`.

2. Remove node `control-plane-2` through `kubemarine remove_node` procedure and procedure inventory:
   ```yaml
   nodes:
     - name: control-plane-2
   ```

Results:

| Before | After |
| ------ | ------ |
| Remove node failed | The cluster is installed and working, the resulting inventory has two nodes with names `control-plane-1`, `control-plane-3` |

**TestCase 6**

API server certSANs in finalized inventory.

Steps:

1. Configure inventory (required properties are skipped for clarity) and install the cluster.
   ```yaml
   vrrp_ips:
     - {}

   nodes:
     - name: node-1
       roles: [control-plane, worker, balancer]
     - name: node-2
       roles: [control-plane, worker, balancer]
     - name: node-3
       roles: [control-plane, worker, balancer]
       
   services:
     kubeadm:
       apiServer:
         certSANs:
           - node-2
   ```

2. Check cluster_finalized.yaml

Results:

| Before | After |
| ------ | ------ |
| certSANs for `node-2` are duplicated | certSANs are not duplicated |

3. Remove node `node-3` through `kubemarine remove_node`.
4. Check cluster_finalized.yaml

Results:

| Before | After |
| ------ | ------ |
| cert SANs for `node-3` are present | cert SANs for `node-3` are absent |

5. Remove node `node-2` through `kubemarine remove_node`.
6. Check cluster_finalized.yaml

ER: cert SANs for `node-2` are still present

**TestCase 7**

Custom 'interface' for VRRP IPs without hosts.

Steps:

1. Configure inventory with two VRRP IPs with different custom interfaces (required properties are skipped for clarity) and install the cluster.
   ```yaml
   vrrp_ips:
     - interface: inf1
     - interface: inf2

   nodes:
     - roles: [control-plane, worker, balancer]
   ```

2. Check that the VRRP IPs are bound to the specified interfaces.

Results:

| Before | After |
| ------ | ------ |
| Bound to the same `inf1` interface | Bound to the specified interfaces |

**TestCase 8**

Migrate old inventory.

Steps:

1. Configure inventory with two VRRP IPs with different custom interfaces (required properties are skipped for clarity)
   ```yaml
   vrrp_ips:
     - interface: inf1
     - interface: inf2

   nodes:
     - roles: [control-plane, worker, balancer]
   ```

2. Install the cluster using **old** Kubemarine.

ER: both VRRP IPs are bound to `inf1`.

3. Run `kubemarine migrate_kubemarine --force-apply fix_vrrp_ips_interfaces`

ER: The inventory becomes
   ```yaml
   vrrp_ips:
     - interface: inf1
     - interface: inf1
   ```

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
test_defaults.py - control_plain calculation based on VRRP IP
test_inventory.py - test enrich certSANs
test_keepalived.py - enrich VRRP IPs hosts, keepalived group, and generate config
test_remove_node.py - various remove_node enrichment cases
test_flow - remove offline node