### PR TITLE
[CPDEV-94929]-rocky_linux_8.8_kubemarine_freezes

### DIFF
--- a/kubemarine/resources/configurations/compatibility/internal/packages.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/packages.yaml
@@ -7,77 +7,77 @@
 docker:
   v1.23.1:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.23.6:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.23.11:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.23.17:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.24.2:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.24.11:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.25.2:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.25.7:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.26.3:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.26.4:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.26.7:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.27.1:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.27.4:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.28.0:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
   v1.28.3:
     version_rhel: 19.03*
-    version_rhel8: 19.03*
+    version_rhel8: 20.10*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
 containerd:


### PR DESCRIPTION
### Description
update packages.yaml to support docker cri with rocky_linux_8.8
* 

### Solution
Update compatible version for docker for rhel8 in packages.yaml
* 


### How to apply
None


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: 6CPU/6RAM
- OS: Rocky Linux 8.8
- Inventory: miniha

Steps:

1. Install Kubernetes version v1.23.17 and specify docker as cri in cluster.yaml

Results:

| Before | After |
| ------ | ------ |
| Fail | Success |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


