### PR TITLE
[PSUPCLPL-14607]-k8s_v1.28.6_support

### DIFF
--- a/kubemarine/resources/configurations/compatibility/internal/kubernetes_images.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/kubernetes_images.yaml
@@ -37,6 +37,8 @@ kube-apiserver:
     version: v1.28.3
   v1.28.4:
     version: v1.28.4
+  v1.28.6:
+    version: v1.28.6
   v1.29.1:
     version: v1.29.1
 kube-controller-manager:
@@ -76,6 +78,8 @@ kube-controller-manager:
     version: v1.28.3
   v1.28.4:
     version: v1.28.4
+  v1.28.6:
+    version: v1.28.6
   v1.29.1:
     version: v1.29.1
 kube-scheduler:
@@ -115,6 +119,8 @@ kube-scheduler:
     version: v1.28.3
   v1.28.4:
     version: v1.28.4
+  v1.28.6:
+    version: v1.28.6
   v1.29.1:
     version: v1.29.1
 kube-proxy:
@@ -154,6 +160,8 @@ kube-proxy:
     version: v1.28.3
   v1.28.4:
     version: v1.28.4
+  v1.28.6:
+    version: v1.28.6
   v1.29.1:
     version: v1.29.1
 pause:
@@ -192,6 +200,8 @@ pause:
   v1.28.3:
     version: '3.9'
   v1.28.4:
+    version: '3.9'
+  v1.28.6:
     version: '3.9'
   v1.29.1:
     version: '3.9'
@@ -232,6 +242,8 @@ etcd:
     version: 3.5.9-0
   v1.28.4:
     version: 3.5.9-0
+  v1.28.6:
+    version: 3.5.10-0
   v1.29.1:
     version: 3.5.10-0
 coredns/coredns:
@@ -270,6 +282,8 @@ coredns/coredns:
   v1.28.3:
     version: v1.10.1
   v1.28.4:
+    version: v1.10.1
+  v1.28.6:
     version: v1.10.1
   v1.29.1:
     version: v1.11.1

--- a/kubemarine/resources/configurations/compatibility/internal/packages.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/packages.yaml
@@ -95,6 +95,11 @@ docker:
     version_rhel8: 19.03*
     version_rhel9: 20.10*
     version_debian: 5:20.10.*
+  v1.28.6:
+    version_rhel: 19.03*
+    version_rhel8: 19.03*
+    version_rhel9: 20.10*
+    version_debian: 5:20.10.*
   v1.29.1:
     version_rhel: 19.03*
     version_rhel8: 19.03*
@@ -136,6 +141,8 @@ containerd:
   v1.28.3:
     version_debian: 1.6.*
   v1.28.4:
+    version_debian: 1.6.*
+  v1.28.6:
     version_debian: 1.6.*
   v1.29.1:
     version_debian: 1.6.*
@@ -226,6 +233,11 @@ containerdio:
     version_rhel9: 1.6*
     version_debian: 1.6.*
   v1.28.4:
+    version_rhel: 1.6*
+    version_rhel8: 1.6*
+    version_rhel9: 1.6*
+    version_debian: 1.6.*
+  v1.28.6:
     version_rhel: 1.6*
     version_rhel8: 1.6*
     version_rhel9: 1.6*

--- a/kubemarine/resources/configurations/compatibility/internal/plugins.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/plugins.yaml
@@ -41,6 +41,8 @@ calico:
     version: v3.26.4
   v1.28.4:
     version: v3.26.4
+  v1.28.6:
+    version: v3.27.0
   v1.29.1:
     version: v3.27.0
 nginx-ingress-controller:
@@ -97,6 +99,9 @@ nginx-ingress-controller:
     webhook-version: v20231011-8b53cabe0
   v1.28.4:
     version: v1.9.4
+    webhook-version: v20231011-8b53cabe0
+  v1.28.6:
+    version: v1.9.5
     webhook-version: v20231011-8b53cabe0
   v1.29.1:
     version: v1.9.5
@@ -156,6 +161,9 @@ kubernetes-dashboard:
   v1.28.4:
     version: v2.7.0
     metrics-scraper-version: v1.0.8
+  v1.28.6:
+    version: v2.7.0
+    metrics-scraper-version: v1.0.8
   v1.29.1:
     version: v2.7.0
     metrics-scraper-version: v1.0.8
@@ -213,6 +221,9 @@ local-path-provisioner:
     busybox-version: 1.34.1
   v1.28.4:
     version: v0.0.25
+    busybox-version: 1.34.1
+  v1.28.6:
+    version: v0.0.26
     busybox-version: 1.34.1
   v1.29.1:
     version: v0.0.26

--- a/kubemarine/resources/configurations/compatibility/internal/thirdparties.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/thirdparties.yaml
@@ -38,6 +38,8 @@ kubeadm:
     sha1: 8935140d6a7b64f9038c911246cfc2a8da843673
   v1.28.4:
     sha1: 450eef85788fb68c4c26db82c6a0fb222e07869d
+  v1.28.6:
+    sha1: a6846fe15ce29865e9c813a677f40dc21868223c
   v1.29.1:
     sha1: 14390d6df2bb0b6546efd2238068c300461053fd
 kubelet:
@@ -77,6 +79,8 @@ kubelet:
     sha1: de8824a4eac34277251f911e944c69488359ee69
   v1.28.4:
     sha1: 32ef1daaf8f4996d16ff386f44cc0555c6f3de24
+  v1.28.6:
+    sha1: 25e2675bcbc59004ef148dc91a25404132b1faa1
   v1.29.1:
     sha1: aa871f4656bf1cc6393058f28d5c938268df3d4e
 kubectl:
@@ -116,6 +120,8 @@ kubectl:
     sha1: 096796f53a9b5af22e9e14b694fdefc870182b6e
   v1.28.4:
     sha1: 9a1691d307cb419d7047baccba89765015b2b7a4
+  v1.28.6:
+    sha1: 1458cc8aa68c2c4406db9fb36eeff181460d7f65
   v1.29.1:
     sha1: 5867f210ce90c62e0551062492751e43c2ae6a46
 calicoctl:
@@ -175,6 +181,9 @@ calicoctl:
   v1.28.4:
     version: v3.26.4
     sha1: 46875b3d28318553fe382db0766a0916f2556217
+  v1.28.6:
+    version: v3.27.0
+    sha1: 4d62cba82a4aee97ab20b96e7270da85d77ce20e
   v1.29.1:
     version: v3.27.0
     sha1: 4d62cba82a4aee97ab20b96e7270da85d77ce20e
@@ -235,6 +244,9 @@ crictl:
   v1.28.4:
     version: v1.28.0
     sha1: 1199411456ab5a1e0dd9524724f15e92aa3f9da7
+  v1.28.6:
+    version: v1.29.0
+    sha1: c4224ed25f729dbf73976198c8bc73dec0bf5a5f
   v1.29.1:
     version: v1.29.0
     sha1: c4224ed25f729dbf73976198c8bc73dec0bf5a5f

--- a/kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
+++ b/kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
@@ -125,6 +125,12 @@ compatibility_map:
     kubernetes-dashboard: v2.7.0
     local-path-provisioner: v0.0.25
     crictl: v1.28.0
+  v1.28.6:
+    calico: v3.27.0
+    nginx-ingress-controller: v1.9.5
+    kubernetes-dashboard: v2.7.0
+    local-path-provisioner: v0.0.26
+    crictl: v1.29.0
   v1.29.1:
     calico: v3.27.0
     nginx-ingress-controller: v1.9.5


### PR DESCRIPTION
### Description
Required files updated with new images and SHA.
Support v1.28.6 version
* 



### Test Cases
**TestCase 1**

Test Configuration:

- Hardware: default
- OS: Centos,Ubuntu
- Inventory: Allinone, miniha

Steps:

1. **Kubemarine install** -- kubernetesVersion: v1.28.6

Results:
Installation is successful

2. **Kubemarine upgrade** from v1.27.8 to v1.28.6

Results:
Upgrade procedure is successful

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


