### PR TITLE
Fix incorrect detection of default services to check configuration

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1161,7 +1161,7 @@ def default_services_configuration_status(cluster: KubernetesCluster) -> None:
         for plugin in plugins.oob_plugins:
             plugin_item = cluster.inventory['plugins'][plugin]
             if not plugin_item['install']:
-                break
+                continue
 
             recommended_version = software_compatibility[plugin][version]["version"]
             expected_version = plugin_item['version']
@@ -1177,7 +1177,7 @@ def default_services_configuration_status(cluster: KubernetesCluster) -> None:
                 if calico.is_typha_enabled(cluster.inventory):
                     entities_to_check["kube-system"]["Deployment"]["calico-typha"] = {"version": expected_version}
 
-            if plugin == 'ingress-nginx-controller':
+            if plugin == 'nginx-ingress-controller':
                 entities_to_check['ingress-nginx'] = {"DaemonSet": {"ingress-nginx-controller": {"version": expected_version}}}
             if plugin == 'local-path-provisioner':
                 entities_to_check['local-path-storage'] = {"Deployment": {"local-path-provisioner": {"version": expected_version}}}


### PR DESCRIPTION
### Description
*  `check_paas` does not check versions of some plugins.

### Solution
* Fixed some typos in `default_services.configuration_status` that did not allow to perform check.

### Test Cases

**TestCase 1**

1. Install cluster with Kubernetes v1.23.1 and with all default plugins enabled except `kubernetes-dashboard` plugin.
2. Change kubernetesVersion to v1.28.3 in the inventory (but not on the cluster)
3. Run `check_paas --tasks default_services.configuration_status`

Results:

| Before | After |
| ------ | ------ |
| Versions of nginx-ingress-controller and local-path-provisioner were not checked | Versions of all plugins are checked |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


