### PR TITLE
[CPDEV-96712] - use formatted procedure inventory for merging with cluster.yaml

### DIFF
--- a/kubemarine/admission.py
+++ b/kubemarine/admission.py
@@ -175,10 +175,11 @@ def verify_version(owner: str, version: str, kubernetes_version: str) -> None:
             raise Exception("%s version must not be higher than Kubernetes version" % owner)
 
 
-def finalize_inventory_psp(cluster: KubernetesCluster, inventory_to_finalize: dict) -> dict:
+def finalize_inventory_psp(cluster: KubernetesCluster, inventory_to_finalize: dict,
+                           procedure_inventory_for_finalization: dict) -> dict:
     if cluster.context.get('initial_procedure') != 'manage_psp':
         return inventory_to_finalize
-    procedure_config = cluster.procedure_inventory["psp"]
+    procedure_config = procedure_inventory_for_finalization["psp"]
 
     if "rbac" not in inventory_to_finalize:
         inventory_to_finalize["rbac"] = {}
@@ -794,21 +795,23 @@ def update_kubeadm_configmap_pss(first_control_plane: NodeGroup, target_state: s
     return final_feature_list
 
 
-def finalize_inventory(cluster: KubernetesCluster, inventory_to_finalize: dict) -> dict:
+def finalize_inventory(cluster: KubernetesCluster, inventory_to_finalize: dict,
+                       procedure_inventory_for_finalization: dict) -> dict:
     admission_impl = cluster.inventory['rbac']['admission']
 
     if admission_impl == "psp":
-        return finalize_inventory_psp(cluster, inventory_to_finalize)
+        return finalize_inventory_psp(cluster, inventory_to_finalize, procedure_inventory_for_finalization)
     elif admission_impl == "pss":
-        return finalize_inventory_pss(cluster, inventory_to_finalize)
+        return finalize_inventory_pss(cluster, inventory_to_finalize, procedure_inventory_for_finalization)
 
     return inventory_to_finalize
 
 
-def finalize_inventory_pss(cluster: KubernetesCluster, inventory_to_finalize: dict) -> dict:
+def finalize_inventory_pss(cluster: KubernetesCluster, inventory_to_finalize: dict,
+                           procedure_inventory_for_finalization: dict) -> dict:
     if cluster.context.get('initial_procedure') != 'manage_pss':
         return inventory_to_finalize
-    procedure_config = cluster.procedure_inventory["pss"]
+    procedure_config = procedure_inventory_for_finalization["pss"]
 
     current_config = inventory_to_finalize.setdefault("rbac", {}).setdefault("pss", {})
 

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -40,6 +40,7 @@ class DynamicResources:
         self._raw_inventory: Optional[dict] = None
         self._formatted_inventory: Optional[dict] = None
         self._procedure_inventory: Optional[dict] = None
+        self._formatted_procedure_inventory: Optional[dict] = None
 
         self._nodes_context: Optional[dict] = None
         """
@@ -91,9 +92,12 @@ class DynamicResources:
         """
         if self._procedure_inventory is None:
             if self.procedure_inventory_filepath:
-                self._procedure_inventory = utils.load_yaml(self.procedure_inventory_filepath)
+                data = utils.read_external(self.procedure_inventory_filepath)
+                self._procedure_inventory = yaml.safe_load(data)
+                self._formatted_procedure_inventory = utils.yaml_structure_preserver().load(data)
             if not self._procedure_inventory:
                 self._procedure_inventory = {}
+                self._formatted_procedure_inventory = {}
 
         return self._procedure_inventory
 
@@ -116,7 +120,8 @@ class DynamicResources:
             utils.do_fail("Failed to load inventory file", exc, logger=logger)
 
     def make_final_inventory(self) -> None:
-        self._formatted_inventory = utils.get_final_inventory(self.cluster(), initial_inventory=self.formatted_inventory())
+        self._formatted_inventory = utils.get_final_inventory(self.cluster(),initial_inventory=self.formatted_inventory(),
+                                                              procedure_initial_inventory=self._formatted_procedure_inventory)
 
     def recreate_inventory(self) -> None:
         """

--- a/kubemarine/cri/__init__.py
+++ b/kubemarine/cri/__init__.py
@@ -48,13 +48,13 @@ def enrich_upgrade_inventory(inventory: dict, cluster: KubernetesCluster) -> dic
     return inventory
 
 
-def upgrade_finalize_inventory(cluster: KubernetesCluster, inventory: dict) -> dict:
+def upgrade_finalize_inventory(cluster: KubernetesCluster, inventory: dict, procedure_inventory: dict) -> dict:
     if cluster.context.get("initial_procedure") != "upgrade":
         return inventory
 
     cri_impl = cluster.inventory['services']['cri']['containerRuntime']
     if cri_impl == "containerd":
-        return containerd.upgrade_finalize_inventory(cluster, inventory)
+        return containerd.upgrade_finalize_inventory(cluster, inventory, procedure_inventory)
 
     return inventory
 

--- a/kubemarine/cri/containerd.py
+++ b/kubemarine/cri/containerd.py
@@ -82,16 +82,19 @@ def get_sandbox_image(cri_config: dict) -> Optional[str]:
     return sandbox_image
 
 
-def get_sandbox_image_upgrade_plan(cluster: KubernetesCluster) -> List[Tuple[str, dict]]:
+def get_sandbox_image_upgrade_plan(cluster: KubernetesCluster, procedure_inventory: dict = None) -> List[Tuple[str, dict]]:
+    if procedure_inventory is None:
+        procedure_inventory = cluster.procedure_inventory
+
     context = cluster.context
     upgrade_plan = []
     if context.get("initial_procedure") == "upgrade":
         upgrade_version = context["upgrade_version"]
-        for version in cluster.procedure_inventory['upgrade_plan']:
+        for version in procedure_inventory['upgrade_plan']:
             if utils.version_key(version) < utils.version_key(upgrade_version):
                 continue
 
-            upgrade_config = cluster.procedure_inventory.get(version, {}).get('cri', {})
+            upgrade_config = procedure_inventory.get(version, {}).get('cri', {})
             upgrade_plan.append((version, upgrade_config))
 
     return upgrade_plan
@@ -136,8 +139,11 @@ def is_sandbox_image_upgrade_required(cluster: KubernetesCluster, inventory: dic
     return old_image != new_image
 
 
-def upgrade_finalize_inventory(cluster: KubernetesCluster, inventory: dict) -> dict:
-    upgrade_plan = get_sandbox_image_upgrade_plan(cluster)
+def upgrade_finalize_inventory(cluster: KubernetesCluster, inventory: dict, procedure_inventory: dict = None) -> dict:
+    if procedure_inventory is None:
+        procedure_inventory = cluster.procedure_inventory
+
+    upgrade_plan = get_sandbox_image_upgrade_plan(cluster, procedure_inventory)
     if not upgrade_plan:
         return inventory
 
@@ -159,16 +165,19 @@ def enrich_migrate_cri_inventory(inventory: dict, cluster: KubernetesCluster) ->
     return migrate_cri_finalize_inventory(cluster, inventory)
 
 
-def migrate_cri_finalize_inventory(cluster: KubernetesCluster, inventory: dict) -> dict:
+def migrate_cri_finalize_inventory(cluster: KubernetesCluster, inventory: dict, procedure_inventory: dict = None) -> dict:
     if cluster.context.get("initial_procedure") != "migrate_cri":
         return inventory
+
+    if procedure_inventory is None:
+        procedure_inventory = cluster.procedure_inventory
 
     cri_section = inventory.setdefault("services", {}).setdefault("cri", {})
 
     if cri_section.get("dockerConfig", {}):
         del cri_section["dockerConfig"]
 
-    default_merger.merge(cri_section, deepcopy(cluster.procedure_inventory["cri"]))
+    default_merger.merge(cri_section, deepcopy(procedure_inventory["cri"]))
     return inventory
 
 

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -54,12 +54,15 @@ def kube_proxy_overwrites_higher_system_values(cluster: KubernetesCluster) -> bo
     return utils.version_key(kubernetes_version)[0:2] >= utils.minor_version_key("v1.29")
 
 
-def add_node_enrichment(inventory: dict, cluster: KubernetesCluster) -> dict:
+def add_node_enrichment(inventory: dict, cluster: KubernetesCluster, procedure_inventory: dict = None) -> dict:
     if cluster.context.get('initial_procedure') != 'add_node':
         return inventory
 
+    if procedure_inventory is None:
+        procedure_inventory = cluster.procedure_inventory
+
     # adding role "new_node" for all specified new nodes and putting these nodes to all "nodes" list
-    for new_node in cluster.procedure_inventory.get("nodes", []):
+    for new_node in procedure_inventory.get("nodes", []):
         # deepcopy is necessary, otherwise role append will happen in procedure_inventory too
         node = deepcopy(new_node)
         node["roles"].append("add_node")
@@ -74,12 +77,15 @@ def add_node_enrichment(inventory: dict, cluster: KubernetesCluster) -> dict:
     return inventory
 
 
-def remove_node_enrichment(inventory: dict, cluster: KubernetesCluster) -> dict:
+def remove_node_enrichment(inventory: dict, cluster: KubernetesCluster,  procedure_inventory: dict = None) -> dict:
     if cluster.context.get('initial_procedure') != 'remove_node':
         return inventory
 
+    if procedure_inventory is None:
+        procedure_inventory = cluster.procedure_inventory
+
     # adding role "remove_node" for all specified nodes
-    node_names_to_remove = [node['name'] for node in cluster.procedure_inventory.get("nodes", [])]
+    node_names_to_remove = [node['name'] for node in procedure_inventory.get("nodes", [])]
     for node_remove in node_names_to_remove:
         for i, node in enumerate(inventory['nodes']):
             # Inventory is not compiled at this step.

--- a/kubemarine/plugins/nginx_ingress.py
+++ b/kubemarine/plugins/nginx_ingress.py
@@ -82,10 +82,11 @@ def cert_renew_enrichment(inventory: dict, cluster: KubernetesCluster) -> dict:
     return inventory
 
 
-def finalize_inventory(cluster: KubernetesCluster, inventory_to_finalize: dict) -> dict:
+def finalize_inventory(cluster: KubernetesCluster, inventory_to_finalize: dict,
+                       procedure_inventory_for_finalization: dict) -> dict:
     # check that renewal is required for nginx
     if cluster.context.get('initial_procedure') != 'cert_renew' \
-            or not cluster.procedure_inventory.get("nginx-ingress-controller"):
+            or not procedure_inventory_for_finalization.get("nginx-ingress-controller"):
         return inventory_to_finalize
 
     if not inventory_to_finalize["plugins"].get("nginx-ingress-controller"):
@@ -98,7 +99,8 @@ def finalize_inventory(cluster: KubernetesCluster, inventory_to_finalize: dict) 
         inventory_to_finalize["plugins"]["nginx-ingress-controller"]["controller"]["ssl"] = {}
 
     nginx_plugin = inventory_to_finalize["plugins"]["nginx-ingress-controller"]
-    nginx_plugin["controller"]["ssl"]["default-certificate"] = cluster.procedure_inventory["nginx-ingress-controller"]
+    nginx_plugin["controller"]["ssl"]["default-certificate"] = (
+        procedure_inventory_for_finalization)["nginx-ingress-controller"]
 
     return inventory_to_finalize
 

--- a/kubemarine/procedures/add_node.py
+++ b/kubemarine/procedures/add_node.py
@@ -60,7 +60,8 @@ def redeploy_plugins_if_needed(cluster: KubernetesCluster) -> None:
         cluster.log.debug("Redeploy ingress-nginx-controller is not needed, skip it")
 
 
-def add_node_finalize_inventory(cluster: KubernetesCluster, inventory_to_finalize: dict) -> dict:
+def add_node_finalize_inventory(cluster: KubernetesCluster, inventory_to_finalize: dict,
+                                procedure_inventory_for_finalization: dict = None) -> dict:
     if cluster.context.get('initial_procedure') != 'add_node':
         return inventory_to_finalize
 
@@ -68,7 +69,7 @@ def add_node_finalize_inventory(cluster: KubernetesCluster, inventory_to_finaliz
 
     if not is_finalization:
         # new nodes are not presented in final inventory - let's add it original config
-        kubernetes.add_node_enrichment(inventory_to_finalize, cluster)
+        kubernetes.add_node_enrichment(inventory_to_finalize, cluster, procedure_inventory_for_finalization)
 
     # new nodes are already presented in final inventory - ok, just remove label
     for i, node in enumerate(inventory_to_finalize['nodes']):

--- a/kubemarine/procedures/remove_node.py
+++ b/kubemarine/procedures/remove_node.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 from collections import OrderedDict
 from typing import List
 
@@ -67,7 +65,8 @@ def remove_kubernetes_nodes(cluster: KubernetesCluster) -> None:
     kubernetes.schedule_running_nodes_report(cluster)
 
 
-def remove_node_finalize_inventory(cluster: KubernetesCluster, inventory_to_finalize: dict) -> dict:
+def remove_node_finalize_inventory(cluster: KubernetesCluster, inventory_to_finalize: dict,
+                                   procedure_inventory_for_finalization: dict = None) -> dict:
     if cluster.context.get('initial_procedure') != 'remove_node':
         return inventory_to_finalize
 
@@ -76,7 +75,7 @@ def remove_node_finalize_inventory(cluster: KubernetesCluster, inventory_to_fina
     is_finalization = any('remove_node' in node['roles'] for node in inventory_to_finalize['nodes'])
 
     if not is_finalization:
-        kubernetes.remove_node_enrichment(inventory_to_finalize, cluster)
+        kubernetes.remove_node_enrichment(inventory_to_finalize, cluster, procedure_inventory_for_finalization)
 
     # Do not remove VRRP IPs and do not change their assigned hosts.
     # If the assigned host does not exist or is not a balancer, it will be just skipped.

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -125,19 +125,22 @@ def _convert_thirdparty(thirdparties: dict, destination: str) -> dict:
     return config
 
 
-def _get_upgrade_plan(cluster: KubernetesCluster) -> List[Tuple[str, dict]]:
+def _get_upgrade_plan(cluster: KubernetesCluster, procedure_inventory: dict = None) -> List[Tuple[str, dict]]:
+    if procedure_inventory is None:
+        procedure_inventory = cluster.procedure_inventory
+
     context = cluster.context
     if context.get("initial_procedure") == "upgrade":
         upgrade_version = context["upgrade_version"]
         upgrade_plan = []
-        for version in cluster.procedure_inventory['upgrade_plan']:
+        for version in procedure_inventory['upgrade_plan']:
             if utils.version_key(version) < utils.version_key(upgrade_version):
                 continue
 
-            upgrade_plan.append((version, cluster.procedure_inventory.get(version, {}).get("thirdparties", {})))
+            upgrade_plan.append((version, procedure_inventory.get(version, {}).get("thirdparties", {})))
 
     elif context.get("initial_procedure") == "migrate_kubemarine" and 'upgrading_thirdparty' in context:
-        upgrade_thirdparties = cluster.procedure_inventory.get('upgrade', {}).get("thirdparties", {})
+        upgrade_thirdparties = procedure_inventory.get('upgrade', {}).get("thirdparties", {})
         upgrade_thirdparties = dict(item for item in upgrade_thirdparties.items()
                                     if item[0] == context['upgrading_thirdparty'])
         upgrade_plan = [("", upgrade_thirdparties)]
@@ -196,12 +199,15 @@ def _verify_upgrade_plan(inventory: dict, previous_version: str,
         previous_version = version
 
 
-def upgrade_finalize_inventory(cluster: KubernetesCluster, inventory: dict) -> dict:
-    return generic_upgrade_inventory(cluster, inventory)
+def upgrade_finalize_inventory(cluster: KubernetesCluster, inventory: dict, procedure_inventory: dict) -> dict:
+    return generic_upgrade_inventory(cluster, inventory, procedure_inventory)
 
 
-def generic_upgrade_inventory(cluster: KubernetesCluster, inventory: dict) -> dict:
-    upgrade_plan = _get_upgrade_plan(cluster)
+def generic_upgrade_inventory(cluster: KubernetesCluster, inventory: dict, procedure_inventory: dict = None) -> dict:
+    if procedure_inventory is None:
+        procedure_inventory = cluster.procedure_inventory
+
+    upgrade_plan = _get_upgrade_plan(cluster, procedure_inventory)
     if not upgrade_plan:
         return inventory
 
@@ -213,11 +219,14 @@ def enrich_restore_inventory(inventory: dict, cluster: KubernetesCluster) -> dic
     return restore_finalize_inventory(cluster, inventory)
 
 
-def restore_finalize_inventory(cluster: KubernetesCluster, inventory: dict) -> dict:
+def restore_finalize_inventory(cluster: KubernetesCluster, inventory: dict, procedure_inventory: dict = None) -> dict:
+    if procedure_inventory is None:
+        procedure_inventory = cluster.procedure_inventory
+
     if cluster.context.get("initial_procedure") != "restore":
         return inventory
 
-    restore_thirdparties = cluster.procedure_inventory.get('restore_plan', {}).get('thirdparties', {})
+    restore_thirdparties = procedure_inventory.get('restore_plan', {}).get('thirdparties', {})
     return _enrich_procedure_inventory(inventory, restore_thirdparties)
 
 
@@ -225,11 +234,14 @@ def enrich_migrate_cri_inventory(inventory: dict, cluster: KubernetesCluster) ->
     return migrate_cri_finalize_inventory(cluster, inventory)
 
 
-def migrate_cri_finalize_inventory(cluster: KubernetesCluster, inventory: dict) -> dict:
+def migrate_cri_finalize_inventory(cluster: KubernetesCluster, inventory: dict, procedure_inventory: dict = None) -> dict:
+    if procedure_inventory is None:
+        procedure_inventory = cluster.procedure_inventory
+
     if cluster.context.get("initial_procedure") != "migrate_cri":
         return inventory
 
-    procedure_thirdparties = cluster.procedure_inventory.get("thirdparties", {})
+    procedure_thirdparties = procedure_inventory.get("thirdparties", {})
     return _enrich_procedure_inventory(inventory, procedure_thirdparties)
 
 


### PR DESCRIPTION
### Description
After some procedure, data from `procedure.yaml` is merged with `cluster.yaml`. But during this merging, all multiline strings from `procedure.yaml` are applied in one line in `cluster.yaml`. It does not affect future procedures, but it's a cosmetic defect, for example, if some certificates are used in `procedure.yaml`, following certificates will be difficult to read for users.


Fixes # (issue)


### Solution
Added new `formated_procedure_inventory` field in `DynamicResource` that is equivalent of `formated_inventory` but for `procedure.yaml`. This field contains formatted procedure inventory, that includes yaml format information.
This formated inventory is used for merging with cluster.yaml, as result all multiline strings will be applied as-is, how they are specified in `procedure.yaml`. Additionally, comments are also transferred from `procedure.yaml` to `cluster.yaml`


### How to apply
Provide steps how to apply on top previous Kubemarine version to execute on existing clusters
* [Install task/s](documentation/Installation.md#installation-tasks-description)
* Any procedure with multiline string in `procedure.yaml`

### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 

Steps:

1. Run `kubemarine install`
2. Run `cert_renew` with new certificates;

Results:

| Before | After |
| ------ | ------ |
| certificates are applied in `cluster.yaml` in one line string | certificates are applied in `cluster.yaml` as-is in `procedure.yaml` |

**TestCase 2**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 

Steps:

1. Run `kubemarine install`
2. Run `upgrade` with new certificates for ingress-nginx;

Results:

| Before | After |
| ------ | ------ |
| certificates are applied in `cluster.yaml` in one line string | certificates are applied in `cluster.yaml` as-is in `procedure.yaml` |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


