### PR TITLE
Allow plugins without installation procedures

### DIFF
--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -415,7 +415,7 @@ def install_all_thirparties(group: NodeGroup) -> None:
         if cluster.context.get("initial_procedure") in ("install", "upgrade"):
             managing_plugin = next((plugin_name
                                     for plugin_name, plugin_configs in cluster.inventory['plugins'].items()
-                                    for plugin_procedure in plugin_configs['installation']['procedures']
+                                    for plugin_procedure in plugin_configs.get('installation', {}).get('procedures', [])
                                     if plugin_procedure.get('thirdparty') == destination),
                                    None)
 


### PR DESCRIPTION
### Description
Plugins which do not have `installation.procedures` cause upgrade failures
```
File "/usr/local/lib/python3.12/site-packages/kubemarine/thirdparties.py", line 418, in <genexpr>
     for plugin_procedure in plugin_configs['installation']['procedures']
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
 KeyError: 'procedures'
```

### Solution
Set keys `installation` and `installation.procedures` as optional, allowing empty values.

### Test Cases

**TestCase 1**

Steps:

1. Add a custom plugins which does not have `installation.procedures` sections, run `upgrade`

Results:

| Before | After |
| ------ | ------ |
| Upgrade fails on thirdparties  | Upgrade continues |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


