### PR TITLE
[CPDEV-95071] Add nf_conntrack to the list of modprobe's modules

### DIFF
--- a/kubemarine/patches/p1_set_sysctl_variables.py
+++ b/kubemarine/patches/p1_set_sysctl_variables.py
@@ -25,8 +25,14 @@ class TheAction(Action):
 
     def run(self, res: DynamicResources) -> None:
         cluster = res.cluster()
-
         node_group = cluster.make_group_from_roles(['all'])
+
+        # add nf_conntrack module to predefined modules list
+        # and load it without the node reboot
+        for node in node_group:
+            node.sudo("echo nf_conntrack >> /etc/modules-load.d/predefined.conf ; modprobe -a nf_conntrack")
+
+        # configure syslog variables
         node_group.call(sysctl.configure)
         node_group.call(sysctl.reload)
         
@@ -43,6 +49,6 @@ class SetSysctlVariables(RegularPatch):
     def description(self) -> str:
         return dedent(
             f"""\
-            This patch sets kernel variables with sysctl at the control-plane, worker nodes according to the new defaults.
+            This patch sets kernel variables with sysctl at all the nodes according to the new defaults.
             """.rstrip()
         )

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -145,29 +145,29 @@ services:
   modprobe:
     rhel:
       - br_netfilter
+      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_conntrack_ipv6{% else %}nf_conntrack{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}ip6table_filter{% endif %}'
-      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_conntrack_ipv6{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_nat_masquerade_ipv6{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_reject_ipv6{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_defrag_ipv6{% endif %}'
     rhel8:
       - br_netfilter
+      - nf_conntrack
       - '{% if not nodes[0]["internal_address"]|isipv4 %}ip6table_filter{% endif %}'
-      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_conntrack{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_nat{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_reject_ipv6{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_defrag_ipv6{% endif %}'
     rhel9:
       - br_netfilter
+      - nf_conntrack
       - '{% if not nodes[0]["internal_address"]|isipv4 %}ip6table_filter{% endif %}'
-      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_conntrack{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_nat{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_reject_ipv6{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_defrag_ipv6{% endif %}'
     debian:
       - br_netfilter
+      - nf_conntrack
       - '{% if not nodes[0]["internal_address"]|isipv4 %}ip6table_filter{% endif %}'
-      - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_conntrack{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_nat{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_reject_ipv6{% endif %}'
       - '{% if not nodes[0]["internal_address"]|isipv4 %}nf_defrag_ipv6{% endif %}'


### PR DESCRIPTION
### Description
After adding `net.netfilter.nf_conntrack_max` kernel variable setting in the `defaults.yaml` installation fails because this variable cannot be set until `nf_conntrack` kernel module is loaded. It's loaded by kubernetes when a node is joining to the cluster, but sysctl variables are configured before kubernetes deployment.

Fixes # (issue)
CPDEV-95071

### Solution
Add `nf_conntrack` to all the lists `services.modprobe.<OS_FAMILY>`.

### How to apply
In case of fresh installation, just install k8s with kubemarine.
In case of running environment, run `kubemarine migrate_kubemarine`.

### Test Cases
1. Deploy k8s cluster with the latest kubemarine.
ER:
`net.netfilter.nf_conntrack_max=1000000` (check with `sysctl net.netfilter.nf_conntrack_max`)

2. Deploy cluster with the previous kubemarine version.
Run `sysctl net.netfilter.nf_conntrack_max` at a node and check that its value is less than 1000000.
Run migration procedure
```
kubemarine migrate_kubemarine
```
ER: 
`net.netfilter.nf_conntrack_max=1000000` (check with `sysctl net.netfilter.nf_conntrack_max`)

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


