### PR TITLE
[CPDEV-95240] Reconfigure modprobe if configuration is outdated

### DIFF
--- a/kubemarine/modprobe.py
+++ b/kubemarine/modprobe.py
@@ -1,0 +1,87 @@
+import io
+from typing import Tuple
+
+from kubemarine.core import utils
+from kubemarine.core.cluster import KubernetesCluster
+from kubemarine.core.group import NodeGroup, RunnersGroupResult, DeferredGroup, CollectorCallback
+
+predefined_file_path = "/etc/modules-load.d/predefined.conf"
+
+
+def generate_config(node: DeferredGroup) -> str:
+    cluster: KubernetesCluster = node.cluster
+    config = ''
+    for module_name in cluster.inventory['services']['modprobe'][node.get_nodes_os()]:
+        module_name = module_name.strip()
+        if module_name is not None and module_name != '':
+            config += module_name + "\n"
+
+    return config
+
+
+def setup_modprobe(group: NodeGroup) -> bool:
+    cluster: KubernetesCluster = group.cluster
+    logger = cluster.log
+    group_os_family = group.get_nodes_os()
+
+    is_valid, is_config_valid, result = is_modprobe_valid(group)
+
+    if is_valid and is_config_valid:
+        logger.debug("Skipped - all necessary kernel modules are presented")
+        logger.debug(result)
+        return False
+
+    defer = group.new_defer()
+    for node in defer.get_ordered_members_list():
+        config = generate_config(node)
+        raw_config = config.replace('\n', ' ')
+
+        logger.debug("Uploading config...")
+        dump_filename = 'modprobe_predefined.conf'
+        if group_os_family == 'multiple':
+            dump_filename = f'modprobe_predefined_{node.get_node_name()}.conf'
+
+        utils.dump_file(cluster, config, dump_filename)
+        node.put(io.StringIO(config), predefined_file_path, backup=True, sudo=True)
+        node.sudo("modprobe -a %s" % raw_config)
+
+    defer.flush()
+
+    return True
+
+
+def is_modprobe_valid(group: NodeGroup) -> Tuple[bool, bool, RunnersGroupResult]:
+    cluster: KubernetesCluster = group.cluster
+    logger = cluster.log
+    defer = group.new_defer()
+
+    lsmod_collector = CollectorCallback(cluster)
+    config_collector = CollectorCallback(cluster)
+    defer.sudo("lsmod", warn=True, callback=lsmod_collector)
+    defer.sudo(f"cat {predefined_file_path}", warn=True, callback=config_collector)
+    defer.flush()
+
+    is_valid = True
+    is_config_valid = True
+
+    for node in defer.get_ordered_members_list():
+        expected_config = generate_config(node)
+        if not expected_config:
+            continue
+
+        expected_modules = expected_config.rstrip('\n').split('\n')
+
+        host = node.get_host()
+        lsmod_result = lsmod_collector.result[host]
+        actual_config = config_collector.result[host]
+
+        for module_name in expected_modules:
+            if module_name not in lsmod_result.stdout:
+                logger.debug(f'Kernel module {module_name} is not found at {host}')
+                is_valid = False
+
+        if expected_config != actual_config.stdout:
+            logger.debug(f'Config is outdated at {host}')
+            is_config_valid = False
+
+    return is_valid, is_config_valid, lsmod_collector.result

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -26,7 +26,10 @@ import ruamel.yaml
 import ipaddress
 import uuid
 
-from kubemarine import packages as pckgs, system, selinux, etcd, thirdparties, apparmor, kubernetes, sysctl, audit, plugins
+from kubemarine import (
+    packages as pckgs, system, selinux, etcd, thirdparties, apparmor, kubernetes, sysctl, audit,
+    plugins, modprobe
+)
 from kubemarine.core.action import Action
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.group import NodeConfig, NodeGroup, CollectorCallback
@@ -861,7 +864,7 @@ def verify_modprobe_rules(cluster: KubernetesCluster) -> None:
     """
     with TestCase(cluster, '217', "System", "Modprobe rules") as tc:
         group = cluster.nodes['all']
-        modprobe_valid, modprobe_result = system.is_modprobe_valid(group)
+        modprobe_valid, _, modprobe_result = modprobe.is_modprobe_valid(group)
         cluster.log.debug(modprobe_result)
         if modprobe_valid:
             tc.success(results='valid')


### PR DESCRIPTION
### Description
* Re-installation of the cluster fails if the cluster was installed by old Kubemarine.
  Error: "Required kernel parameters are not presented"
* Root cause is in `net.netfilter.nf_conntrack_max` kernel parameter. The parameter is not loaded at startup as the module `nf_conntrack` is not yet loaded. Conversely, during the installation the module is already loaded, returned by `lsmod` and modprobe is thus not reconfigured.

### Solution
* In `prepare.system.modprobe` task verify not only that `lsmod` returns the module, but also that `/etc/modules-load.d/predefined.conf` is actual.

### Test Cases

**TestCase 1**

Re-installed the cluster that was installed by old Kubemarine.

1. Install the cluster using Kubemarine v0.23.0.
2. Re-install the cluster using new Kubemarine.

Results:

| Before | After |
| ------ | ------ |
| "Required kernel parameters are not presented" error | Re-installation is successful |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

