### PR TITLE
[CPDEV-96929] Support of granular 3rd party updates per specific Kubernetes version

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -216,7 +216,10 @@ The configuration format for the plugins is the same.
   * https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy is configured to _AlwaysAllow_
 * API versions `extensions/v1beta1` and `networking.k8s.io/v1beta1` are not supported starting from Kubernetes 1.22 and higher. Need to update ingress to the new API `networking.k8s.io/v1`. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122
 * Before starting the upgrade, make sure you make a backup. For more information, see the section [Backup Procedure](#backup-procedure).
-* The upgrade procedure only maintains upgrading from one `supported` version to the next `supported` version. For example, from 1.18 to 1.20 or from 1.20 to 1.21.
+* The upgrade procedure only maintains upgrading from one `supported` version to the higher `supported` version.
+  The target version must also be the latest patch version supported by Kubemarine.
+  For example, upgrade is allowed from v1.26.7 to v1.26.11, or from v1.26.7 to v1.27.8, or from v1.26.7 to v1.28.4 through v1.27.8,
+  but not from v1.26.7 to v1.27.1 as v1.27.1 is not the latest supported patch version of Kubernetes v1.27.
 * Since Kubernetes v1.25 doesn't support PSP, any clusters with `PSP` enabled must be migrated to `PSS` **before the upgrade** procedure running. For more information see the [Admission Migration Procedure](#admission-migration-procedure). The migration procedure is very important for Kubernetes cluster. If the solution doesn't have appropriate description about what `PSS` profile should be used for every namespace, it is better not to migrate from PSP for a while.  
 
 ### Upgrade Procedure Parameters

--- a/scripts/thirdparties/src/software/thirdparties.py
+++ b/scripts/thirdparties/src/software/thirdparties.py
@@ -15,7 +15,7 @@
 import os
 from typing import List, Tuple, Dict
 
-from kubemarine import thirdparties
+from kubemarine import thirdparties, kubernetes
 from kubemarine.core import utils
 from ..shell import curl, TEMP_FILE, SYNC_CACHE
 from ..tracker import SummaryTracker, ComposedTracker
@@ -90,6 +90,9 @@ def validate_thirdparty_versions(kubernetes_versions: Dict[str, Dict[str, str]],
     for i, older_k8s_version in enumerate(k8s_versions):
         for j in range(i + 1, len(k8s_versions)):
             newer_k8s_version = k8s_versions[j]
+            if not kubernetes.is_version_upgrade_possible(older_k8s_version, newer_k8s_version):
+                continue
+
             older_version = kubernetes_versions[older_k8s_version][thirdparty_name]
             newer_version = kubernetes_versions[newer_k8s_version][thirdparty_name]
             if key(newer_version) < key(older_version):


### PR DESCRIPTION
### Description
* Support of granular 3rd party updates per specific Kubernetes version not touching the compatibility map of higher Kubernetes versions.
* Prohibit upgrade to not the latest supported patch version to avoid accidental downgrade of plugins or thirdparties.

### Solution
* Added validation of `upgrade_plan` to allow upgrade only to the latest patch versions (either intermediate or target).
* Changed validation in `scripts/thirdparties/sync.py` to check that plugins are not downgraded only if upgrade is possible.

### Breaking changes
Upgrade to intermediate patch versions is no longer allowed.

### Test Cases

**TestCase 1**

Granular upgrade of 3rd-parties.

Steps:

1. Embed new Kubernetes patch versions, and upgrade compatible plugins only for new Kubernetes versions.
2. Run `scripts/thirdparties/sync.py`

Results:

| Before | After |
| ------ | ------ |
| `Plugins should have non-decreasing versions` error is raised | Synchronization is performed successfully |

**TestCase 2**

Prohibit upgrade to intermediate patch version.

Steps:

1. Try upgrading Kubernetes from v1.27.8 to v1.28.0

Results:

| Before | After |
| ------ | ------ |
| Upgrade is successful | `New version "v1.28.0" is not the latest supported patch version "v1.28.4"` error is raised |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_sync.py, test_upgrade_py - added tests to cover new functionality.
