### PR TITLE
[CPREQ-8436] Clarify documentation Hardening.md: Disable Anonymous Authentication for kube-apiserver

### DIFF
--- a/documentation/internal/Hardening.md
+++ b/documentation/internal/Hardening.md
@@ -58,7 +58,7 @@ kind: ClusterRole
 metadata:
   name: healthz
 rules:
-- nonResourceURLs: ["/readyz", "/livez", "/healthz"]
+- nonResourceURLs: ["/readyz", "/livez"]
   verbs: ["get"]
 ---
 apiVersion: v1

--- a/documentation/internal/Hardening.md
+++ b/documentation/internal/Hardening.md
@@ -92,6 +92,7 @@ subjects:
 
 **Note:** ClusterRole and ClusterRoleBinding are not required
 if you have `system:discovery` or `system:public-info-viewer` ClusterRoleBindings installed on the cluster (default).
+Though, such role bindings provide wider permissions than those that are necessary for the probes.
 
 ### Disabling Procedure
 


### PR DESCRIPTION
### Description
* Clarify limitations and prerequisites for [Disable Anonymous Authentication for `kube-apiserver`](https://github.com/Netcracker/KubeMarine/blob/main/documentation/internal/Hardening.md#disable-anonymous-authentication-for-kube-apiserver).

### Test Cases

**TestCase 1**

Install cluster, and then disable anonymous-auth for `kube-apiserver` according to guide [documentation/internal/Hardening.md#disable-anonymous-authentication-for-kube-apiserver](https://github.com/Netcracker/KubeMarine/blob/documentation/clarify_hardening_anonymous_auth/documentation/internal/Hardening.md#disable-anonymous-authentication-for-kube-apiserver)

**TestCase 2**

Perform maintenance procedures: upgrade, add/remove nodes taking into account [documentation/internal/Hardening.md#limitations](https://github.com/Netcracker/KubeMarine/blob/documentation/clarify_hardening_anonymous_auth/documentation/internal/Hardening.md#limitations)

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
