### PR TITLE
[PSUPCLPL-13377] Instructions for cryptographic cipher suites

### DIFF
--- a/documentation/internal/Hardening.md
+++ b/documentation/internal/Hardening.md
@@ -504,7 +504,7 @@ After this, restart the pod to reflect the changes and verify that the secret is
 
 ### Mnaual Application for Strong Cyrptographic Ciphers for API server on pr-installed cluster
 
-Edit the API server pod specification `file /etc/kubernetes/manifests/kube-apiserver.yaml` on the control all plane nodes and add below parameter to the API server arguments
+Edit the API server pod specification file `/etc/kubernetes/manifests/kube-apiserver.yaml` on the control all plane nodes and add below parameter to the API server arguments
 
 ```yaml
 spec:
@@ -517,6 +517,10 @@ spec:
 ```
 Save the file with above mentioned changes and the kube-apiserver pods will be restarted.
 Restart the pods manually in case automatic restart doesn't happen in order to apply the changes in the cluster.
+
+Also make sure to update `kubeadm-config` configmap in kube-system namespace to store these changes. Elseon running any of the mantenance procedue, these changes would be lost.
+
+`kubectl edit cm kubeadm-config -n kube-system`
 
 ### Automated Application for Strong Cyrptographic Ciphers for API server during new cluster installation
 

--- a/documentation/internal/Hardening.md
+++ b/documentation/internal/Hardening.md
@@ -5,6 +5,7 @@
 - [Data Encryption in Kubernetes](#data-encryption-in-kubernetes)
 - [Kubelet Server Certificate Approval](#kubelet-server-certificate-approval)
 - [Disabling Auto-Mounting of Tokens for Service Accounts](#disabling-auto-mounting-of-tokens-for-service-accounts)
+- [Use strong cryptographic ciphers for API server] (#Use-strong-cryptographic-ciphers-for-api-server) 
 <!-- /TOC -->
 
 ## Overview
@@ -486,3 +487,52 @@ volumes:
 ...
 ```
 After this, restart the pod to reflect the changes and verify that the secret is mounted to the pod at the specified mount point.
+
+## Use strong cryptographic ciphers for API server
+
+**Kube-bench Identifier**:
+
+* 1.2.31
+
+### Strong Cyrptographic Ciphers suggested by CIS
+* TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+* TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+* TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+* TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+* TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+* TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+
+### Mnaual Application for Strong Cyrptographic Ciphers for API server on pr-installed cluster
+
+Edit the API server pod specification `file /etc/kubernetes/manifests/kube-apiserver.yaml` on the control all plane nodes and add below parameter to the API server arguments
+
+```yaml
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    ...
+    - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA
+    ...
+```
+Save the file with above mentioned changes and the kube-apiserver pods will be restarted.
+Restart the pods manually in case automatic restart doesn't happen in order to apply the changes in the cluster.
+
+### Automated Application for Strong Cyrptographic Ciphers for API server during new cluster installation
+
+For applying Strong Cyrptographic Ciphers for API server at the time of installation of cluster itself, then it can be done thourgh kubemarine.
+To do so follow below procdure
+
+- Add cryptographic chipers suites to the kubeadm config as extra arguments for API server in `cluster.yaml` file
+```yaml
+services:
+  kubeadm:
+    kubernetesVersion: v1.28.3
+    ...
+    apiServer:
+      extraArgs:
+        tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    ...
+```
+
+- Run kubemarine install procedure using above config added to `cluster.yaml` file.

--- a/documentation/internal/Hardening.md
+++ b/documentation/internal/Hardening.md
@@ -5,7 +5,7 @@
 - [Data Encryption in Kubernetes](#data-encryption-in-kubernetes)
 - [Kubelet Server Certificate Approval](#kubelet-server-certificate-approval)
 - [Disabling Auto-Mounting of Tokens for Service Accounts](#disabling-auto-mounting-of-tokens-for-service-accounts)
-- [Use strong cryptographic ciphers for API server] (#Use-strong-cryptographic-ciphers-for-api-server) 
+- [Use strong cryptographic ciphers for API server](#Use-strong-cryptographic-ciphers-for-api-server) 
 <!-- /TOC -->
 
 ## Overview


### PR DESCRIPTION
### Description
* We use `kube-bench` to make `KubeMarine` CIS aligned. Some of the improvements do not support in source code and could be applied manually.
* The suggested improvements have be reproduced
* Some additional observation in CIS scan which needs to be added in the hardening guide


### Solution
* Update the guide (hardening) in `KubeMarine` documentations


### How to apply
Not applicable

### Test Plan
After applying the changes mentioned in this PR, run the kube-bench scan and verify result for identifier 1.2.31.

* Login to one of the master node of the cluster on which it is going to be tested
* Download `kube-bench_0.6.17_linux_amd64` package from `https://github.com/aquasecurity/kube-bench`
* Install downloaded pkg using `sudo dpkg -i kube-bench_0.6.17_linux_amd64.deb`
* Run scan using command - `kube-bench` and check for identifier 1.2.31.


### Checklist
- [x] I have made corresponding changes to the documentation
- [x] There is no merge conflicts
