### PR TITLE
[CPDEV-95434] - fix cleanup command

### DIFF
--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -29,7 +29,7 @@ from kubemarine.procedures import install
 def cleanup_tmp_dir(cluster: KubernetesCluster) -> None:
     # Clean up kubernetes tmp dir, where backup files from previous upgrades are located
     nodes = cluster.make_group_from_roles(roles=["control-plane", "worker"])
-    nodes.sudo("rm -rf /etc/kubernetes/tmp/*")
+    nodes.sudo("rm -rf $(sudo find /etc/kubernetes/tmp -mindepth 1 -maxdepth 1)")
     cluster.log.debug("Backup files for previous upgrades were cleaned")
 
 


### PR DESCRIPTION
### Description
The command, provided in the PR https://github.com/Netcracker/KubeMarine/pull/557 does not work for not-root user.
In that case it does nothing, because `-f` option is used and backup files still exist in the nodes.
Without `-f` option the following exception appears:
```
$ sudo rm -r /etc/kubernetes/tmp/*
rm: cannot remove '/etc/kubernetes/tmp/*': No such file or directory
```
The problem is in `*`, because shell tries to expand, but can't do it without read permissions `sudo` doesn't help in that case.
This `/etc/kubernetes/tmp` directory uses 700 grants, for this reason not-root user does not have read grants for it.
For this reason the command should be rewritten not to use `*`.

Fixes # (issue)


### Solution
Fixed command to work with not-root user


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: not root user for nodes

Steps:
1. run `kubemarine install`;
2. run `kubemarine upgrade` to one version;
3. check content of `/etc/kubernetes/tmp` folder on worker and control-plane nodes;
4.  run `kubemarine upgrade` again to another version;
5. check content of `/etc/kubernetes/tmp` folder again on worker and control-plane nodes;
Results:

| Before | After |
| ------ | ------ |
| files from step 3 are visible for step 5 | step 3 and step 5 have different backup files |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


