### PR TITLE
[CPDEV-50513] Add nf_conntrack_max and NetworkManager config recommended for calico

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2522,6 +2522,7 @@ The `services.sysctl` section manages the Linux Kernel parameters for all hosts 
 |net.bridge.bridge-nf-call-ip6tables|1|Presented only when IPv6 detected in node IP|
 |net.ipv6.conf.all.forwarding|1|Presented only when IPv6 detected in node IP|
 |net.ipv6.ip_nonlocal_bind|1|Presented only when IPv6 detected in node IP|
+|net.netfilter.nf_conntrack_max|1000000||
 |kernel.panic|10||
 |vm.overcommit_memory|1||
 |kernel.panic_on_oops|1||

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -209,6 +209,13 @@ The actual information about the supported versions can be found in `compatibili
 **Warning**: `Kubemarine` works only with `firewalld` as an IP firewall, and switches it off during the installation.
 If you have other solution, remove or switch off the IP firewall before the installation.
 
+* In case of NetworkManager usage at the control-plane and/or worker nodes, create the following configuration file at `/etc/NetworkManager/conf.d/calico.conf` to prevent NetworkManager from interfering with the interfaces being created by Calico:
+
+```conf
+[keyfile]
+unmanaged-devices=interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico
+```
+
 **Preinstalled software**
 
 * Installation of the following packages is highly recommended; however, Kubernetes can work without them, but may show warnings:

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -23,10 +23,12 @@ from typing import List
 
 from kubemarine.core.patch import Patch
 from kubemarine.patches.p0_bind_vrrp_ips_interfaces import FixVRRP_IPsInterfaces
+from kubemarine.patches.p1_set_sysctl_variables import SetSysctlVariables
 
 patches: List[Patch] = [
     # FixVRRP_IPsInterfaces should be the first RegularPatch.
     FixVRRP_IPsInterfaces(),
+    SetSysctlVariables(),
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/p1_set_sysctl_variables.py
+++ b/kubemarine/patches/p1_set_sysctl_variables.py
@@ -12,7 +12,7 @@ class TheAction(Action):
     def run(self, res: DynamicResources) -> None:
         cluster = res.cluster()
 
-        node_group = cluster.make_group_from_roles(['control-plane', 'worker'])
+        node_group = cluster.make_group_from_roles(['all'])
         node_group.call(sysctl.configure)
         node_group.call(sysctl.reload)
         

--- a/kubemarine/patches/p1_set_sysctl_variables.py
+++ b/kubemarine/patches/p1_set_sysctl_variables.py
@@ -1,0 +1,34 @@
+from textwrap import dedent
+
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine import sysctl
+
+class TheAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Set sysctl variables")
+
+    def run(self, res: DynamicResources) -> None:
+        cluster = res.cluster()
+
+        node_group = cluster.make_group_from_roles(['control-plane', 'worker'])
+        node_group.call(sysctl.configure)
+        node_group.call(sysctl.reload)
+        
+
+class SetSysctlVariables(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("set_sysctl_variables")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            This patch sets kernel variables with sysctl at the control-plane, worker nodes according to the new defaults.
+            """.rstrip()
+        )

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -144,20 +144,6 @@ def system_prepare_system_sysctl(group: NodeGroup) -> None:
     cluster.schedule_cumulative_point(system.verify_system)
 
 
-@_applicable_for_new_nodes_with_roles('control-plane', 'worker')
-def system_prepare_system_networkmanager(group: NodeGroup) -> None:
-    cluster: KubernetesCluster = group.cluster
-    with group.new_executor() as exe:
-        for node in exe.group.get_ordered_members_list():
-            nm_folder_result = node.sudo("ls /etc/NetworkManager", warn=True)
-            if nm_folder_result == 0 :
-                # upload NM config file for calico
-                nm_calico_conf = "[keyfile]\nunmanaged-devices=interface-name:cali*;interface-name:tunl*\n"
-                node.sudo("mkdir -p /etc/NetworkManager/conf.d")
-                utils.dump_file(cluster, nm_calico_conf, "nm_kubemarine_calico.conf")
-                node.put(io.StringIO(nm_calico_conf), "/etc/NetworkManager/conf.d/kubemarine_calico.conf", sudo=True)
-
-
 @_applicable_for_new_nodes_with_roles('all')
 def system_prepare_system_setup_selinux(group: NodeGroup) -> None:
     group.call(selinux.setup_selinux)
@@ -548,7 +534,6 @@ tasks = OrderedDict({
             "disable_firewalld": system_prepare_system_disable_firewalld,
             "disable_swap": system_prepare_system_disable_swap,
             "modprobe": system_prepare_system_modprobe,
-            "networkmanager": system_prepare_system_networkmanager,
             "sysctl": system_prepare_system_sysctl,
             "audit": {
                 "install": system_install_audit,

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -144,6 +144,20 @@ def system_prepare_system_sysctl(group: NodeGroup) -> None:
     cluster.schedule_cumulative_point(system.verify_system)
 
 
+@_applicable_for_new_nodes_with_roles('control-plane', 'worker')
+def system_prepare_system_networkmanager(group: NodeGroup) -> None:
+    cluster: KubernetesCluster = group.cluster
+    with group.new_executor() as exe:
+        for node in exe.group.get_ordered_members_list():
+            nm_folder_result = node.sudo("ls /etc/NetworkManager", warn=True)
+            if nm_folder_result == 0 :
+                # upload NM config file for calico
+                nm_calico_conf = "[keyfile]\nunmanaged-devices=interface-name:cali*;interface-name:tunl*\n"
+                node.sudo("mkdir -p /etc/NetworkManager/conf.d")
+                utils.dump_file(cluster, nm_calico_conf, "nm_kubemarine_calico.conf")
+                node.put(io.StringIO(nm_calico_conf), "/etc/NetworkManager/conf.d/kubemarine_calico.conf", sudo=True)
+
+
 @_applicable_for_new_nodes_with_roles('all')
 def system_prepare_system_setup_selinux(group: NodeGroup) -> None:
     group.call(selinux.setup_selinux)
@@ -534,6 +548,7 @@ tasks = OrderedDict({
             "disable_firewalld": system_prepare_system_disable_firewalld,
             "disable_swap": system_prepare_system_disable_swap,
             "modprobe": system_prepare_system_modprobe,
+            "networkmanager": system_prepare_system_networkmanager,
             "sysctl": system_prepare_system_sysctl,
             "audit": {
                 "install": system_install_audit,

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -180,6 +180,7 @@ services:
     net.bridge.bridge-nf-call-ip6tables: '{% if not nodes[0]["internal_address"]|isipv4 %}1{% endif %}'
     net.ipv6.conf.all.forwarding: '{% if not nodes[0]["internal_address"]|isipv4 %}1{% endif %}'
     net.ipv6.ip_nonlocal_bind: '{% if not nodes[0]["internal_address"]|isipv4 %}1{% endif %}'
+    net.netfilter.nf_conntrack_max: 1000000
     kernel.panic: 10
     vm.overcommit_memory: 1
     kernel.panic_on_oops: 1


### PR DESCRIPTION
### Description
There are recommendations from Calico developers about [NetworkManager configuration](https://docs.tigera.io/calico/latest/operations/troubleshoot/troubleshooting#configure-networkmanager) and [nf_conntrack_max setting](https://docs.tigera.io/calico/latest/operations/troubleshoot/troubleshooting#configure-networkmanager).

Fixes # (issue)
CPDEV-50513

### Solution
1. The `net.netfilter.nf_conntrack_max` kernel variable is set to `1000000` in the `defaults.yaml`. The Installation Guide is updated accordingly.
2.  New networking prerequisite is added in the Installation Guide for the case when NetworkManager is in use.
3.  A patch to align cluster with new default sysctl settings is added.

### How to apply
Run `kubemarine migrate_kubemarine` for the patch `set_sysctl_variables`. 

### Test Cases
1. Deploy k8s cluster with the latest kubemarine. 
ER: 
- `net.netfilter.nf_conntrack_max=1000000` (check with `sysctl net.netfilter.nf_conntrack_max`)

2. Deploy cluster with the previous kubemarine version. 
Run `sysctl net.netfilter.nf_conntrack_max` at a node and check that its value is less than 1000000.
```
kubemarine migrate_kubemarine
```
Run `sysctl net.netfilter.nf_conntrack_max` at a node and check that itrs value is 1000000.

#### Unit tests
Indicate new or changed unit tests and what they do, if any.


