### PR TITLE
[CPDEV-95723] Support release candidate version

### DIFF
--- a/kubemarine/jinja.py
+++ b/kubemarine/jinja.py
@@ -11,48 +11,42 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Callable, Dict, Any
 
 import yaml
 import jinja2
 
-from kubemarine.core import defaults, log
+from kubemarine.core import log, utils
 
 
-def new(logger: log.EnhancedLogger, recursive_compile: bool = False, root: dict = None) -> jinja2.Environment:
+def new(_: log.EnhancedLogger, *,
+        recursive_compiler: Callable[[str], str] = None) -> jinja2.Environment:
     def _precompile(filter_: str, struct: str) -> str:
         if not isinstance(struct, str):
             raise ValueError(f"Filter {filter_!r} can be applied only on string")
 
-        if not recursive_compile:
-            return struct
-        elif root is None:
-            raise Exception(
-                "If recursive compilation is enabled, "
-                "'root' parameter should also be specified to provide compilation context.")
-
-        struct = precompile(logger, struct, root)
-
-        return struct
-
+        # maybe we have non compiled string like templates/plugins/calico-{{ globals.compatibility_map }} ?
+        return recursive_compiler(struct) if recursive_compiler is not None and is_template(struct) else struct
 
     env = jinja2.Environment()
-    env.filters['toyaml'] = lambda data: yaml.dump(data, default_flow_style=False)
-    env.filters['isipv4'] = lambda ip: ":" not in _precompile('isipv4', ip)
-    env.filters['minorversion'] = lambda version: ".".join(_precompile('minorversion', version).split('.')[0:2])
-    env.filters['majorversion'] = lambda version: _precompile('majorversion', version).split('.')[0]
 
+    precompile_filters: Dict[str, Callable[[str], Any]] = {}
+    precompile_filters['isipv4'] = lambda ip: utils.isipv(ip, [4])
+    precompile_filters['minorversion'] = utils.minor_version
+    precompile_filters['majorversion'] = utils.major_version
+
+    for name, filter_ in precompile_filters.items():
+        env.filters[name] = lambda s, n=name, f=filter_: f(_precompile(n, s))
+
+    env.filters['toyaml'] = lambda data: yaml.dump(data, default_flow_style=False)
     env.tests['has_role'] = lambda node, role: role in node['roles']
 
     # we need these filters because rendered cluster.yaml can contain variables like 
     # enable: 'true'
-    env.filters['is_true'] = lambda v: v in ['true', 'True', 'TRUE', True]
-    env.filters['is_false'] = lambda v: v in ['false', 'False', 'FALSE', False]
+    env.filters['is_true'] = lambda v: v is True or utils.strtobool(_precompile('is_true', v))
+    env.filters['is_false'] = lambda v: v is False or not utils.strtobool(_precompile('is_false', v))
     return env
 
 
-def precompile(logger: log.EnhancedLogger, struct: str, root: dict) -> str:
-    # maybe we have non compiled string like templates/plugins/calico-{{ globals.compatibility_map }} ?
-    if '{{' in struct or '{%' in struct:
-        struct = defaults.compile_string(logger, struct, root)
-
-    return struct
+def is_template(struct: str) -> bool:
+    return '{{' in struct or '{%' in struct

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -42,10 +42,10 @@ def enrich_inventory(inventory: dict, _: KubernetesCluster) -> dict:
         if account['configs'][1]['subjects'][0].get('namespace') is None:
             rbac["accounts"][i]['configs'][1]['subjects'][0]['namespace'] = account['namespace']
 
-        # For Kubernetes v1.23 and lower are used legacy enrichment
+        # For Kubernetes lower than v1.24 use legacy enrichment
         # It has only 'ServiceAccount' and 'ClusterRoleBinding'
-        minor_version = int(inventory["services"]["kubeadm"]["kubernetesVersion"].split('.')[1])
-        if minor_version < 24:
+        kubernetes_version = inventory["services"]["kubeadm"]["kubernetesVersion"]
+        if utils.version_key(kubernetes_version)[0:2] < utils.minor_version_key("v1.24"):
             if len(rbac["accounts"][i]['configs']) > 2:
                 rbac["accounts"][i]['configs'].pop(2)
             if rbac["accounts"][i]['configs'][0].get('secrets') is not None:

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -49,10 +49,12 @@ def prepull_images(cluster: KubernetesCluster) -> None:
 
 
 def kubernetes_upgrade(cluster: KubernetesCluster) -> None:
-    minor_version = int(cluster.context['upgrade_version'].split('.')[1])
+    initial_kubernetes_version = cluster.context['initial_kubernetes_version']
 
     upgrade_group = kubernetes.get_group_for_upgrade(cluster)
-    if minor_version >= 28 and cluster.inventory['rbac']['pss']['pod-security'] == 'enabled':
+    if (admission.is_pod_security_unconditional(cluster)
+            and utils.version_key(initial_kubernetes_version)[0:2] < utils.minor_version_key("v1.28")
+            and cluster.inventory['rbac']['pss']['pod-security'] == 'enabled'):
         first_control_plane = cluster.nodes["control-plane"].get_first_member()
 
         cluster.log.debug("Updating kubeadm config map")

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -40,7 +40,6 @@ services:
   kubeadm_flags:
     ignorePreflightErrors: Port-6443,CoreDNSUnsupportedPlugins
   kubeadm:
-    # for patches functionality we need v1beta3 which is available since k8s v1.22 only
     apiVersion: 'kubeadm.k8s.io/v1beta3'
     kind: ClusterConfiguration
     kubernetesVersion: v1.26.11

--- a/scripts/thirdparties/src/compatibility.py
+++ b/scripts/thirdparties/src/compatibility.py
@@ -64,13 +64,19 @@ class KubernetesVersions:
         mandatory_fields.update(['crictl'])
         optional_fields = {
             'webhook', 'metrics-scraper', 'busybox',
-            # Although we are able to operate with pause image, custom version is not fully supported,
-            # because pause image version is not enriched when installing in public.
+            # To support custom pause image, it is necessary to implement software upgrade patch.
             # 'pause',
         }
 
         compatibility_map = self._kubernetes_versions['compatibility_map']
+        unique_version_keys = set()
         for k8s_version, software in compatibility_map.items():
+            version_key = utils.version_key(k8s_version)
+            if version_key in unique_version_keys:
+                raise Exception(f"Only one release or release candidate is supported "
+                                f"for v{'.'.join(map(str, version_key))}")
+
+            unique_version_keys.add(version_key)
             missing_mandatory = mandatory_fields - set(software)
             if missing_mandatory:
                 raise Exception(f"Missing {', '.join(map(repr, missing_mandatory))} software "

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -128,7 +128,7 @@ class UpgradeDefaultsEnrichment(unittest.TestCase):
         old_kubernetes_version = 'v1.24.11'
         new_kubernetes_version = 'v1.25.2'
         self.prepare_inventory(old_kubernetes_version, new_kubernetes_version)
-        with self.assertRaisesRegex(Exception, "PSP is not supported in Kubernetes version higher than v1.24"):
+        with self.assertRaisesRegex(Exception, "PSP is not supported in Kubernetes v1.25 or higher"):
             self._new_cluster()
 
     def test_incorrect_disable_eviction(self):


### PR DESCRIPTION
### Description
* The PR is intended to support Kubernetes release candidate testing.

### Solution
* `utils.version_key` takes into account versions like `v1.29.0-rc.1`
* Use `kubemarine.utils` everywhere where necessary to work with versions.

### Test Cases

**TestCase 1**

Steps:

1. Add `v1.29.0-rc.1` to `kubernetes_versions.yaml` compatibility map.
2. Run `scripts/thirdparties/sync.py`.

ER: the script succeeds

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
