### PR TITLE
[CPDEV-94593] Upgrade to v1.28.3 issue

### DIFF
--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -18,7 +18,7 @@ This section provides troubleshooting information for Kubemarine and Kubernetes 
   - [`kube-controller-manager` Unable to Sync Caches for Garbage Collector](#kube-controller-manager-unable-to-sync-caches-for-garbage-collector)
   - [Etcdctl Compaction and Defragmentation](#etcdctl-compaction-and-defragmentation)
   - [Etcdctl Defrag Return Context Deadline Exceeded](#etcdctl-defrag-return-context-deadline-exceeded)
-  - [Etcdserver Request Timeout](#etcdserver-request-rimeout)
+  - [Etcdserver Request Timeout](#etcdserver-request-timeout)
   - [Etcd Database Corruption](#etcd-database-corruption)
     - [Manual Restoration of Etcd Database](#manual-restoration-of-etcd-database)
   - [HTTPS Ingress Doesn't Work](#https-ingress-doesnt-work)
@@ -36,7 +36,7 @@ This section provides troubleshooting information for Kubemarine and Kubernetes 
   - [Failure During Installation on Ubuntu OS With Cloud-init](#failure-during-installation-on-ubuntu-os-with-cloud-init)
   - [Troubleshooting an Installation That Ended Incorrectly](#troubleshooting-an-installation-that-ended-incorrectly)
   - [Kubelet Has Conflict With Kubepods-burstable.slice and Kube-proxy Pods Stick in ContainerCreating Status](#kubelet-has-conflict-with-kubepods-burstableslice-and-kube-proxy-pods-stick-in-containercreating-status)
-  - [Upgrade Procedure to v1.28.3 Fails on ETCD Step](#upgrade-procedure-to-v1.28.3-fails-on-etcd-step)
+  - [Upgrade Procedure to v1.28.3 Fails on ETCD Step](#upgrade-procedure-to-v1283-fails-on-etcd-step)
   - [kubectl logs and kubectl exec fail](#kubectl-logs-and-kubectl-exec-fail)
 
 # Kubemarine Errors
@@ -474,13 +474,13 @@ Failed to defragment etcd member
 
 **Symptoms**: there are such error messages in the `kubelet` logs:
 
-```commandline
+```bash
 Apr 23 06:32:33 node-9 kubelet: 2023-04-23 06:32:33.378 [ERROR][9428] ipam_plugin.go 309: Failed to release address ContainerID="8938210a16212763148e8fcc3b4785440eea07e52ff82d1f0370495ed3315ffc" HandleID="k8s-pod-network.8938210a16212763148e8fcc3b4785440eea07e52ff82d1f0370495ed3315ffc" Workload="example-workload-name" error=etcdserver: request timed out
 ```
 
 In etcd logs there are such messages:
 
-```commandline
+```bash
 2023-04-29 06:06:16.087641 W | etcdserver: failed to send out heartbeat on time (exceeded the 100ms timeout for 6.102899ms, to fa4ddfec63d549fc)
 ```
 
@@ -500,7 +500,7 @@ Then add the following flags to the `/etc/kubernetes/manifests/etcd.yaml` manife
 Also it is recommended to set different `snapshot-count` values at different control-plane nodes so they persist snapshots to the disk not simultaneously.
 Default value of `snapshot-count` is `10000`, so set it to a different value at the second and the third control-plane nodes in the `/etc/kubernetes/manifests/etcd.yaml` manifest, for example:
 
-```commandline
+```bash
 # second master: 
 --snapshot-count=11210
 # third master:
@@ -1133,7 +1133,7 @@ kind: Pod
 spec:
   containers:
   - command:
-...
+      ...  
     image: registry.k8s.io/etcd:3.5.9-0
     imagePullPolicy: IfNotPresent
     livenessProbe:
@@ -1145,7 +1145,7 @@ spec:
         scheme: HTTP
       initialDelaySeconds: 10
       periodSeconds: 10
--     successThreshold: 1
+      successThreshold: 1
       timeoutSeconds: 15
     name: etcd
     resources:
@@ -1161,26 +1161,26 @@ spec:
         scheme: HTTP
       initialDelaySeconds: 10
       periodSeconds: 10
--     successThreshold: 1
+      successThreshold: 1
       timeoutSeconds: 15
--   terminationMessagePath: /dev/termination-log
--   terminationMessagePolicy: File
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
     volumeMounts:
     - mountPath: /var/lib/etcd
       name: etcd-data
     - mountPath: /etc/kubernetes/pki/etcd
       name: etcd-certs
-- dnsPolicy: ClusterFirst
-- enableServiceLinks: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
   hostNetwork: true
   priority: 2000001000
   priorityClassName: system-node-critical
-- restartPolicy: Always
-- schedulerName: default-scheduler
+  restartPolicy: Always
+  schedulerName: default-scheduler
   securityContext:
     seccompProfile:
       type: RuntimeDefault
-- terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 30
 ...
 ```
 

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -36,7 +36,7 @@ This section provides troubleshooting information for Kubemarine and Kubernetes 
   - [Failure During Installation on Ubuntu OS With Cloud-init](#failure-during-installation-on-ubuntu-os-with-cloud-init)
   - [Troubleshooting an Installation That Ended Incorrectly](#troubleshooting-an-installation-that-ended-incorrectly)
   - [Kubelet Has Conflict With Kubepods-burstable.slice and Kube-proxy Pods Stick in ContainerCreating Status](#kubelet-has-conflict-with-kubepods-burstableslice-and-kube-proxy-pods-stick-in-containercreating-status)
-  - [Upgrade Procedure Fails on ETCD Step](#upgrade-procedure-fails-on-etcd-step)
+  - [Upgrade Procedure to v1.28.3 Fails on ETCD Step](#upgrade-procedure-fails-on-etcd-step)
   - [kubectl logs and kubectl exec fail](#kubectl-logs-and-kubectl-exec-fail)
 
 # Kubemarine Errors

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -36,6 +36,7 @@ This section provides troubleshooting information for Kubemarine and Kubernetes 
   - [Failure During Installation on Ubuntu OS With Cloud-init](#failure-during-installation-on-ubuntu-os-with-cloud-init)
   - [Troubleshooting an Installation That Ended Incorrectly](#troubleshooting-an-installation-that-ended-incorrectly)
   - [Kubelet Has Conflict With Kubepods-burstable.slice and Kube-proxy Pods Stick in ContainerCreating Status](#kubelet-has-conflict-with-kubepods-burstableslice-and-kube-proxy-pods-stick-in-containercreating-status)
+  - [Upgrade Procedure Fails on ETCD Step](#upgrade-procedure-fails-on-etcd-step)
   - [kubectl logs and kubectl exec fail](#kubectl-logs-and-kubectl-exec-fail)
 
 # Kubemarine Errors
@@ -1105,7 +1106,7 @@ If other files except images and containers use the disk so that GC cannot free 
 KUBELET_KUBEADM_ARGS="--cgroup-driver=systemd --network-plugin=cni --pod-infra-container-image=registry.k8s.io/pause:3.1 --kube-reserved cpu=200m,memory=256Mi --system-reserved cpu=200m,memory=512Mi --max-pods 250 --image-gc-high-threshold 80 --image-gc-low-threshold 70"
 ```
 
-### Upgrade Procedure Fails on etcd step
+### Upgrade Procedure Fails on ETCD Step
 
 **Symptoms**:
 Upgrade procedure from v1.28.x to v1.28.3 fails with error message:
@@ -1114,17 +1115,17 @@ Upgrade procedure from v1.28.x to v1.28.3 fails with error message:
 2023-11-10 11:56:44,465 CRITICAL        Command: "sudo kubeadm upgrade apply v1.28.3 -f --certificate-renewal=true --ignore-preflight-errors='Port-6443,CoreDNSUnsupportedPlugins' --patches=/etc/kubernetes/patches && sudo kubectl uncordon ubuntu && sudo systemctl restart kubelet"
 ```
 
-and debug log has the following message:
+and `debug.log` has the following message:
 
 ```
 2023-11-10 11:56:44,441 140368685827904 DEBUG [__init__.upgrade_first_control_plane]    [upgrade/apply] FATAL: fatal error when trying to upgrade the etcd cluster, rolled the state back to pre-upgrade state: couldn't upgrade control plane. kubeadm has tried to recover everything into the earlier state. Errors faced: static Pod hash for component etcd on Node ubuntu did not change after 5m0s: timed out waiting for the condition
 ```
 
-**Root cause**: currently is undefined
+**Root cause**: `kubeadm v1.28.0` adds default fields that are not comatible with `kubeadm v1.28.3`
 
-**Solution**: remove the following parts from the `etcd.yaml` manifest:
+**Solution**: remove the following parts from the `etcd.yaml` manifest(lines are marked by `-`):
 
-```
+```yaml
 apiVersion: v1
 kind: Pod
 ...

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -36,7 +36,7 @@ This section provides troubleshooting information for Kubemarine and Kubernetes 
   - [Failure During Installation on Ubuntu OS With Cloud-init](#failure-during-installation-on-ubuntu-os-with-cloud-init)
   - [Troubleshooting an Installation That Ended Incorrectly](#troubleshooting-an-installation-that-ended-incorrectly)
   - [Kubelet Has Conflict With Kubepods-burstable.slice and Kube-proxy Pods Stick in ContainerCreating Status](#kubelet-has-conflict-with-kubepods-burstableslice-and-kube-proxy-pods-stick-in-containercreating-status)
-  - [Upgrade Procedure to v1.28.3 Fails on ETCD Step](#upgrade-procedure-fails-on-etcd-step)
+  - [Upgrade Procedure to v1.28.3 Fails on ETCD Step](#upgrade-procedure-to-v1.28.3-fails-on-etcd-step)
   - [kubectl logs and kubectl exec fail](#kubectl-logs-and-kubectl-exec-fail)
 
 # Kubemarine Errors
@@ -1106,7 +1106,7 @@ If other files except images and containers use the disk so that GC cannot free 
 KUBELET_KUBEADM_ARGS="--cgroup-driver=systemd --network-plugin=cni --pod-infra-container-image=registry.k8s.io/pause:3.1 --kube-reserved cpu=200m,memory=256Mi --system-reserved cpu=200m,memory=512Mi --max-pods 250 --image-gc-high-threshold 80 --image-gc-low-threshold 70"
 ```
 
-### Upgrade Procedure Fails on ETCD Step
+### Upgrade Procedure to v1.28.3 Fails on ETCD Step
 
 **Symptoms**:
 Upgrade procedure from v1.28.0(v1.28.1, v1.28.2 as well) to v1.28.3 fails with error message:

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -1109,7 +1109,7 @@ KUBELET_KUBEADM_ARGS="--cgroup-driver=systemd --network-plugin=cni --pod-infra-c
 ### Upgrade Procedure Fails on ETCD Step
 
 **Symptoms**:
-Upgrade procedure from v1.28.x to v1.28.3 fails with error message:
+Upgrade procedure from v1.28.0(v1.28.1, v1.28.2 as well) to v1.28.3 fails with error message:
 
 ```
 2023-11-10 11:56:44,465 CRITICAL        Command: "sudo kubeadm upgrade apply v1.28.3 -f --certificate-renewal=true --ignore-preflight-errors='Port-6443,CoreDNSUnsupportedPlugins' --patches=/etc/kubernetes/patches && sudo kubectl uncordon ubuntu && sudo systemctl restart kubelet"
@@ -1121,7 +1121,7 @@ and `debug.log` has the following message:
 2023-11-10 11:56:44,441 140368685827904 DEBUG [__init__.upgrade_first_control_plane]    [upgrade/apply] FATAL: fatal error when trying to upgrade the etcd cluster, rolled the state back to pre-upgrade state: couldn't upgrade control plane. kubeadm has tried to recover everything into the earlier state. Errors faced: static Pod hash for component etcd on Node ubuntu did not change after 5m0s: timed out waiting for the condition
 ```
 
-**Root cause**: `kubeadm v1.28.0` adds default fields that are not comatible with `kubeadm v1.28.3`
+**Root cause**: `kubeadm v1.28.0` adds default fields that are not compatible with `kubeadm v1.28.3`
 
 **Solution**: remove the following parts from the `etcd.yaml` manifest(lines are marked by `-`):
 

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -1123,7 +1123,8 @@ and `debug.log` has the following message:
 
 **Root cause**: `kubeadm v1.28.0` adds default fields that are not compatible with `kubeadm v1.28.3`
 
-**Solution**: remove the following parts from the `etcd.yaml` manifest(lines are marked by `-`):
+**Solution**: 
+* Remove the following parts from the `etcd.yaml` manifest on each control plane node in the cluster one by one(lines are marked by `-`):
 
 ```yaml
 apiVersion: v1
@@ -1183,7 +1184,8 @@ spec:
 ...
 ```
 
-wait for the ETCD restart and run upgrade procedure once again.
+* Wait for the ETCD restart.
+* Run upgrade procedure once again.
 
 ## Numerous Generation of `Auditd` System
 

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -1120,7 +1120,7 @@ and debug log has the following message:
 2023-11-10 11:56:44,441 140368685827904 DEBUG [__init__.upgrade_first_control_plane]    [upgrade/apply] FATAL: fatal error when trying to upgrade the etcd cluster, rolled the state back to pre-upgrade state: couldn't upgrade control plane. kubeadm has tried to recover everything into the earlier state. Errors faced: static Pod hash for component etcd on Node ubuntu did not change after 5m0s: timed out waiting for the condition
 ```
 
-**Root cause**: currently undefined
+**Root cause**: currently is undefined
 
 **Solution**: remove the following parts from the `etcd.yaml` manifest:
 
@@ -1182,7 +1182,7 @@ spec:
 ...
 ```
 
-and run upgrade procedure once again.
+wait for the ETCD restart and run upgrade procedure once again.
 
 ## Numerous Generation of `Auditd` System
 


### PR DESCRIPTION
### Description
* Upgrade to Kubernetes v1.28.3 from previous v1.28 versions fails

Fixes #544 


### Solution
* Troubleshooting guide update


### How to apply
Not applicable


### Test Cases

**TestCase 1**
Check if the solution works

Test Configuration:

- Hardware: 4CPU/4GB
- OS: Ubuntu 22.04
- Inventory: AllinOne

Steps:

1. Install Kubernetes v1.28.0 (or upgrade to v1.28.0 from v1.27.x) via `KubeMarine`
2. Change `/etc/kubernetes/manifests/etcd.yaml` as it's described in TG
3. Run the upgrade procedure via `KubeMarine`

Results:

| Before | After |
| ------ | ------ |
| Fail | Success |


### Checklist
- [x] I have made corresponding changes to the documentation
- [x] There is no merge conflicts


