### PR TITLE
Disable package automatic discovery of setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+include = ["kubemarine*"]
+
 [project]
 dynamic = ["version", "readme"]
 name = "kubemarine"


### PR DESCRIPTION
### Description
* If Kubemarine is run from sources and dump/ directory is created, attempt to build the package fails with
  `Multiple top-level packages discovered in a flat-layout: ['dump', 'kubemarine']`

### Solution
* Disable package automatic discovery by explicitly specifying where to search the packages in.

### Test Cases

**TestCase 1**

Steps:

1. Run Kubemarine from sources
2. Install package from sources using `pip install .`

Results:

| Before | After |
| ------ | ------ |
| Multiple top-level packages discovered in a flat-layout: ['dump', 'kubemarine'] | Package is built successfully |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

