### PR TITLE
[CPDEV-96114] add keepalived globals and custom template support

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3468,6 +3468,12 @@ These settings can be overrided in the **cluster.yaml**. Currently, the followin
     <td>"vrrp_garp_master_refresh". Number of gratuitous ARP messages to send at a time while MASTER. Not applied by default. </td>
   </tr>
   <tr>
+    <td>keep_configs_updated</td>
+    <td>boolean</td>
+    <td>True</td>
+    <td>Allows Kubemarine update keepalived configs every time, when cluster (re)installed or it's schema updated (added/removed nodes)</td>
+  </tr>
+  <tr>
     <td>config</td>
     <td>string</td>
     <td></td>

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3477,7 +3477,7 @@ These settings can be overrided in the **cluster.yaml**. Currently, the followin
     <td>config</td>
     <td>string</td>
     <td></td>
-    <td>Custom keepalived config value to be used instead of the default one.</td>
+    <td>Custom keepalived config value to be used instead of the default one. It can be userful, when every installation/add_node procedure adds only one balancer. In that case it's possible to specify custom configuration for every balancer without jinja templates./td>
   </tr>
   <tr>
     <td>config_file</td>

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3599,7 +3599,7 @@ Kubemarine supports maintenance mode for HAproxy balancer. HAproxy balancer has 
 ```yaml
 services:
   loadbalancer:
-    keepalived:
+    haproxy:
       maintenance_mode: True
       mntc_config_location: '/etc/haproxy/haproxy_mntc_v1.cfg'
 ```

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3489,7 +3489,7 @@ Parameter `config` allows to specify your custom config file. The priority of th
 ```yaml
 services:
   loadbalancer:
-    haproxy:
+    keepalived:
       keep_configs_updated: True
       config: |
         global_defs {
@@ -3529,7 +3529,7 @@ Parameter `config_file` allows to specify path to Jinja-compiled template. Examp
 ```yaml
 services:
   loadbalancer:
-    haproxy:
+    keepalived:
       keep_configs_updated: True
       config_file: '/root/my_keepalived_config.conf.j2'
 ```
@@ -3599,7 +3599,7 @@ Kubemarine supports maintenance mode for HAproxy balancer. HAproxy balancer has 
 ```yaml
 services:
   loadbalancer:
-    haproxy:
+    keepalived:
       maintenance_mode: True
       mntc_config_location: '/etc/haproxy/haproxy_mntc_v1.cfg'
 ```

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -424,6 +424,10 @@ def deploy_loadbalancer_keepalived_install(group: NodeGroup) -> None:
 
 
 def deploy_loadbalancer_keepalived_configure(cluster: KubernetesCluster) -> None:
+    if not cluster.inventory['services'].get('loadbalancer', {}) \
+            .get('keepalived', {}).get('keep_configs_updated', True):
+        cluster.log.debug('Skipped - keepalived balancers configs update manually disabled')
+        return
     # For install procedure, configure all keepalives.
     # If balancer with VRPP IP is added or removed, reconfigure all keepalives
     keepalived_nodes = cluster.make_group_from_roles(['keepalived'])

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -435,6 +435,7 @@ services:
       http: '{% if nodes | select("has_role", "balancer") | reject("has_role", "remove_node") | first %}20080{% else %}80{% endif %}'
       https: '{% if nodes | select("has_role", "balancer") | reject("has_role", "remove_node") | first %}20443{% else %}443{% endif %}'
     keepalived:
+      keep_configs_updated: True
       global: {}
 
   packages:

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -434,6 +434,8 @@ services:
     target_ports:
       http: '{% if nodes | select("has_role", "balancer") | reject("has_role", "remove_node") | first %}20080{% else %}80{% endif %}'
       https: '{% if nodes | select("has_role", "balancer") | reject("has_role", "remove_node") | first %}20443{% else %}443{% endif %}'
+    keepalived:
+      global: {}
 
   packages:
     cache_versions: true

--- a/kubemarine/resources/schemas/definitions/services/loadbalancer.json
+++ b/kubemarine/resources/schemas/definitions/services/loadbalancer.json
@@ -94,6 +94,30 @@
           "description": "Target https port"
         }
       }
+    },
+    "keepalived": {
+      "type": "object",
+      "description": "The section contains the configuration parameters that are applied to the keepalived.conf config file",
+      "properties": {
+        "global": {
+          "type": "object",
+          "description": "Parameters that are passed directly to the 'global_defs ' section of keepalived.conf file.",
+          "properties": {
+            "vrrp_garp_master_refresh": {
+              "type": "integer",
+              "description": "minimum time interval (in seconds) for refreshing gratuitous ARPs while MASTER."
+            }
+          }
+        },
+        "config": {
+          "type": "string",
+          "description": "Custom keepalived config value to be used instead of the default one"
+        },
+        "config_file": {
+          "type": "string",
+          "description": "Path to the Jinja-template file with custom keepalived config to be used instead of the default one"
+        }
+      }
     }
   },
   "additionalProperties": false

--- a/kubemarine/resources/schemas/definitions/services/loadbalancer.json
+++ b/kubemarine/resources/schemas/definitions/services/loadbalancer.json
@@ -116,6 +116,11 @@
         "config_file": {
           "type": "string",
           "description": "Path to the Jinja-template file with custom keepalived config to be used instead of the default one"
+        },
+        "keep_configs_updated": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allows Kubemarine update keepalived configs every time, when cluster (re)installed or it's schema updated (added/removed nodes)"
         }
       }
     }

--- a/kubemarine/resources/schemas/definitions/services/loadbalancer.json
+++ b/kubemarine/resources/schemas/definitions/services/loadbalancer.json
@@ -39,7 +39,8 @@
               "default": 10000,
               "description": "Set the total number of connections allowed, process-wide."
             }
-          }  
+          },
+          "additionalProperties": false
         },
         "defaults": {
           "type": "object",
@@ -75,9 +76,11 @@
               "default": 10000,
               "description": "Limits the sockets to this number of concurrent connections"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "target_ports": {
       "type": "object",
@@ -93,7 +96,8 @@
           "default": 443,
           "description": "Target https port"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "keepalived": {
       "type": "object",
@@ -107,7 +111,8 @@
               "type": "integer",
               "description": "minimum time interval (in seconds) for refreshing gratuitous ARPs while MASTER."
             }
-          }
+          },
+          "additionalProperties": false
         },
         "config": {
           "type": "string",
@@ -122,7 +127,8 @@
           "default": true,
           "description": "Allows Kubemarine update keepalived configs every time, when cluster (re)installed or it's schema updated (added/removed nodes)"
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/kubemarine/templates/keepalived.conf.j2
+++ b/kubemarine/templates/keepalived.conf.j2
@@ -1,3 +1,10 @@
+{% if globals|length %}
+global_defs {
+    {% if globals['vrrp_garp_master_refresh'] is defined %}vrrp_garp_master_refresh {{ globals['vrrp_garp_master_refresh'] }}{% endif %}
+}
+{% endif %}
+
+{%- for item in vrrp_ips %}
 vrrp_script script_{{ item['id'] }} {
     script       "/usr/local/bin/check_haproxy.sh"
     interval 2
@@ -8,12 +15,12 @@ vrrp_script script_{{ item['id'] }} {
 
 vrrp_instance balancer_{{ item['id'] }} {
     state BACKUP
-    interface {{ interface }}
+    interface {{ item['interface'] }}
     virtual_router_id {{ item['router_id'] }}
-    priority {{ priority }}
+    priority {{ item['priority'] }}
     nopreempt
     virtual_ipaddress {
-        {{ item['ip'] }} dev {{ interface }} label vip_{{ item['id'] }}
+        {{ item['ip'] }} dev {{ item['interface'] }} label vip_{{ item['id'] }}
     }
 
     track_script {
@@ -24,12 +31,15 @@ vrrp_instance balancer_{{ item['id'] }} {
         auth_type PASS
         auth_pass {{ item['password'] }}
     }
-{%- if peers | length > 0 %}
-    unicast_src_ip {{ source }}
+
+{%- if item['peers'] | length > 0 %}
+    unicast_src_ip {{ item['source'] }}
     unicast_peer {
-{%- for ip in peers %}
+{%- for ip in item['peers'] %}
         {{ ip }}
 {%- endfor %}
     }
 {%- endif %}
 }
+
+{%- endfor %}


### PR DESCRIPTION
### Description
Now it's not possible to provide additional parameters for keepalived configuration except vrrp_ips.
But in fact, user should sometimes specify some custom parameters related to their environment, e.g.: https://serverfault.com/questions/821809/keepalived-send-gratuitous-arp-periodically/822004#822004

Fixes # (issue)


### Solution
* Added new `services.loadbalancer.keepalived.global` section for `global_defs` keepalived parameters. Now following parameters are supported here:
   * `vrrp_garp_master_refresh`;
* Modified keepalived config generation to support common parameters, not related to specific vrrp-ip;
* Supported user specified `config` or `config_file` as for haproxy configuration;
* Added documentation section with the list of parameters that are used for keepalived configuration;


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**: custom `vrrp_garp_master_refresh` value

Test Configuration:

- Hardware: 
- OS: 
- Inventory: custom  `vrrp_garp_master_refresh` (e.g. 10) specified;

Steps:

1. Run kubemarine install;
2. Run `sudo tcpdump  -i <interface> -nn arp` on some node;

Results:

| Before | After |
| ------ | ------ |
| Installation task fails, if schema validation is enabled | Successful installation |
| No `global_defs` section in `/etc/keepalived/keepalived.conf` on balancers | `global_defs` section with `vrrp_garp_master_refresh` specified  in `/etc/keepalived/keepalived.conf` on balancers |
| `tcpdump` handles garp requests only when vrrp ip changes the node | `tcpdump`  handles garp request for vrrp every 10 seconds (or other time, specified in vrrp_garp_master_refresh`) |

**TestCase 2**: custom `config` value

Test Configuration:

- Hardware: 
- OS: 
- Inventory: custom  `config`  specified for keepalived;

Steps:

1. Run kubemarine install;

Results:

| Before | After |
| ------ | ------ |
| Installation task fails, if schema validation is enabled | Successful installation |
| Default keepalived configuraiton `/etc/keepalived/keepalived.conf` on balancers  | custom configuration  in `/etc/keepalived/keepalived.conf` on balancers |

**TestCase 3**: custom `config_file` value

Test Configuration:

- Hardware: 
- OS: 
- Inventory: custom  `config_file`  specified for keepalived;

Steps:

0. Create custom keepalived template, based on default one. Add `vrrp_garp_master_refresh_repeat` parameter in `global_def` section with 5 value.
1. Run kubemarine install;
2. Run `sudo tcpdump  -i <interface> -nn arp` on some node;

Results:

| Before | After |
| ------ | ------ |
| Installation task fails, if schema validation is enabled | Successful installation |
| No `vrrp_garp_master_refresh_repeat` in `/etc/keepalived/keepalived.conf` on balancers  | custom `vrrp_garp_master_refresh_repeat` in `/etc/keepalived/keepalived.conf` on balancers |
| `tcpdump` handles garp requests only when vrrp ip changes the node | `tcpdump`  handles 5 garp requests for vrrp every 10 seconds (or other time, specified in vrrp_garp_master_refresh`) |

**TestCase 4**: `keep_config_updated=False` case

Test Configuration:

- Hardware: 
- OS: 
- Inventory: inentory with `services.loadbalancer.keepalived.keep_config_updated=False` property

Steps:

1. Run kubemarine install --tasks prepare,deploy.loadbalancer;
2. Check keepalived configuration;

Results:

| Before | After |
| ------ | ------ |
| Keepalived configured by kubemaine | keepalived is not configured |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


