### PR TITLE
Fix scheduler's patch name

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -1335,7 +1335,7 @@ def create_kubeadm_patches_for_node(cluster: KubernetesCluster, node: NodeGroup)
         'apiServer' : 'kube-apiserver+json.json',
         'etcd' : 'etcd+json.json',
         'controllerManager' : 'kube-controller-manager+json.json',
-        'scheduler' : 'kube-scheduler_json.json',
+        'scheduler' : 'kube-scheduler+json.json',
         'kubelet' : 'kubeletconfiguration.yaml'
     }
 


### PR DESCRIPTION
### Description
There was a typo in the name of the file with scheduler's patch: `kube-scheduler_json.json` instead of `kube-scheduler+json.json`

Fixes # (issue)


### Solution
The typo is fixed.

### How to apply

### Test Cases
Deploy kubernetes with some kube-scheduler's customization, for example:
```
service:
  kubeadm_patches:
    scheduler:
    - groups: [control-plane]
      patch:
        log-flush-frequency duration: 20s 
```
ER: kube-scheduler's manifest at the master nodes contains the new `log-flush-frequency duration` value.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


