### PR TITLE
[CPDEV-94459] Backup custom apt repositories

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -552,6 +552,7 @@ By default, the following files are backed up from all nodes in the cluster:
 * /etc/systemd/system/{keepalived_service_name}.service.d/{keepalived_service_name}.conf
 * /usr/local/bin/check_haproxy.sh
 * /etc/yum.repos.d/
+* /etc/apt/sources.list.d/
 * /etc/modules-load.d/
 * /etc/audit/rules.d/
 * /etc/kubernetes/

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -50,6 +50,7 @@ def get_default_backup_files_list(cluster: KubernetesCluster) -> List[str]:
         "/etc/chrony.conf",
         "/etc/selinux/config",
         "/etc/yum.repos.d/",
+        "/etc/apt/sources.list.d/",
         "/var/lib/kubelet/pki",
         "/etc/modules-load.d/",
         "/etc/audit/rules.d/",


### PR DESCRIPTION
### Description
* Backup procedure does not backup custom apt repositories.

Fixes #282

### Solution
* Add `/etc/apt/sources.list.d/` to the list of directories to backup.

### Test Cases

**TestCase 1**

Backup and restore custom apt repo.

Test Configuration:

- OS: Ubuntu 20.04

Steps:

1. Install the cluster with custom `services.packages.package_manager.repositories`
2. `apt show` some package from some of there repos.
3. Run backup.
4. Remove the repos from nodes manually or using Kubemarine.
5. `apt show` the same package.

ER: package is shown.

7. Run restore.
8. `apt show` the same package.

Results:

| Before | After |
| ------ | ------ |
| Package is not shown | Package is shown  |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
