### PR TITLE
[CPDEV-96370] - add secure registries doc examples

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2320,7 +2320,7 @@ services:
       source: 'http://user:password@some-registry-url/kubernetes-sigs/cri-tools/releases/download/{{crictl-version}}/crictl-{{crictl-version}}-linux-amd64.tar.gz'
 ```
 
-**Note**: Do not forget to use percent-encoded credentials, for example for username `user` and password `p@$$w0rD`:
+**Note**: Percent-encoded (URL encoded) should be used for credentials. For example for username `user` and password `p@$$w0rD`:
 ```yaml
 services:
   thirdparties:

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -1783,6 +1783,8 @@ services:
 
 **Note**: You cannot and do not need to specify repositories for different package managers. The package manager is detected automatically and the specified configuration should match it.
 
+**Note**: You can use secure repositories with credentials as for [thirdparties](#secure-registries-for-thirdparties).
+
 ##### management
 
 *Installation task*: `prepare.package_manager.manage_packages`
@@ -2300,6 +2302,56 @@ services:
       source: https://example.com/kubernetes/kubeadm/v1.22.2/bin/linux/amd64/kubeadm
 ```
 
+##### secure registries for thirdparties
+
+If you have secure registry for thirdparties, you can specify credentials in `source` field using HTTP basic configuration, e.g.:
+```yaml
+services:
+  thirdparties:
+    /usr/bin/kubeadm:
+      source: 'http://user:password@some-registry-url/kubernetes-release/release/{{k8s-version}}/bin/linux/amd64/kubeadm'
+    /usr/bin/kubelet:
+      source: 'http://user:password@some-registry-url/kubernetes-release/release/{{k8s-version}}/bin/linux/amd64/kubelet'
+    /usr/bin/kubectl:
+      source: 'http://user:password@some-registry-url/kubernetes-release/release/{{k8s-version}}/bin/linux/amd64/kubectl'
+    /usr/bin/calicoctl:
+      source: 'http://user:password@some-registry-url/projectcalico/calico/releases/download/{{calico-version}}/calicoctl-linux-amd64'
+    /usr/bin/crictl.tar.gz:
+      source: 'http://user:password@some-registry-url/kubernetes-sigs/cri-tools/releases/download/{{crictl-version}}/crictl-{{crictl-version}}-linux-amd64.tar.gz'
+```
+
+**Note**: Do not forget to use percent-encoded credentials, for example for username `user` and password `p@$$w0rD`:
+```yaml
+services:
+  thirdparties:
+    /usr/bin/kubeadm:
+      source: 'http://user:p%40%24%24w0rD@some-registry-url/kubernetes-release/release/{{k8s-version}}/bin/linux/amd64/kubeadm'
+```
+
+Also it's possible to use environment variables for such credentials. 
+For that kubemarine provide following jinja functions to convert strings:
+* `b64encode` to encode to base64;
+* `b64decode` to decode from base64;
+* `url_quote` to use percent-encoding;
+
+**Note**: such functions can be used not only for thirdparties, but in any places and order;
+
+For example, if you use `REG_USERNAME` and `REG_PASSWORD` [environments](#environment-variables) for credentials, you can use following configuration:
+```yaml
+services:
+  thirdparties:
+    /usr/bin/kubeadm:
+      source: 'http://{{ env.REG_USERNAME | url_quote }}:{{ env.REG_PASSWORD | url_quote }}@some-registry-url/kubernetes-release/release/{{k8s-version}}/bin/linux/amd64/kubeadm'
+    /usr/bin/kubelet:
+      source: 'http://{{ env.REG_USERNAME | url_quote }}:{{ env.REG_PASSWORD | url_quote }}@some-registry-url/kubernetes-release/release/{{k8s-version}}/bin/linux/amd64/kubelet'
+    /usr/bin/kubectl:
+      source: 'http://{{ env.REG_USERNAME | url_quote }}:{{ env.REG_PASSWORD | url_quote }}@some-registry-url/kubernetes-release/release/{{k8s-version}}/bin/linux/amd64/kubectl'
+    /usr/bin/calicoctl:
+      source: 'http://{{ env.REG_USERNAME | url_quote }}:{{ env.REG_PASSWORD | url_quote }}@some-registry-url/projectcalico/calico/releases/download/{{calico-version}}/calicoctl-linux-amd64'
+    /usr/bin/crictl.tar.gz:
+      source: 'http://{{ env.REG_USERNAME | url_quote }}:{{ env.REG_PASSWORD | url_quote }}@some-registry-url/kubernetes-sigs/cri-tools/releases/download/{{crictl-version}}/crictl-{{crictl-version}}-linux-amd64.tar.gz'
+```
+
 #### CRI
 
 *Installation task*: `prepare.cri`
@@ -2419,6 +2471,38 @@ services:
 ```
 
 Where, `auth: "bmMtdXNlcjperfr="` field is `username:password` string in base64 encoding.
+
+**Note**: it's possible to use environment variables for credentials as for [thirdparies](#secure-registries-for-thirdparties). 
+For example, you can use `REG_USERNAME` and `REG_PASSWORD` environments with folowing configuration:
+```yaml
+services:
+  cri:
+    containerRuntime: containerd
+    containerdConfig:
+      plugins."io.containerd.grpc.v1.cri".registry.configs."private-registry:5000".auth:
+        auth: "{{ (env.REG_USERNAME ~ ':' ~ env.REG_PASSWORD ) | b64encode }}"
+    containerdRegistriesConfig:
+      private-registry:5000:
+        host."https://private-registry:5000":
+          capabilities: [ "pull", "resolve" ]
+          skip_verify: true
+```
+
+Or more simple:
+```yaml
+services:
+  cri:
+    containerRuntime: containerd
+    containerdConfig:
+      plugins."io.containerd.grpc.v1.cri".registry.configs."private-registry:5000".auth:
+        username: "{{ env.REG_USERNAME }}"
+        password: "{{ env.REG_PASSWORD }}"
+    containerdRegistriesConfig:
+      private-registry:5000:
+        host."https://private-registry:5000":
+          capabilities: [ "pull", "resolve" ]
+          skip_verify: true
+```
 
 Note how `containerdConfig` and `containerdRegistriesConfig.<registry>` sections reflect the toml format structure.
 For more details on containerd configuration, refer to the official containerd configuration file documentation at [https://github.com/containerd/containerd/blob/main/docs/cri/config.md](https://github.com/containerd/containerd/blob/main/docs/cri/config.md).

--- a/kubemarine/jinja.py
+++ b/kubemarine/jinja.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import base64
 from typing import Callable, Dict, Any
+from urllib.parse import quote_plus
 
 import yaml
 import jinja2
@@ -34,6 +36,9 @@ def new(_: log.EnhancedLogger, *,
     precompile_filters['isipv4'] = lambda ip: utils.isipv(ip, [4])
     precompile_filters['minorversion'] = utils.minor_version
     precompile_filters['majorversion'] = utils.major_version
+    precompile_filters['b64encode'] = lambda s: base64.b64encode(s.encode()).decode()
+    precompile_filters['b64decode'] = lambda s: base64.b64decode(s.encode()).decode()
+    precompile_filters['url_quote'] = lambda u: quote_plus(u)
 
     for name, filter_ in precompile_filters.items():
         env.filters[name] = lambda s, n=name, f=filter_: f(_precompile(n, s))


### PR DESCRIPTION
### Description
It's not obvious, how to specify credentials for thirdparties/packages registries, especially using environment variables.

Fixes # (issue)


### Solution
* Added some descriptions and examples, how to use secure registries in kubemarine;
* Added some jinja functions, that can be useful for credentials managing (they are used in provided examples);


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


