### PR TITLE
Track changes and schedule support of Kubernetes v1.29.0

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -33,6 +33,7 @@ This section provides information about the inventory, features, and steps for i
         - [Cloud Provider Plugin](#cloud-provider-plugin)
         - [Service Account Issuer](#service-account-issuer)
       - [kubeadm_kubelet](#kubeadm_kubelet)
+      - [kubeadm_kube-proxy](#kubeadm_kube-proxy)
       - [kubeadm_patches](#kubeadm_patches)
       - [kernel_security](#kernel_security)
         - [selinux](#selinux)
@@ -1078,7 +1079,8 @@ In the `services` section, you can configure the service settings. The settings 
 
 *OS specific*: No
 
-In `services.kubeadm` section, you can override the original settings for the kubeadm. For more information these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
+In `services.kubeadm` section, you can override the original settings for the kubeadm.
+For more information about these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
 By default, the installer uses the following parameters:
 
 |Parameter| Default Value                                            |
@@ -1476,7 +1478,8 @@ Example result:
 
 *OS specific*: No
 
-In `services.kubeadm_kubelet` section, you can override the original settings for the kubelet. For more information these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
+In `services.kubeadm_kubelet` section, you can override the original settings for the kubelet.
+For more information about these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
 By default, the installer uses the following parameters:
 
 |Parameter|Default Value|
@@ -1507,6 +1510,23 @@ services:
     maxPods: 100
     cgroupDriver: systemd
 ```
+
+#### kubeadm_kube-proxy
+
+*Installation task*: `deploy.kubernetes`
+
+*Can cause reboot*: no
+
+*Can restart service*: always yes, `kubelet`
+
+*OS specific*: No
+
+In `services.kubeadm_kube-proxy` section, you can override the original settings for the kube-proxy.
+For more information about these settings, refer to the [Official Kubernetes Documentation](https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration).
+By default, the installer uses the following parameters:
+
+|Parameter|Default Value|
+|---|---|
 
 #### kubeadm_patches
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -1527,6 +1527,9 @@ By default, the installer uses the following parameters:
 
 |Parameter|Default Value|
 |---|---|
+|conntrack.min|1000000|
+
+`conntrack.min` inherits the `services.sysctl.net.netfilter.nf_conntrack_max` value from [sysctl](#sysctl).
 
 #### kubeadm_patches
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -1149,7 +1149,7 @@ The `cert_renew` procedure allows you to renew some certificates on an existing 
 
 For Kubernetes, most of the internal certificates could be updated, specifically: 
 `apiserver`, `apiserver-etcd-client`, `apiserver-kubelet-client`, `etcd-healthcheck-client`, `etcd-peer`, `etcd-server`,
-`admin.conf`, `controller-manager.conf`, `scheduler.conf`, `front-proxy-client`. 
+`admin.conf`, `super-admin.conf`, `controller-manager.conf`, `scheduler.conf`, `front-proxy-client`. 
 Certificate used by `kubelet.conf` by default is updated automatically by Kubernetes, 
 link to Kubernetes docs regarding `kubelet.conf` rotation: https://kubernetes.io/docs/tasks/tls/certificate-rotation/#understanding-the-certificate-rotation-configuration.
 
@@ -1221,6 +1221,7 @@ kubernetes:
     - etcd-peer
     - etcd-server
     - admin.conf
+    - super-admin.conf
     - controller-manager.conf
     - scheduler.conf
     - front-proxy-client

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -516,6 +516,7 @@ def manage_primitive_values(inventory: dict, _: KubernetesCluster) -> dict:
         (['services', 'cri', 'containerdConfig',
           'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options',
           'SystemdCgroup'], utils.strtobool, False),
+        (['services', 'kubeadm_kube-proxy', 'conntrack', 'min'], utils.strtoint, True),
         (['services', 'modprobe', '*', '*'], str, True),
         # kernel parameters are actually not always represented as integers
         (['services', 'sysctl', '*'], utils.strtoint, True),

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -14,7 +14,7 @@
 import re
 from importlib import import_module
 from copy import deepcopy
-from typing import Optional, Dict, Any, Tuple, List
+from typing import Optional, Dict, Any, Tuple, List, Callable, Union
 
 import yaml
 
@@ -40,7 +40,7 @@ DEFAULT_ENRICHMENT_FNS = [
     "kubemarine.kubernetes.enrich_upgrade_inventory",
     "kubemarine.kubernetes.enrich_restore_inventory",
     "kubemarine.core.defaults.compile_inventory",
-    "kubemarine.core.defaults.manage_true_false_values",
+    "kubemarine.core.defaults.manage_primitive_values",
     "kubemarine.plugins.enrich_upgrade_inventory",
     "kubemarine.packages.enrich_inventory",
     "kubemarine.packages.enrich_upgrade_inventory",
@@ -77,7 +77,7 @@ DEFAULT_ENRICHMENT_FNS = [
     "kubemarine.plugins.builtin.verify_inventory",
     "kubemarine.k8s_certs.renew_verify",
     "kubemarine.cri.enrich_inventory",
-    "kubemarine.system.enrich_kernel_modules"
+    "kubemarine.modprobe.enrich_kernel_modules"
 ]
 
 supported_defaults = {
@@ -511,12 +511,59 @@ def prepare_for_dump(inventory: dict, copy: bool = True) -> dict:
     return dump_inventory
 
 
-def manage_true_false_values(inventory: dict, _: KubernetesCluster) -> dict:
-    # Check undefined values for plugin.name.install and convert it to bool
-    for plugin_name, plugin_item in inventory["plugins"].items():
-        # Check install value
-        if 'install' not in plugin_item:
-            continue
-        value = utils.strtobool(plugin_item.get('install', False), f"plugin.{plugin_name}.install")
-        plugin_item['install'] = value
+def manage_primitive_values(inventory: dict, _: KubernetesCluster) -> dict:
+    paths_func_strip: List[Tuple[List[str], Callable[[Any], Any], bool]] = [
+        (['services', 'cri', 'containerdConfig',
+          'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options',
+          'SystemdCgroup'], utils.strtobool, False),
+        (['services', 'modprobe', '*', '*'], str, True),
+        # kernel parameters are actually not always represented as integers
+        (['services', 'sysctl', '*'], utils.strtoint, True),
+        (['plugins', '*', 'install'], utils.strtobool, False),
+        (['plugins', 'calico', 'typha', 'enabled'], utils.strtobool, False),
+        (['plugins', 'calico', 'typha', 'replicas'], utils.strtoint, False),
+    ]
+    for search_path, func, strip in paths_func_strip:
+        _convert_primitive_values(inventory, [], search_path, func, strip)
+
     return inventory
+
+
+def _convert_primitive_values(struct: Union[dict, list], path: List[Union[str, int]],
+                              search_path: List[str], func: Callable[[Any], Any], strip: bool) -> None:
+    depth = len(path)
+    section = search_path[depth]
+    if section == '*':
+        if isinstance(struct, list):
+            for i in reversed(range(len(struct))):
+                _convert_primitive_value_section(struct, i, path, search_path, func, strip)
+
+        elif isinstance(struct, dict):
+            for k in list(struct):
+                _convert_primitive_value_section(struct, k, path, search_path, func, strip)
+
+    # Only dict is possible here as struct
+    elif section in struct:
+        _convert_primitive_value_section(struct, section, path, search_path, func, strip)
+
+
+def _convert_primitive_value_section(struct: Union[dict, list], section: Union[str, int],
+                                     path: List[Union[str, int]],
+                                     search_path: List[str], func: Callable[[Any], Any], strip: bool) -> None:
+    value = struct[section]  # type: ignore[index]
+    path.append(section)
+    depth = len(path)
+    if depth < len(search_path):
+        _convert_primitive_values(value, path, search_path, func, strip)
+    else:
+        if strip and isinstance(value, str):
+            value = value.strip()
+        if strip and value == '':
+            del struct[section]  # type: ignore[arg-type]
+        else:
+            try:
+                struct[section] = func(value)  # type: ignore[index]
+            except ValueError as e:
+                raise ValueError(f"{str(e)} in section [{']['.join(repr(p) for p in path)}]")
+
+    path.pop()

--- a/kubemarine/core/utils.py
+++ b/kubemarine/core/utils.py
@@ -455,7 +455,7 @@ def load_yaml(filepath: str) -> dict:
         return {}  # unreachable
 
 
-def strtobool(value: Union[str, bool], section: str = None) -> bool:
+def strtobool(value: Union[str, bool]) -> bool:
     """
     The method check string and boolean value
     :param value: Value that should be checked
@@ -467,10 +467,18 @@ def strtobool(value: Union[str, bool], section: str = None) -> bool:
     elif val in ('n', 'no', 'f', 'false', 'off', '0'):
         return False
     else:
-        msg = f"invalid truth value {value!r}"
-        if section is not None:
-            msg = f"invalid truth value for {section}: {value!r}"
-        raise ValueError(msg)
+        raise ValueError(f"invalid truth value {value!r}")
+
+
+def strtoint(value: Union[str, int]) -> int:
+    if isinstance(value, int):
+        return value
+
+    try:
+        # whitespace required because python's int() ignores them
+        return int(value.replace(' ', '.'))
+    except ValueError:
+        raise ValueError(f"invalid integer value {value!r}")
 
 
 def print_diff(logger: log.EnhancedLogger, diff: deepdiff.DeepDiff) -> None:

--- a/kubemarine/cri/containerd.py
+++ b/kubemarine/cri/containerd.py
@@ -33,11 +33,6 @@ def enrich_inventory(inventory: dict, _: KubernetesCluster) -> dict:
     kubernetes_version = inventory['services']['kubeadm']['kubernetesVersion']
     containerd_config[path].setdefault('sandbox_image', get_default_sandbox_image(inventory, kubernetes_version))
 
-    runc_options_path = f'{path}.containerd.runtimes.runc.options'
-    if not isinstance(containerd_config[runc_options_path]['SystemdCgroup'], bool):
-        containerd_config[runc_options_path]['SystemdCgroup'] = \
-            utils.strtobool(containerd_config[runc_options_path]['SystemdCgroup'], "containerdConfig.SystemdCgroup")
-
     # Check if field for new and old configuration formats are presented
     old_format_result, old_format_field = contains_old_format_properties(inventory)
     new_format_result, new_format_field = contains_new_format_properties(inventory)

--- a/kubemarine/jinja.py
+++ b/kubemarine/jinja.py
@@ -11,48 +11,42 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Callable, Dict, Any
 
 import yaml
 import jinja2
 
-from kubemarine.core import defaults, log
+from kubemarine.core import log, utils
 
 
-def new(logger: log.EnhancedLogger, recursive_compile: bool = False, root: dict = None) -> jinja2.Environment:
+def new(_: log.EnhancedLogger, *,
+        recursive_compiler: Callable[[str], str] = None) -> jinja2.Environment:
     def _precompile(filter_: str, struct: str) -> str:
         if not isinstance(struct, str):
             raise ValueError(f"Filter {filter_!r} can be applied only on string")
 
-        if not recursive_compile:
-            return struct
-        elif root is None:
-            raise Exception(
-                "If recursive compilation is enabled, "
-                "'root' parameter should also be specified to provide compilation context.")
-
-        struct = precompile(logger, struct, root)
-
-        return struct
-
+        # maybe we have non compiled string like templates/plugins/calico-{{ globals.compatibility_map }} ?
+        return recursive_compiler(struct) if recursive_compiler is not None and is_template(struct) else struct
 
     env = jinja2.Environment()
-    env.filters['toyaml'] = lambda data: yaml.dump(data, default_flow_style=False)
-    env.filters['isipv4'] = lambda ip: ":" not in _precompile('isipv4', ip)
-    env.filters['minorversion'] = lambda version: ".".join(_precompile('minorversion', version).split('.')[0:2])
-    env.filters['majorversion'] = lambda version: _precompile('majorversion', version).split('.')[0]
 
+    precompile_filters: Dict[str, Callable[[str], Any]] = {}
+    precompile_filters['isipv4'] = lambda ip: utils.isipv(ip, [4])
+    precompile_filters['minorversion'] = utils.minor_version
+    precompile_filters['majorversion'] = utils.major_version
+
+    for name, filter_ in precompile_filters.items():
+        env.filters[name] = lambda s, n=name, f=filter_: f(_precompile(n, s))
+
+    env.filters['toyaml'] = lambda data: yaml.dump(data, default_flow_style=False)
     env.tests['has_role'] = lambda node, role: role in node['roles']
 
     # we need these filters because rendered cluster.yaml can contain variables like 
     # enable: 'true'
-    env.filters['is_true'] = lambda v: v in ['true', 'True', 'TRUE', True]
-    env.filters['is_false'] = lambda v: v in ['false', 'False', 'FALSE', False]
+    env.filters['is_true'] = lambda v: v is True or utils.strtobool(_precompile('is_true', v))
+    env.filters['is_false'] = lambda v: v is False or not utils.strtobool(_precompile('is_false', v))
     return env
 
 
-def precompile(logger: log.EnhancedLogger, struct: str, root: dict) -> str:
-    # maybe we have non compiled string like templates/plugins/calico-{{ globals.compatibility_map }} ?
-    if '{{' in struct or '{%' in struct:
-        struct = defaults.compile_string(logger, struct, root)
-
-    return struct
+def is_template(struct: str) -> bool:
+    return '{{' in struct or '{%' in struct

--- a/kubemarine/jinja.py
+++ b/kubemarine/jinja.py
@@ -34,6 +34,7 @@ def new(_: log.EnhancedLogger, *,
     precompile_filters['isipv4'] = lambda ip: utils.isipv(ip, [4])
     precompile_filters['minorversion'] = utils.minor_version
     precompile_filters['majorversion'] = utils.major_version
+    precompile_filters['versionkey'] = utils.version_key
 
     for name, filter_ in precompile_filters.items():
         env.filters[name] = lambda s, n=name, f=filter_: f(_precompile(n, s))

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -793,8 +793,9 @@ def is_cluster_installed(cluster: KubernetesCluster) -> bool:
 
 def get_kubeadm_config(inventory: dict) -> str:
     kubeadm_kubelet = yaml.dump(inventory["services"]["kubeadm_kubelet"], default_flow_style=False)
+    kubeadm_kube_proxy = yaml.dump(inventory["services"]["kubeadm_kube-proxy"], default_flow_style=False)
     kubeadm = yaml.dump(inventory["services"]["kubeadm"], default_flow_style=False)
-    return f'{kubeadm_kubelet}---\n{kubeadm}'
+    return f'{kubeadm_kube_proxy}---\n{kubeadm_kubelet}---\n{kubeadm}'
 
 
 def upgrade_first_control_plane(upgrade_group: NodeGroup, cluster: KubernetesCluster, **drain_kwargs: Any) -> None:

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -48,6 +48,11 @@ def is_container_runtime_not_configurable(cluster: KubernetesCluster) -> bool:
     return utils.version_key(kubernetes_version)[0:2] >= utils.minor_version_key("v1.27")
 
 
+def kube_proxy_overwrites_higher_system_values(cluster: KubernetesCluster) -> bool:
+    kubernetes_version = cluster.inventory["services"]["kubeadm"]["kubernetesVersion"]
+    return utils.version_key(kubernetes_version)[0:2] >= utils.minor_version_key("v1.29")
+
+
 def add_node_enrichment(inventory: dict, cluster: KubernetesCluster) -> dict:
     if cluster.context.get('initial_procedure') != 'add_node':
         return inventory

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -42,10 +42,10 @@ def enrich_inventory(inventory: dict, _: KubernetesCluster) -> dict:
         if account['configs'][1]['subjects'][0].get('namespace') is None:
             rbac["accounts"][i]['configs'][1]['subjects'][0]['namespace'] = account['namespace']
 
-        # For Kubernetes v1.23 and lower are used legacy enrichment
+        # For Kubernetes lower than v1.24 use legacy enrichment
         # It has only 'ServiceAccount' and 'ClusterRoleBinding'
-        minor_version = int(inventory["services"]["kubeadm"]["kubernetesVersion"].split('.')[1])
-        if minor_version < 24:
+        kubernetes_version = inventory["services"]["kubeadm"]["kubernetesVersion"]
+        if utils.version_key(kubernetes_version)[0:2] < utils.minor_version_key("v1.24"):
             if len(rbac["accounts"][i]['configs']) > 2:
                 rbac["accounts"][i]['configs'].pop(2)
             if rbac["accounts"][i]['configs'][0].get('secrets') is not None:

--- a/kubemarine/plugins/calico.py
+++ b/kubemarine/plugins/calico.py
@@ -63,7 +63,8 @@ def apply_calico_yaml(cluster: KubernetesCluster, calico_original_yaml: str, cal
 
 
 def is_typha_enabled(inventory: dict) -> bool:
-    return utils.strtobool(inventory['plugins']['calico']['typha']['enabled'], 'plugins.calico.typha.enabled')
+    enabled: bool = inventory['plugins']['calico']['typha']['enabled']
+    return enabled
 
 
 def is_apiserver_enabled(inventory: dict) -> bool:
@@ -246,7 +247,7 @@ class CalicoManifestProcessor(Processor):
                                {'key': 'node.kubernetes.io/network-unavailable', 'effect': 'NoExecute'}]
 
         val = self.inventory['plugins']['calico']['typha']['replicas']
-        source_yaml['spec']['replicas'] = int(val)
+        source_yaml['spec']['replicas'] = val
         self.log.verbose(f"The {key} has been patched in 'spec.replicas' with '{val}'")
 
         self.enrich_node_selector(manifest, key, plugin_service='typha')

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1423,9 +1423,9 @@ def kubernetes_admission_status(cluster: KubernetesCluster) -> None:
                 cluster.inventory["rbac"]["pss"]["pod-security"] == "enabled":
             profile_inv = cluster.inventory["rbac"]["pss"]["defaults"]["enforce"]
         profile = ""
-        result = first_control_plane.sudo("kubectl get cm kubeadm-config -n kube-system -o yaml")
-        kubeadm_cm = yaml.safe_load(list(result.values())[0].stdout)
-        cluster_config = yaml.safe_load(kubeadm_cm["data"]["ClusterConfiguration"])
+        kubeadm_cm = kubernetes.KubernetesObject(cluster, 'ConfigMap', 'kubeadm-config', 'kube-system')
+        kubeadm_cm.reload(first_control_plane)
+        cluster_config = yaml.safe_load(kubeadm_cm.obj["data"]["ClusterConfiguration"])
         api_result = first_control_plane.sudo("cat /etc/kubernetes/manifests/kube-apiserver.yaml")
         api_conf = yaml.safe_load(list(api_result.values())[0].stdout)
         ext_args = [cmd for cmd in api_conf["spec"]["containers"][0]["command"]]

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -90,7 +90,6 @@ def kubernetes_cleanup_nodes_versions(cluster: KubernetesCluster) -> None:
         cluster.nodes['control-plane'].get_first_member().sudo('rm -f /etc/kubernetes/nodes-k8s-versions.txt')
     else:
         cluster.log.verbose('Cached nodes versions already cleaned')
-    kubernetes_apply_taints(cluster)
 
 
 def upgrade_packages(cluster: KubernetesCluster) -> None:

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -49,10 +49,12 @@ def prepull_images(cluster: KubernetesCluster) -> None:
 
 
 def kubernetes_upgrade(cluster: KubernetesCluster) -> None:
-    minor_version = int(cluster.context['upgrade_version'].split('.')[1])
+    initial_kubernetes_version = cluster.context['initial_kubernetes_version']
 
     upgrade_group = kubernetes.get_group_for_upgrade(cluster)
-    if minor_version >= 28 and cluster.inventory['rbac']['pss']['pod-security'] == 'enabled':
+    if (admission.is_pod_security_unconditional(cluster)
+            and utils.version_key(initial_kubernetes_version)[0:2] < utils.minor_version_key("v1.28")
+            and cluster.inventory['rbac']['pss']['pod-security'] == 'enabled'):
         first_control_plane = cluster.nodes["control-plane"].get_first_member()
 
         cluster.log.debug("Updating kubeadm config map")

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -51,16 +51,33 @@ def prepull_images(cluster: KubernetesCluster) -> None:
 def kubernetes_upgrade(cluster: KubernetesCluster) -> None:
     initial_kubernetes_version = cluster.context['initial_kubernetes_version']
 
+    first_control_plane = cluster.nodes["control-plane"].get_first_member()
     upgrade_group = kubernetes.get_group_for_upgrade(cluster)
     if (admission.is_pod_security_unconditional(cluster)
             and utils.version_key(initial_kubernetes_version)[0:2] < utils.minor_version_key("v1.28")
             and cluster.inventory['rbac']['pss']['pod-security'] == 'enabled'):
-        first_control_plane = cluster.nodes["control-plane"].get_first_member()
 
         cluster.log.debug("Updating kubeadm config map")
         final_features_list = first_control_plane.call(admission.update_kubeadm_configmap_pss, target_state="enabled")
         cluster.log.debug("Updating kube-apiserver configs on control-planes")
         cluster.nodes["control-plane"].call(admission.update_kubeapi_config_pss, features_list=final_features_list)
+
+    if (kubernetes.kube_proxy_overwrites_higher_system_values(cluster)
+            and utils.version_key(initial_kubernetes_version)[0:2] < utils.minor_version_key("v1.29")):
+        cluster.log.debug("Updating kube-proxy config map")
+
+        def edit_kube_proxy_conntrack_min(kube_proxy_cm: dict) -> dict:
+            expected_conntrack: dict = cluster.inventory['services']['kubeadm_kube-proxy']['conntrack']
+            if 'min' not in expected_conntrack:
+                return kube_proxy_cm
+
+            actual_conntrack = kube_proxy_cm['conntrack']
+            if expected_conntrack['min'] != actual_conntrack.get('min'):
+                actual_conntrack['min'] = expected_conntrack['min']
+
+            return kube_proxy_cm
+
+        first_control_plane.call(kubernetes.reconfigure_kube_proxy_configmap, mutate_func=edit_kube_proxy_conntrack_min)
 
     drain_timeout = cluster.procedure_inventory.get('drain_timeout')
     grace_period = cluster.procedure_inventory.get('grace_period')

--- a/kubemarine/resources/configurations/compatibility/internal/kubernetes_images.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/kubernetes_images.yaml
@@ -37,6 +37,8 @@ kube-apiserver:
     version: v1.28.3
   v1.28.4:
     version: v1.28.4
+  v1.29.0-rc.1:
+    version: v1.29.0-rc.1
 kube-controller-manager:
   v1.23.1:
     version: v1.23.1
@@ -74,6 +76,8 @@ kube-controller-manager:
     version: v1.28.3
   v1.28.4:
     version: v1.28.4
+  v1.29.0-rc.1:
+    version: v1.29.0-rc.1
 kube-scheduler:
   v1.23.1:
     version: v1.23.1
@@ -111,6 +115,8 @@ kube-scheduler:
     version: v1.28.3
   v1.28.4:
     version: v1.28.4
+  v1.29.0-rc.1:
+    version: v1.29.0-rc.1
 kube-proxy:
   v1.23.1:
     version: v1.23.1
@@ -148,6 +154,8 @@ kube-proxy:
     version: v1.28.3
   v1.28.4:
     version: v1.28.4
+  v1.29.0-rc.1:
+    version: v1.29.0-rc.1
 pause:
   v1.23.1:
     version: '3.6'
@@ -184,6 +192,8 @@ pause:
   v1.28.3:
     version: '3.9'
   v1.28.4:
+    version: '3.9'
+  v1.29.0-rc.1:
     version: '3.9'
 etcd:
   v1.23.1:
@@ -222,6 +232,8 @@ etcd:
     version: 3.5.9-0
   v1.28.4:
     version: 3.5.9-0
+  v1.29.0-rc.1:
+    version: 3.5.10-0
 coredns/coredns:
   v1.23.1:
     version: v1.8.6
@@ -259,3 +271,5 @@ coredns/coredns:
     version: v1.10.1
   v1.28.4:
     version: v1.10.1
+  v1.29.0-rc.1:
+    version: v1.11.1

--- a/kubemarine/resources/configurations/compatibility/internal/packages.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/packages.yaml
@@ -95,6 +95,11 @@ docker:
     version_rhel8: 19.03*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
+  v1.29.0-rc.1:
+    version_rhel: 19.03*
+    version_rhel8: 19.03*
+    version_rhel9: 20.10*
+    version_debian: 5:20.10.*
 containerd:
   v1.23.1:
     version_debian: 1.5.*
@@ -131,6 +136,8 @@ containerd:
   v1.28.3:
     version_debian: 1.6.*
   v1.28.4:
+    version_debian: 1.6.*
+  v1.29.0-rc.1:
     version_debian: 1.6.*
 containerdio:
   v1.23.1:
@@ -219,6 +226,11 @@ containerdio:
     version_rhel9: 1.6*
     version_debian: 1.6.*
   v1.28.4:
+    version_rhel: 1.6*
+    version_rhel8: 1.6*
+    version_rhel9: 1.6*
+    version_debian: 1.6.*
+  v1.29.0-rc.1:
     version_rhel: 1.6*
     version_rhel8: 1.6*
     version_rhel9: 1.6*

--- a/kubemarine/resources/configurations/compatibility/internal/plugins.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/plugins.yaml
@@ -41,6 +41,8 @@ calico:
     version: v3.26.4
   v1.28.4:
     version: v3.26.4
+  v1.29.0-rc.1:
+    version: v3.26.4
 nginx-ingress-controller:
   v1.23.1:
     version: v1.2.0
@@ -94,6 +96,9 @@ nginx-ingress-controller:
     version: v1.8.4
     webhook-version: v20231011-8b53cabe0
   v1.28.4:
+    version: v1.9.4
+    webhook-version: v20231011-8b53cabe0
+  v1.29.0-rc.1:
     version: v1.9.4
     webhook-version: v20231011-8b53cabe0
 kubernetes-dashboard:
@@ -151,6 +156,9 @@ kubernetes-dashboard:
   v1.28.4:
     version: v2.7.0
     metrics-scraper-version: v1.0.8
+  v1.29.0-rc.1:
+    version: v2.7.0
+    metrics-scraper-version: v1.0.8
 local-path-provisioner:
   v1.23.1:
     version: v0.0.22
@@ -204,5 +212,8 @@ local-path-provisioner:
     version: v0.0.25
     busybox-version: 1.34.1
   v1.28.4:
+    version: v0.0.25
+    busybox-version: 1.34.1
+  v1.29.0-rc.1:
     version: v0.0.25
     busybox-version: 1.34.1

--- a/kubemarine/resources/configurations/compatibility/internal/thirdparties.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/thirdparties.yaml
@@ -38,6 +38,8 @@ kubeadm:
     sha1: 8935140d6a7b64f9038c911246cfc2a8da843673
   v1.28.4:
     sha1: 450eef85788fb68c4c26db82c6a0fb222e07869d
+  v1.29.0-rc.1:
+    sha1: 839c36679892366a5c3a48c4cbf713745542cd7a
 kubelet:
   v1.23.1:
     sha1: 4a7e2e5f5e6b8e95efa52931786bc275a037bc50
@@ -75,6 +77,8 @@ kubelet:
     sha1: de8824a4eac34277251f911e944c69488359ee69
   v1.28.4:
     sha1: 32ef1daaf8f4996d16ff386f44cc0555c6f3de24
+  v1.29.0-rc.1:
+    sha1: a918d359e2edd6df71182eb4bb3c152a40d97fd3
 kubectl:
   v1.23.1:
     sha1: 4ceb8d046a2d8253495aa86d13f11e2eb29644fc
@@ -112,6 +116,8 @@ kubectl:
     sha1: 096796f53a9b5af22e9e14b694fdefc870182b6e
   v1.28.4:
     sha1: 9a1691d307cb419d7047baccba89765015b2b7a4
+  v1.29.0-rc.1:
+    sha1: 2445db3d922c0978f65ae8ffdeb4f8844fd73b74
 calicoctl:
 # calicoctl version is duplicated from kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
 # It also corresponds to the plugin version in kubemarine/resources/configurations/compatibility/internal/plugins.yaml
@@ -169,6 +175,9 @@ calicoctl:
   v1.28.4:
     version: v3.26.4
     sha1: 46875b3d28318553fe382db0766a0916f2556217
+  v1.29.0-rc.1:
+    version: v3.26.4
+    sha1: 46875b3d28318553fe382db0766a0916f2556217
 crictl:
 # crictl version is duplicated from kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
 # for backward compatibility with clusters in a private environment.
@@ -224,5 +233,8 @@ crictl:
     version: v1.28.0
     sha1: 1199411456ab5a1e0dd9524724f15e92aa3f9da7
   v1.28.4:
+    version: v1.28.0
+    sha1: 1199411456ab5a1e0dd9524724f15e92aa3f9da7
+  v1.29.0-rc.1:
     version: v1.28.0
     sha1: 1199411456ab5a1e0dd9524724f15e92aa3f9da7

--- a/kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
+++ b/kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
@@ -13,6 +13,8 @@ kubernetes_versions:
     supported: true
   v1.28:
     supported: true
+  v1.29:
+    supported: true
 compatibility_map:
 # This section should be changed manually.
   v1.23.1:
@@ -123,7 +125,12 @@ compatibility_map:
     kubernetes-dashboard: v2.7.0
     local-path-provisioner: v0.0.25
     crictl: v1.28.0
-
+  v1.29.0-rc.1:
+    calico: v3.26.4
+    nginx-ingress-controller: v1.9.4
+    kubernetes-dashboard: v2.7.0
+    local-path-provisioner: v0.0.25
+    crictl: v1.28.0
 
 # After any change, please run scripts/thirdparties/sync.py
 

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -40,7 +40,6 @@ services:
   kubeadm_flags:
     ignorePreflightErrors: Port-6443,CoreDNSUnsupportedPlugins
   kubeadm:
-    # for patches functionality we need v1beta3 which is available since k8s v1.22 only
     apiVersion: 'kubeadm.k8s.io/v1beta3'
     kind: ClusterConfiguration
     kubernetesVersion: v1.26.11

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -40,6 +40,11 @@ services:
   kubeadm_kube-proxy:
     apiVersion: kubeproxy.config.k8s.io/v1alpha1
     kind: KubeProxyConfiguration
+    conntrack:
+      min: |
+        {% if services.kubeadm.kubernetesVersion | versionkey >= (1, 29, 0) %}
+        {{ services.sysctl["net.netfilter.nf_conntrack_max"] }}
+        {% endif %}
   kubeadm_flags:
     ignorePreflightErrors: Port-6443,CoreDNSUnsupportedPlugins
   kubeadm:

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -37,6 +37,9 @@ services:
     podPidsLimit: 4096
     cgroupDriver: systemd
     serializeImagePulls: false
+  kubeadm_kube-proxy:
+    apiVersion: kubeproxy.config.k8s.io/v1alpha1
+    kind: KubeProxyConfiguration
   kubeadm_flags:
     ignorePreflightErrors: Port-6443,CoreDNSUnsupportedPlugins
   kubeadm:

--- a/kubemarine/resources/schemas/cert_renew.json
+++ b/kubemarine/resources/schemas/cert_renew.json
@@ -37,7 +37,8 @@
               "all",
               "apiserver", "apiserver-etcd-client", "apiserver-kubelet-client",
               "etcd-healthcheck-client", "etcd-peer", "etcd-server",
-              "admin.conf", "controller-manager.conf", "scheduler.conf",
+              "admin.conf", "super-admin.conf",
+              "controller-manager.conf", "scheduler.conf",
               "front-proxy-client"
             ]
           },

--- a/kubemarine/resources/schemas/definitions/services.json
+++ b/kubemarine/resources/schemas/definitions/services.json
@@ -6,6 +6,9 @@
     "kubeadm_kubelet": {
       "$ref": "services/kubeadm_kubelet.json"
     },
+    "kubeadm_kube-proxy": {
+      "$ref": "services/kubeadm_kube-proxy.json"
+    },
     "kubeadm_patches": {
       "$ref": "services/kubeadm_patches.json"
     },

--- a/kubemarine/resources/schemas/definitions/services/kubeadm_kube-proxy.json
+++ b/kubemarine/resources/schemas/definitions/services/kubeadm_kube-proxy.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "description": "Override the original settings for the kube-proxy",
+  "properties": {
+    "apiVersion": {"enum": ["kubeproxy.config.k8s.io/v1alpha1"], "default": "kubeproxy.config.k8s.io/v1alpha1"},
+    "kind": {"enum": ["KubeProxyConfiguration"], "default": "KubeProxyConfiguration"}
+  }
+}

--- a/kubemarine/resources/schemas/definitions/services/kubeadm_kube-proxy.json
+++ b/kubemarine/resources/schemas/definitions/services/kubeadm_kube-proxy.json
@@ -3,6 +3,17 @@
   "type": "object",
   "description": "Override the original settings for the kube-proxy",
   "properties": {
+    "conntrack": {
+      "type": "object",
+      "description": "Conntrack settings for the Kubernetes proxy server",
+      "properties": {
+        "min": {
+          "type": ["string", "integer"],
+          "description": "Minimum value of connect-tracking records to allocate. By default, inherits the `services.sysctl.net.netfilter.nf_conntrack_max` value.",
+          "default": 1000000
+        }
+      }
+    },
     "apiVersion": {"enum": ["kubeproxy.config.k8s.io/v1alpha1"], "default": "kubeproxy.config.k8s.io/v1alpha1"},
     "kind": {"enum": ["KubeProxyConfiguration"], "default": "KubeProxyConfiguration"}
   }

--- a/kubemarine/resources/schemas/definitions/services/sysctl.json
+++ b/kubemarine/resources/schemas/definitions/services/sysctl.json
@@ -17,5 +17,8 @@
       "type": ["string", "integer"],
       "description": "If this parameter is not explicitly indicated in the cluster.yaml, then this value is calculated by this formula: maxPods * podPidsLimit + 2048"
     }
+  },
+  "additionalProperties": {
+    "type": ["string", "integer"]
   }
 }

--- a/kubemarine/system.py
+++ b/kubemarine/system.py
@@ -80,20 +80,6 @@ def enrich_etc_hosts(inventory: dict, cluster: KubernetesCluster) -> dict:
     return inventory
 
 
-def enrich_kernel_modules(inventory: dict, cluster: KubernetesCluster) -> dict:
-    """
-    The method enrich the list of kernel modules ('services.modprobe') according to OS family
-    """
-
-    final_nodes = cluster.nodes['all'].get_final_nodes()
-    for os_family in ('debian', 'rhel', 'rhel8', 'rhel9'):
-        # Remove the section for OS families if no node has these OS families.
-        if final_nodes.get_subgroup_with_os(os_family).is_empty():
-            del inventory["services"]["modprobe"][os_family]
-
-    return inventory
-
-
 def fetch_os_versions(cluster: KubernetesCluster) -> RunnersGroupResult:
     group = cluster.nodes['all'].get_accessible_nodes()
     '''

--- a/scripts/thirdparties/src/compatibility.py
+++ b/scripts/thirdparties/src/compatibility.py
@@ -64,13 +64,19 @@ class KubernetesVersions:
         mandatory_fields.update(['crictl'])
         optional_fields = {
             'webhook', 'metrics-scraper', 'busybox',
-            # Although we are able to operate with pause image, custom version is not fully supported,
-            # because pause image version is not enriched when installing in public.
+            # To support custom pause image, it is necessary to implement software upgrade patch.
             # 'pause',
         }
 
         compatibility_map = self._kubernetes_versions['compatibility_map']
+        unique_version_keys = set()
         for k8s_version, software in compatibility_map.items():
+            version_key = utils.version_key(k8s_version)
+            if version_key in unique_version_keys:
+                raise Exception(f"Only one release or release candidate is supported "
+                                f"for v{'.'.join(map(str, version_key))}")
+
+            unique_version_keys.add(version_key)
             missing_mandatory = mandatory_fields - set(software)
             if missing_mandatory:
                 raise Exception(f"Missing {', '.join(map(repr, missing_mandatory))} software "

--- a/test/unit/test_defaults.py
+++ b/test/unit/test_defaults.py
@@ -233,5 +233,51 @@ class DefaultsEnrichmentAppendControlPlain(unittest.TestCase):
         self.assertEqual(inventory['control_plain']['external'], inventory['vrrp_ips'][1]['floating_ip'])
 
 
+class PrimitiveValuesAsString(unittest.TestCase):
+    def test_default_enrichment(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['services'].setdefault('cri', {})['containerRuntime'] = 'containerd'
+        context = demo.create_silent_context()
+        context['nodes'] = demo.generate_nodes_context(inventory, os_name='ubuntu', os_version='22.04')
+        inventory = demo.new_cluster(inventory, context=context).inventory
+
+        self.assertEqual(True, inventory['services']['cri']['containerdConfig']
+                         ['plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options']['SystemdCgroup'])
+        self.assertEqual(['br_netfilter', 'nf_conntrack'],
+                         inventory['services']['modprobe']['debian'])
+        self.assertEqual({'net.bridge.bridge-nf-call-iptables', 'net.ipv4.ip_forward', 'net.ipv4.ip_nonlocal_bind',
+                          'net.ipv4.conf.all.route_localnet', 'net.netfilter.nf_conntrack_max',
+                          'kernel.panic', 'vm.overcommit_memory', 'kernel.panic_on_oops'},
+                         set(inventory['services']['sysctl'].keys()))
+        typha = inventory['plugins']['calico']['typha']
+        self.assertEqual(False, typha['enabled'])
+        self.assertEqual(2, typha['replicas'])
+
+    def test_custom_jinja_enrichment(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['services'].setdefault('modprobe', {})['debian'] = [
+            """
+            {% if true %}
+            custom_module
+            {% endif %}
+            """,
+            {'<<': 'merge'}
+        ]
+        inventory['services'].setdefault('sysctl', {})['custom_parameter'] = \
+            """
+            {% if true %}
+            1
+            {% endif %}
+            """
+        inventory.setdefault('plugins', {}).setdefault('kubernetes-dashboard', {})['install'] = "{{ true }}"
+        context = demo.create_silent_context()
+        context['nodes'] = demo.generate_nodes_context(inventory, os_name='ubuntu', os_version='22.04')
+        inventory = demo.new_cluster(inventory, context=context).inventory
+
+        self.assertEqual('custom_module', inventory['services']['modprobe']['debian'][0])
+        self.assertEqual(1, inventory['services']['sysctl']['custom_parameter'])
+        self.assertEqual(True, inventory['plugins']['kubernetes-dashboard']['install'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -128,7 +128,7 @@ class UpgradeDefaultsEnrichment(unittest.TestCase):
         old_kubernetes_version = 'v1.24.11'
         new_kubernetes_version = 'v1.25.2'
         self.prepare_inventory(old_kubernetes_version, new_kubernetes_version)
-        with self.assertRaisesRegex(Exception, "PSP is not supported in Kubernetes version higher than v1.24"):
+        with self.assertRaisesRegex(Exception, "PSP is not supported in Kubernetes v1.25 or higher"):
             self._new_cluster()
 
     def test_incorrect_disable_eviction(self):


### PR DESCRIPTION
### Description
* The PR is aimed to track changes to support Kubernetes v1.29.0.
  Should not be merged.
* Depends on [PR569](https://github.com/Netcracker/KubeMarine/pull/569), [PR571](https://github.com/Netcracker/KubeMarine/pull/571), [PR572](https://github.com/Netcracker/KubeMarine/pull/572).
* Added v1.29.0-rc.1 for testing.

### Solution
* Added kube-proxy upgrade procedure based on [https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/#applying-kube-proxy-configuration-changes](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/#applying-kube-proxy-configuration-changes)
* Added new default for `services.kubeadm_kube-proxy.conntrack.min` property.
* Added fine-grained renew of `super-admin.conf`.

### Test Cases

Install v1.29.0-rc.1, upgrade to v1.29.0-rc.1, renew `super-admin.conf`.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_detaults.py - cover enrichment of `services.kubeadm_kube-proxy.conntrack.min` property.


