### PR TITLE
[CPDEV-96588] - apply kubeadm-config during upgrade

### DIFF
--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -120,6 +120,7 @@ tasks = OrderedDict({
     "verify_upgrade_versions": kubernetes.verify_upgrade_versions,
     "thirdparties": system_prepare_thirdparties,
     "prepull_images": prepull_images,
+    "configure_policy": install.deploy_kubernetes_audit,
     "kubernetes": kubernetes_upgrade,
     "kubernetes_cleanup": kubernetes_cleanup_nodes_versions,
     "packages": upgrade_packages,


### PR DESCRIPTION
### Description
After https://github.com/Netcracker/KubeMarine/pull/495 kubeadm-config changes are not applied during upgrade procedure.
But it should be possible according this documentation: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Maintenance.md#custom-settings-preservation-for-system-service

Fixes # (issue)


### Solution
* Returned task, that was excluded from upgrade procedure.


### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

Steps:

1. Run `kubemarine install` task;
3. Override some parameter (e.g. `goaway-chance`) in cluster.yaml;
4. Run `kubemarine upgrade` task;
5. Get `kubeadm-config` from cluster;

Results:

| Before | After |
| ------ | ------ |
| Overridden parameter is not applied in `kubeadm-config` | Parameter is overridden in `kubeadm-config` |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


