### PR TITLE
Return patches from v0.24.0

### DIFF
--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -22,8 +22,13 @@ The whole directory is automatically cleared and reset after new version of Kube
 from typing import List
 
 from kubemarine.core.patch import Patch
+from kubemarine.patches.p0_bind_vrrp_ips_interfaces import FixVRRP_IPsInterfaces
+from kubemarine.patches.p1_set_sysctl_variables import SetSysctlVariables
 
 patches: List[Patch] = [
+    # FixVRRP_IPsInterfaces should be the first RegularPatch.
+    FixVRRP_IPsInterfaces(),
+    SetSysctlVariables(),
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/p0_bind_vrrp_ips_interfaces.py
+++ b/kubemarine/patches/p0_bind_vrrp_ips_interfaces.py
@@ -1,0 +1,82 @@
+# Copyright 2021-2023 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from textwrap import dedent
+from typing import Optional
+
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+
+
+class TheAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Set previously resolved interfaces for VRRP IPs")
+
+    def run(self, res: DynamicResources) -> None:
+        logger = res.logger()
+        cluster = res.cluster()
+
+        if cluster.make_group_from_roles(['keepalived']).is_empty():
+            return logger.info("Skipping the patch as Keepalived is not configured.")
+
+        first_resolved_interface: Optional[str] = None
+        for i, raw_item in enumerate(cluster.raw_inventory['vrrp_ips']):
+            # If hosts are not specified, they are resolved by new algorithm.
+            if isinstance(raw_item, str) or 'hosts' not in raw_item:
+                item = cluster.inventory['vrrp_ips'][i]
+                # There is at least one balancer that produced at least one host for VRRP IP
+                resolved_interface = item['hosts'][0]['interface']
+                if first_resolved_interface is None:
+                    first_resolved_interface = resolved_interface
+                    continue
+
+                # The further VRRP IPs without hosts previously was enriched with 'first_resolved_interface'
+                # Let's compare it with how it is resolved now.
+                if resolved_interface != first_resolved_interface:
+                    logger.info(f"Changing vrrp_ips[{i}].interface to {first_resolved_interface} "
+                                f"to preserve the backward compatibility.")
+                    formatted_item = res.formatted_inventory()['vrrp_ips'][i]
+                    if isinstance(raw_item, str):
+                        res.formatted_inventory()['vrrp_ips'][i] = formatted_item = {
+                            'ip': formatted_item
+                        }
+
+                    formatted_item['interface'] = first_resolved_interface
+                    item['interface'] = first_resolved_interface
+                    for record in item['hosts']:
+                        record['interface'] = first_resolved_interface
+
+                    self.recreate_inventory = True
+
+        if not self.recreate_inventory:
+            logger.info("Skipping the patch as interfaces for `vrrp_ips` were not changed.")
+
+
+class FixVRRP_IPsInterfaces(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("fix_vrrp_ips_interfaces")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            The patch sets previously resolved interfaces for the VRRP IPs
+            in the inventory to preserve the backward compatibility.
+            """.rstrip()
+        )

--- a/kubemarine/patches/p1_set_sysctl_variables.py
+++ b/kubemarine/patches/p1_set_sysctl_variables.py
@@ -1,0 +1,73 @@
+# Copyright 2021-2023 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from textwrap import dedent
+
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine import sysctl
+from kubemarine.core import utils
+import io
+
+class TheAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Set sysctl variables")
+
+    def run(self, res: DynamicResources) -> None:
+        cluster = res.cluster()
+        node_group = cluster.make_group_from_roles(['all'])
+        group_os_family = node_group.get_nodes_os()
+
+        # add nf_conntrack module to predefined modules list
+        # and load it without the node reboot
+        for node in node_group.get_ordered_members_list():
+            config = ''
+            raw_config = ''
+
+            for module_name in cluster.inventory['services']['modprobe'][node.get_nodes_os()]:
+                module_name = module_name.strip()
+                if module_name is not None and module_name != '':
+                    config += module_name + "\n"
+                    raw_config += module_name + " "
+
+            dump_filename = 'modprobe_predefined.conf'
+            if group_os_family == 'multiple':
+                dump_filename = f'modprobe_predefined_{node.get_node_name()}.conf'
+
+            utils.dump_file(cluster, config, dump_filename)
+            node.put(io.StringIO(config), "/etc/modules-load.d/predefined.conf", backup=True, sudo=True)
+            node.sudo("modprobe -a %s" % raw_config)
+ 
+
+        # configure syslog variables
+        node_group.call(sysctl.configure)
+        node_group.call(sysctl.reload)
+        
+
+class SetSysctlVariables(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("set_sysctl_variables")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            This patch sets kernel variables with sysctl at all the nodes according to the new defaults.
+            """.rstrip()
+        )


### PR DESCRIPTION
### Description
* Since v0.24.0 is yanked, need to create new release with the same patches.

### How to apply
Run `kubemarine migrate_kubemarine`.

### Test Cases

See
* Test Cases from #546
* TestCase 8 from #532

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
