### PR TITLE
[CPDEV-94486] Add sysctl and audit rules validation

### DIFF
--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -74,7 +74,8 @@ This section provides information about the Kubecheck functionality.
     - [227 Apparmor Status](#227-apparmor-status)
     - [228 Apparmor Configuration](#228-apparmor-configuration)
     - [229 Audit Policy Configuration](#229-audit-policy-configuration)
-    - [231 Kernel Parameters Configuration](#231-kernel-parameters-configuration)
+    - [231 Audit Daemon Rules](#231-audit-daemon-rules)
+    - [232 Kernel Parameters Configuration](#232-kernel-parameters-configuration)
 - [Report File Generation](#report-file-generation)
   - [HTML Report](#html-report)
   - [CSV Report](#csv-report)
@@ -700,7 +701,15 @@ The test checks the AppArmor configuration. It has several modes: `enforce`, `co
 This test checks that the configuration of Kubernetes audit policy is actual
 and matches the effectively resolved configuration from the inventory.
 
-##### 231 Kernel Parameters Configuration
+##### 231 Audit Daemon Rules
+
+*Task*: `system.audit.rules`
+
+This test compares the Audit rules on the nodes
+with the rules specified in the inventory or with the default rules.
+If the configured rules are not presented, the test fails.
+
+##### 232 Kernel Parameters Configuration
 
 *Task*: `system.sysctl.config`
 

--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -713,7 +713,7 @@ If the configured rules are not presented, the test fails.
 
 *Task*: `system.sysctl.config`
 
-This test compares the kernel parameters on the nodes
+This test compares the Kernel parameters on the nodes
 with the parameters specified in the inventory or with the default parameters.
 If the configured parameters are not presented, the test fails.
 

--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -713,7 +713,7 @@ If the configured rules are not presented, the test fails.
 
 *Task*: `system.sysctl.config`
 
-This test compares the Kernel parameters on the nodes
+This test compares the kernel parameters on the nodes
 with the parameters specified in the inventory or with the default parameters.
 If the configured parameters are not presented, the test fails.
 

--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -74,6 +74,7 @@ This section provides information about the Kubecheck functionality.
     - [227 Apparmor Status](#227-apparmor-status)
     - [228 Apparmor Configuration](#228-apparmor-configuration)
     - [229 Audit Policy Configuration](#229-audit-policy-configuration)
+    - [231 Kernel Parameters Configuration](#231-kernel-parameters-configuration)
 - [Report File Generation](#report-file-generation)
   - [HTML Report](#html-report)
   - [CSV Report](#csv-report)
@@ -698,6 +699,14 @@ The test checks the AppArmor configuration. It has several modes: `enforce`, `co
 
 This test checks that the configuration of Kubernetes audit policy is actual
 and matches the effectively resolved configuration from the inventory.
+
+##### 231 Kernel Parameters Configuration
+
+*Task*: `system.sysctl.config`
+
+This test compares the kernel parameters on the nodes
+with the parameters specified in the inventory or with the default parameters.
+If the configured parameters are not presented, the test fails.
 
 ### Report File Generation
 

--- a/kubemarine/audit.py
+++ b/kubemarine/audit.py
@@ -28,7 +28,10 @@ from kubemarine.core.group import NodeGroup, RunnersGroupResult, CollectorCallba
 
 
 def verify_inventory(inventory: dict, cluster: KubernetesCluster) -> dict:
-    for host in cluster.nodes['all'].get_final_nodes().get_hosts():
+    for node in cluster.nodes['all'].get_final_nodes().get_ordered_members_list():
+        if node.get_nodes_os() in ('unknown', 'unsupported'):
+            continue
+        host = node.get_host()
         package_name = cluster.get_package_association_for_node(host, 'audit', 'package_name')
         if isinstance(package_name, str):
             package_name = [package_name]

--- a/kubemarine/audit.py
+++ b/kubemarine/audit.py
@@ -18,7 +18,8 @@ Using this module you can install, enable audit and configure audit rules.
 """
 
 import io
-from typing import Optional
+import shlex
+from typing import Optional, Tuple, List, Set
 
 from kubemarine import system, packages
 from kubemarine.core import utils
@@ -80,6 +81,10 @@ def install(group: NodeGroup) -> Optional[RunnersGroupResult]:
     return collector.result
 
 
+def make_config(cluster: KubernetesCluster) -> str:
+    return " \n".join(cluster.inventory['services']['audit']['rules'])
+
+
 def apply_audit_rules(group: NodeGroup) -> RunnersGroupResult:
     """
     Generates and applies audit rules to the group
@@ -89,8 +94,13 @@ def apply_audit_rules(group: NodeGroup) -> RunnersGroupResult:
     cluster: KubernetesCluster = group.cluster
     log = cluster.log
 
+    rules_valid, auditctl_results = audit_rules_valid(group)
+    if rules_valid:
+        log.debug('Auditd rules are already actual on all nodes')
+        return auditctl_results
+
     log.debug('Applying audit rules...')
-    rules_content = " \n".join(cluster.inventory['services']['audit']['rules'])
+    rules_content = make_config(cluster)
     utils.dump_file(cluster, rules_content, 'audit.rules')
 
     collector = CollectorCallback(cluster)
@@ -104,4 +114,30 @@ def apply_audit_rules(group: NodeGroup) -> RunnersGroupResult:
             service_name = cluster.get_package_association_for_node(host, 'audit', 'service_name')
             node.sudo(f'service {service_name} restart', callback=collector)
 
-    return collector.result
+    _, auditctl_results = audit_rules_valid(group, silent=True)
+    return auditctl_results
+
+
+def audit_rules_valid(group: NodeGroup, silent: bool = False) -> Tuple[bool, RunnersGroupResult]:
+    cluster: KubernetesCluster = group.cluster
+    logger = cluster.log
+
+    rules_content = make_config(cluster)
+
+    collector = CollectorCallback(cluster)
+    with group.new_executor() as exe:
+        for node in exe.group.get_ordered_members_list():
+            executable = cluster.get_package_association_for_node(node.get_host(), 'audit', 'executable_name')
+            node.sudo(f'{executable} -l', callback=collector)
+
+    verify_results = collector.result
+    rules_valid = True
+    for host, result in verify_results.items():
+        tokens: List[Set[str]] = [set(shlex.split(line)) for line in result.stdout.rstrip('\n').split('\n')]
+        for rule in rules_content.split('\n'):
+            if not any(set(shlex.split(rule)).issubset(token) for token in tokens):
+                if not silent:
+                    logger.debug(f'Audit rule {rule!r} is not found at {host}')
+                rules_valid = False
+
+    return rules_valid, verify_results

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -417,7 +417,7 @@ def new_cluster(inventory: dict, procedure_inventory: dict = None, context: dict
 
 def generate_nodes_context(inventory: dict, os_name: str = 'centos', os_version: str = '7.9',
                            net_interface: str = 'eth0') -> dict:
-    os_family = system.detect_of_family_by_name_version(os_name, os_version)
+    os_family = system.detect_os_family_by_name_version(os_name, os_version)
 
     context = {}
     for node in inventory['nodes']:

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -849,7 +849,6 @@ def verify_modprobe_rules(cluster: KubernetesCluster) -> None:
     :return: None
     """
     with TestCase(cluster, '217', "System", "Modprobe rules") as tc:
-        _check_same_os(cluster)
         group = cluster.nodes['all']
         modprobe_valid, modprobe_result = system.is_modprobe_valid(group)
         cluster.log.debug(modprobe_result)

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -25,7 +25,7 @@ import ruamel.yaml
 import ipaddress
 import uuid
 
-from kubemarine import packages as pckgs, system, selinux, etcd, thirdparties, apparmor, kubernetes, sysctl
+from kubemarine import packages as pckgs, system, selinux, etcd, thirdparties, apparmor, kubernetes, sysctl, audit
 from kubemarine.core.action import Action
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.group import NodeConfig, NodeGroup
@@ -869,7 +869,7 @@ def verify_sysctl_config(cluster: KubernetesCluster) -> None:
     :param cluster: KubernetesCluster object
     :return: None
     """
-    with TestCase(cluster, '231', "System", "Kernel Parameters") as tc:
+    with TestCase(cluster, '232', "System", "Kernel Parameters") as tc:
         group = cluster.nodes['all']
         sysctl_valid = sysctl.is_valid(group)
         if sysctl_valid:
@@ -878,6 +878,27 @@ def verify_sysctl_config(cluster: KubernetesCluster) -> None:
         else:
             raise TestFailure('invalid',
                               hint=f"Some configured kernel parameters are not loaded on the cluster nodes.\n"
+                                   f"Check manually what the differences are, and make changes on the appropriate nodes.")
+
+
+def verify_system_audit_rules(cluster: KubernetesCluster) -> None:
+    """
+    This test compares the Audit rules on the nodes
+    with the rules specified in the inventory or with the default rules.
+    If the configured rules are not presented, the test fails.
+
+    :param cluster: KubernetesCluster object
+    :return: None
+    """
+    with TestCase(cluster, '231', "System", "Audit Daemon Rules") as tc:
+        group = cluster.nodes['all']
+        rules_valid, auditctl_results = audit.audit_rules_valid(group)
+        cluster.log.debug(auditctl_results)
+        if rules_valid:
+            tc.success(results='valid')
+        else:
+            raise TestFailure('invalid',
+                              hint=f"Some configured Audit rules are not loaded on the cluster nodes.\n"
                                    f"Check manually what the differences are, and make changes on the appropriate nodes.")
 
 
@@ -1490,7 +1511,10 @@ tasks = OrderedDict({
             },
             'sysctl': {
                 'config': verify_sysctl_config
-            }
+            },
+            'audit': {
+                'rules': verify_system_audit_rules
+            },
         },
         'haproxy': {
             'status': lambda cluster: services_status(cluster, 'haproxy'),

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -891,7 +891,7 @@ def verify_system_audit_rules(cluster: KubernetesCluster) -> None:
     :return: None
     """
     with TestCase(cluster, '231', "System", "Audit Daemon Rules") as tc:
-        group = cluster.nodes['all']
+        group = cluster.make_group_from_roles(['control-plane', 'worker'])
         rules_valid, auditctl_results = audit.audit_rules_valid(group)
         cluster.log.debug(auditctl_results)
         if rules_valid:

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -23,7 +23,7 @@ from typing import Dict, Tuple, Optional, List
 from dateutil.parser import parse
 from ordered_set import OrderedSet
 
-from kubemarine import selinux, kubernetes, apparmor
+from kubemarine import selinux, kubernetes, apparmor, sysctl
 from kubemarine.core import utils, static
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.executor import RunnersResult, Token, GenericResult, Callback, RawExecutor
@@ -590,6 +590,16 @@ def verify_system(cluster: KubernetesCluster) -> None:
             raise Exception("Required kernel modules are not presented")
     else:
         log.debug('Modprobe verification skipped - origin setup task was not completed')
+
+    if cluster.is_task_completed('prepare.system.sysctl'):
+        log.debug("Verifying kernel parameters...")
+        sysctl_valid = sysctl.is_valid(group)
+        if not sysctl_valid:
+            raise Exception("Required kernel parameters are not presented")
+        else:
+            log.debug("Required kernel parameters are presented")
+    else:
+        log.debug('Kernel parameters verification skipped - origin setup task was not completed')
 
 
 def detect_active_interface(cluster: KubernetesCluster) -> None:


### PR DESCRIPTION
### Description
* Need to add validation of kernel parameters and audit rules.

Fixes #42

### Solution
* Added validation of already configured sysctl parameters and audit rules during the `install` procedure.
  If they are actual, the configuration is skipped.
* After #331 we no longer need reboot before configuring of sysctl.
  Reboot and `verify_system` now happen after configuring of sysctl.
  Added validation that sysctl parameters are still actual after reboot.
* Added PaaS checks of sysctl parameters and audit rules.

### Test Cases

**TestCase 1**

Double installation skips configuration of kernel parameters and audit rules.

Steps:

1. Install the cluster, and then run `install` procedure to reinstall the cluster.

Results:

| Before | After |
| ------ | ------ |
| sysctl parameters and audit rules are always reconfigured | sysctl parameters and audit rules are not reconfigured during re-installation |

**TestCase 2**

PaaS check of kernel parameters and audit rules.

Steps:

1. Install the cluster, and run check_paas

ER: new checks 231 and 232 are successfull

2. Change sysctl parameters or audit rules in `cluster.yaml`
3. Run check_paas

ER: 231 or 232 checks fail.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_audit.py - audit.configure() now returns list of rules. Corresponding test is updated.
