### PR TITLE
Finalized inventory loses overridden blank strings

### DIFF
--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -484,6 +484,7 @@ class DynamicResources:
         return [
             kubemarine.packages.cache_package_versions,
             kubemarine.core.defaults.escape_jinja_characters_for_inventory,
+            kubemarine.core.defaults.finalize_primitive_values,
             kubemarine.controlplane.controlplane_finalize_inventory,
         ]
 

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -186,8 +186,9 @@ def enrich_inventory(cluster: KubernetesCluster) -> None:
 
     # override kubeadm_kube-proxy.conntrack.min with sysctl.net.netfilter.nf_conntrack_max since they define the same kernel variable
     version_key = utils.version_key(inventory["services"]["kubeadm"]["kubernetesVersion"])
-    if version_key >= (1, 29, 0):
-        inventory["services"]["kubeadm_kube-proxy"]["conntrack"]["min"] = inventory["services"]["sysctl"]["net.netfilter.nf_conntrack_max"]
+    conntrack_max = inventory["services"]["sysctl"].get("net.netfilter.nf_conntrack_max")
+    if version_key >= (1, 29, 0) and conntrack_max is not None:
+        inventory["services"]["kubeadm_kube-proxy"]["conntrack"]["min"] = conntrack_max
     else:
         inventory["services"]["kubeadm_kube-proxy"]["conntrack"].pop("min",None)
 


### PR DESCRIPTION
### Description
If source inventory contains blank values for some properties, they override defaults and then can be deleted during enrichment. Finalized inventory does not contain blank values for these properties. If it is used as a source inventory, the properties no longer override the defaults.

### Solution
Added inventory finalization function that return blank overridden values to the finalized inventory.

### Test Cases

**TestCase 1**

Steps:

1. Configure inventory
   ```yaml
   services:
     sysctl:
       net.netfilter.nf_conntrack_max: ''
     kubeadm_kube-proxy:
       conntrack:
         min: ''
   ```
2. Install cluster v1.29.1
3. Check `sysctl -a | grep net.netfilter.nf_conntrack_max`

ER: The property is set by kube-proxy to some default != 1000000.

4. Install new cluster using finalized inventory from step 2
5. Check `sysctl -a | grep net.netfilter.nf_conntrack_max`

Results:

| Before | After |
| ------ | ------ |
| The property is equal to 1000000 | The property is set by kube-proxy to some default != 1000000 equal to that from step 2 |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_defaults.py - covers this bug
