### PR TITLE
[CPDEV-93171] - do not export kubernetes resources by default

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -448,7 +448,7 @@ The `upgrade` procedure executes the following sequence of tasks:
 The backup procedure automatically saves the following entities:
 * ETCD snapshot
 * Files and configs from cluster nodes
-* Kubernetes resources
+* Kubernetes resources (if it's configured in procedure.yaml)
 
 As a result of the procedure, you receive an archive with all the stored objects inside. The archive has approximately the following structure inside:
 
@@ -585,7 +585,7 @@ backup_plan:
 
 #### kubernetes Parameter
 
-The procedure exports all available Kubernetes resources from the cluster to yaml files. There are two types of resources - namespaced and non-namespaced. If you need to restrict resources for export, you can specify which ones you need.
+The procedure can export any available Kubernetes resources from the cluster to yaml files. There are two types of resources - namespaced and non-namespaced. If you need to export resources, you can specify which ones you need. By default, **no** resources from **all** namespaces are exported.
 
 **Note**: If the specified resource is missing, it is skipped without an error.
 
@@ -628,6 +628,16 @@ Another example:
 backup_plan:
   kubernetes:
     nonnamespaced_resources: all
+```
+
+If you do not specify `backup_plan.kubernetes`, the following configuration will be used:
+```yaml
+backup_plan:
+  kubernetes:
+    namespaced_resources:
+      namespaces: all
+      resources: []
+    nonnamespaced_resources: []
 ```
 
 ### Backup Procedure Tasks Tree

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -537,6 +537,10 @@ class ExportKubernetesDownloader:
                 if task is None:
                     break
 
+                # Skip task with empty resource list
+                if not task.resources:
+                    continue
+
                 random = uuid.uuid4().hex
                 temp_local_filepath = os.path.join(self.backup_directory, random)
                 self._download(task, temp_local_filepath)
@@ -585,12 +589,12 @@ def export_kubernetes(cluster: KubernetesCluster) -> None:
 
     logger.debug('Loading namespaced resource types:')
     loaded_resources = _load_resources(logger, control_plane, True)
-    proposed_resources = backup_kubernetes.get('namespaced_resources', {}).get('resources', 'all')
+    proposed_resources = backup_kubernetes.get('namespaced_resources', {}).get('resources', [])
     namespaced_resources = _filter_resources_by_proposed(logger, loaded_resources, proposed_resources, 'resource')
 
     logger.debug('Loading non-namespaced resource types:')
     loaded_resources = _load_resources(logger, control_plane, False)
-    proposed_resources = backup_kubernetes.get('nonnamespaced_resources', 'all')
+    proposed_resources = backup_kubernetes.get('nonnamespaced_resources', [])
     nonnamespaced_resources = _filter_resources_by_proposed(logger, loaded_resources, proposed_resources, 'resource')
 
     logger.debug('Loading resources:')

--- a/kubemarine/resources/schemas/backup.json
+++ b/kubemarine/resources/schemas/backup.json
@@ -64,7 +64,7 @@
     "ListOrEverything": {
       "oneOf": [
         {"type": "string", "enum": ["all"], "default": "all"},
-        {"$ref": "definitions/common/utils.json#/definitions/NonEmptySetOfStrings"}
+        {"$ref": "definitions/common/utils.json#/definitions/SetOfStrings"}
       ]
     }
   }


### PR DESCRIPTION
### Description
Exported kubernetes objects in `backup` procedure are not used in `restore` procedure, but they take a lot of time to export (especially in big clusters). They can be helpful only for some manual changes, but they do not needed by default.

Additionally now user can't skip kubernetes resources export in `procedure.yaml`, because it's not allowed in json schema. He can only skip whole task. 
And finally user can't export only specific resource because of the same reason. For example the following configuration is restricted:
```yaml
backup_plan:
  kubernetes:
    namespaced_resources:
      namespaces: all
      resources:
      - configmaps
    nonnamespaced_resources: []
``` 

Fixes # (issue)


### Solution
* Fixed json schema and backup procedure itself to process empty list of resources and namespaces;
* Fixed defaults for `backup_plan.kubernetes` not to load kubernetes resources by default;
* Fixed unittests for backup procedure;
* Added information about new defaults in documentation;



### Test Cases

**TestCase 1**: default behavior

Test Configuration:

- Hardware: 
- OS: 
- Inventory: any cluster, empty ``backup_plan.kubernetes` in procedure inventory for backup;

Steps:

1. kubemarine install;
2. kubemarine backup;

Results:

| Before | After |
| ------ | ------ |
| All kubernetes resources are exported in backup | No kubernetes resources in backup |

**TestCase 2**: specific not-namespaced resource

Test Configuration:

- Hardware: 
- OS: 
- Inventory: any cluster, procedure.yaml contains only one not-namespaced resource, e.g. for CRD:
```
backup_plan:
  kubernetes:
    namespaced_resources:
      resources: []
    nonnamespaced_resources:
      - customresourcedefinitions.apiextensions.k8s.io
```
Steps:

1. kubemarine install;
2. kubemarine backup;

Results:

| Before | After |
| ------ | ------ |
| Schema error | **Only** specified resources are exported |

**TestCase 3**: specific namespaced resource (loaded for all namespaces)

Test Configuration:

- Hardware: 
- OS: 
- Inventory: any cluster, procedure.yaml contains only one namespaced resource, e.g. for configmaps:
```
backup_plan:
  kubernetes:
    namespaced_resources:
      resources:
      - configmaps
    nonnamespaced_resources: []
```
Steps:

1. kubemarine install;
2. kubemarine backup;

Results:

| Before | After |
| ------ | ------ |
| Schema error | **Only** specified resources are exported for **all** namespaces |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


