### PR TITLE
[PSUPCLPL-14127] Kubernteset Dashboard check fails

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -603,11 +603,12 @@ def kubernetes_dashboard_status(cluster: KubernetesCluster) -> None:
                 found_url = result.stdout
                 
                 if ipaddress.ip_address(ingress_ip).version == 4:
-                    check_url = cluster.nodes['control-plane'].get_first_member().sudo(f'curl -k -I --resolve {found_url}:443:{ingress_ip} https://{found_url} 2>&1', warn=True)
+                    check_url = cluster.nodes['control-plane'].get_first_member().sudo(f'curl -k -I -L --resolve {found_url}:443:{ingress_ip} https://{found_url} -s -o /dev/null -w "%{{http_code}}"', warn=True)
                 else:
-                    check_url = cluster.nodes['control-plane'].get_first_member().sudo(f'curl -g -k -I --resolve "{found_url}:443:{ingress_ip}" https://{found_url} 2>&1', warn=True)
+                    check_url = cluster.nodes['control-plane'].get_first_member().sudo(f'curl -g -k -I -L --resolve "{found_url}:443:{ingress_ip}" https://{found_url} -s -o /dev/null -w "%{{http_code}}"', warn=True)
                 status = list(check_url.values())[0].stdout
-                if '200' in status:
+                cluster.log.debug(f"HTTP STATUS: {status}")
+                if status == '200':
                     cluster.log.verbose(status)
                     cluster.log.debug('Dashboard ingress is OK')
                     test_ingress_succeeded = True


### PR DESCRIPTION
### Description
* Kubernteset Dashboard check fails if the response has HTTP redirections


### Solution
* Support HTTP redirections in `check_paas` procedure during the Kubernetes Dashboard check


### How to apply
Not applicable


### Test Cases

**TestCase 1**

Check if the check works for the Kubernetes Dashboard with redirections (for example: Kubernetes Dashboard uses LDAP authentication)

Test Configuration:

- Hardware: 2CPU/4GB
- OS: CentOS7
- Inventory: fullHA

Steps:

1. Run `check_paas` with --tasks="kubernetes.plugins.dashboard" option (the Kubernetes Dashboard is available on the cluster)

Results:

| Before | After |
| ------ | ------ |
| Fail | Success |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts




