### PR TITLE
[CPDEV-95920] Support KubeProxyConfiguration as services.kubeadm_kube-proxy section

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -33,6 +33,7 @@ This section provides information about the inventory, features, and steps for i
         - [Cloud Provider Plugin](#cloud-provider-plugin)
         - [Service Account Issuer](#service-account-issuer)
       - [kubeadm_kubelet](#kubeadm_kubelet)
+      - [kubeadm_kube-proxy](#kubeadm_kube-proxy)
       - [kubeadm_patches](#kubeadm_patches)
       - [kernel_security](#kernel_security)
         - [selinux](#selinux)
@@ -1078,7 +1079,8 @@ In the `services` section, you can configure the service settings. The settings 
 
 *OS specific*: No
 
-In `services.kubeadm` section, you can override the original settings for the kubeadm. For more information these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
+In `services.kubeadm` section, you can override the original settings for the kubeadm.
+For more information about these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
 By default, the installer uses the following parameters:
 
 |Parameter| Default Value                                            |
@@ -1476,7 +1478,8 @@ Example result:
 
 *OS specific*: No
 
-In `services.kubeadm_kubelet` section, you can override the original settings for the kubelet. For more information these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
+In `services.kubeadm_kubelet` section, you can override the original settings for the kubelet.
+For more information about these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
 By default, the installer uses the following parameters:
 
 |Parameter|Default Value|
@@ -1507,6 +1510,23 @@ services:
     maxPods: 100
     cgroupDriver: systemd
 ```
+
+#### kubeadm_kube-proxy
+
+*Installation task*: `deploy.kubernetes`
+
+*Can cause reboot*: no
+
+*Can restart service*: always yes, `kubelet`
+
+*OS specific*: No
+
+In `services.kubeadm_kube-proxy` section, you can override the original settings for the kube-proxy.
+For more information about these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration).
+By default, the installer uses the following parameters:
+
+|Parameter|Default Value|
+|---|---|
 
 #### kubeadm_patches
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -1079,8 +1079,8 @@ In the `services` section, you can configure the service settings. The settings 
 
 *OS specific*: No
 
-In `services.kubeadm` section, you can override the original settings for the kubeadm.
-For more information about these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
+In the `services.kubeadm` section, you can override the original settings for kubeadm.
+For more information about these settings, refer to the official Kubernetes documentation at [https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
 By default, the installer uses the following parameters:
 
 |Parameter| Default Value                                            |
@@ -1478,8 +1478,8 @@ Example result:
 
 *OS specific*: No
 
-In `services.kubeadm_kubelet` section, you can override the original settings for the kubelet.
-For more information about these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
+In the `services.kubeadm_kubelet` section, you can override the original settings for kubelet.
+For more information about these settings, refer to the official Kubernetes documentation at [https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
 By default, the installer uses the following parameters:
 
 |Parameter|Default Value|
@@ -1515,14 +1515,14 @@ services:
 
 *Installation task*: `deploy.kubernetes`
 
-*Can cause reboot*: no
+*Can cause reboot*: No
 
-*Can restart service*: always yes, `kubelet`
+*Can restart service*: Always yes, `kubelet`
 
 *OS specific*: No
 
-In `services.kubeadm_kube-proxy` section, you can override the original settings for the kube-proxy.
-For more information about these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration).
+In the `services.kubeadm_kube-proxy` section, you can override the original settings for kube-proxy.
+For more information about these settings, refer to the official Kubernetes documentation at [https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration](https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration).
 By default, the installer uses the following parameters:
 
 |Parameter|Default Value|

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -811,8 +811,9 @@ def is_cluster_installed(cluster: KubernetesCluster) -> bool:
 
 def get_kubeadm_config(inventory: dict) -> str:
     kubeadm_kubelet = yaml.dump(inventory["services"]["kubeadm_kubelet"], default_flow_style=False)
+    kubeadm_kube_proxy = yaml.dump(inventory["services"]["kubeadm_kube-proxy"], default_flow_style=False)
     kubeadm = yaml.dump(inventory["services"]["kubeadm"], default_flow_style=False)
-    return f'{kubeadm_kubelet}---\n{kubeadm}'
+    return f'{kubeadm_kube_proxy}---\n{kubeadm_kubelet}---\n{kubeadm}'
 
 
 def upgrade_first_control_plane(upgrade_group: NodeGroup, cluster: KubernetesCluster, **drain_kwargs: Any) -> None:

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -37,6 +37,9 @@ services:
     podPidsLimit: 4096
     cgroupDriver: systemd
     serializeImagePulls: false
+  kubeadm_kube-proxy:
+    apiVersion: kubeproxy.config.k8s.io/v1alpha1
+    kind: KubeProxyConfiguration
   kubeadm_flags:
     ignorePreflightErrors: Port-6443,CoreDNSUnsupportedPlugins
   kubeadm:

--- a/kubemarine/resources/schemas/definitions/services.json
+++ b/kubemarine/resources/schemas/definitions/services.json
@@ -6,6 +6,9 @@
     "kubeadm_kubelet": {
       "$ref": "services/kubeadm_kubelet.json"
     },
+    "kubeadm_kube-proxy": {
+      "$ref": "services/kubeadm_kube-proxy.json"
+    },
     "kubeadm_patches": {
       "$ref": "services/kubeadm_patches.json"
     },

--- a/kubemarine/resources/schemas/definitions/services/kubeadm_kube-proxy.json
+++ b/kubemarine/resources/schemas/definitions/services/kubeadm_kube-proxy.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "description": "Override the original settings for the kube-proxy",
+  "properties": {
+    "apiVersion": {"enum": ["kubeproxy.config.k8s.io/v1alpha1"], "default": "kubeproxy.config.k8s.io/v1alpha1"},
+    "kind": {"enum": ["KubeProxyConfiguration"], "default": "KubeProxyConfiguration"}
+  }
+}


### PR DESCRIPTION
### Description
* Support [KubeProxyConfiguration](https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration)
* **Note** that this is still an alpha feature.

### Solution
* Added `services.kubeadm_kube-proxy` that directly converted to the KubeProxyConfiguration for `kubeadm init`.

### Test Cases

**TestCase 1**

Configure custom properties in  `services.kubeadm_kube-proxy`.

Steps:

1. Configure custom properties in  `services.kubeadm_kube-proxy` and install the cluster.

ER: The properties are handled respectively. Check at least `kubectl get cm -n kube-system kube-proxy -o yaml`.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
