### PR TITLE
[CPDEV-93171] - clean kubernetes tmp dir before upgrade

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -255,6 +255,12 @@ UPGRADING KUBERNETES v1.18.8 ⭢ v1.19.3
 
 The script upgrades Kubernetes versions one-by-one. After each upgrade, the `cluster.yaml` is regenerated to reflect the actual cluster state. Use the latest updated `cluster.yaml` configuration to further work with the cluster.
 
+Additionally, before the upgrade kubemarine cleans up `/etc/kubernetes/tmp` directory, where kubeadm stores [backup files](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/#recovering-from-a-failure-state)
+during upgrade. For this reason only backups for the latest upgrade via kubemarine will be placed here after the upgrade procedure.
+
+**Note**: we do not recommend to use those backup files for rolling back after upgrade, because it can follow inconsistent state 
+for `cluster.yaml`. Please, use kubemarine [backup](#backup-procedure) and [restore](#restore-procedure) procedures instead of manual restoration.
+
 #### Upgrading Specific Nodes
 
 **Note**: Kubemarine automatically determines already upgraded nodes and excludes them from the Kubernetes upgrade procedure. Use manual nodes specifying for updating in exceptional cases when the problem cannot be solved automatically. Also, if any of the nodes are not available, first remove the node from the cluster, instead of changing the list of nodes for the upgrade.

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -29,7 +29,7 @@ from kubemarine.procedures import install
 def cleanup_tmp_dir(cluster: KubernetesCluster) -> None:
     # Clean up kubernetes tmp dir, where backup files from previous upgrades are located
     nodes = cluster.make_group_from_roles(roles=["control-plane", "worker"])
-    nodes.sudo("rm -rf /etc/kubernetes/tmp")
+    nodes.sudo("rm -rf /etc/kubernetes/tmp/*")
     cluster.log.debug("Backup files for previous upgrades were cleaned")
 
 

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -576,9 +576,9 @@ class InventoryRecreation(unittest.TestCase):
         self.upgrade = demo.generate_procedure_inventory('upgrade')
         self.upgrade['upgrade_plan'] = upgrade_plan
         self.actions = []
-        for ver in upgrade_plan:
+        for i, ver in enumerate(upgrade_plan):
             self.upgrade[ver] = {}
-            self.actions.append(upgrade.UpgradeAction(ver))
+            self.actions.append(upgrade.UpgradeAction(ver, i == 0))
 
         self.resources: Optional[demo.FakeResources] = None
 


### PR DESCRIPTION
### Description
During upgrade procedure kubeadm creates special [backup files](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/#recovering-from-a-failure-state), that are used for manual restoration.
But no one uses or cleans those files, for this reason they are not really needed and only take up the place on the disk.

Fixes # (issue)


### Solution
* Added the special task, that cleans up that directory before upgrade procedure; As result backups only for the last upgrade will be in that directory after the procedure;
* Added information about it in documentation;

### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory:

Steps:
1. run `kubemarine install`;
2. run `kubemarine upgrade` to one version;
3. check content of `/etc/kubernetes/tmp` folder on worker and control-plane nodes;
4.  run `kubemarine upgrade` again to another version;
5. check content of `/etc/kubernetes/tmp` folder again on worker and control-plane nodes;
Results:

| Before | After |
| ------ | ------ |
| files from step 3 are visible for step 5 | step 3 and step 5 have different backup files |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


