### PR TITLE
[CPREQ-8729] Improve paas_check_detected_incorrect_packages_versions_explanation

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -239,7 +239,7 @@ def check_packages_versions(cluster: KubernetesCluster, tc: TestCase, hosts_to_p
             if version.startswith(package_name):
                 good_results.append(version)
             else:
-                bad_results.append(f"{package} (Actual version: {version}, Expected package version: {package_name})")
+                bad_results.append(f"{package} (Actual version: {version}, Expected package version: {package})")
     if bad_results:
         hint_message = f'Check the presence and correctness of the version of the following packages on the ' \
                        f'system: {bad_results}'

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -239,8 +239,7 @@ def check_packages_versions(cluster: KubernetesCluster, tc: TestCase, hosts_to_p
             if version.startswith(package_name):
                 good_results.append(version)
             else:
-                bad_results.append(version)
-
+                bad_results.append(f"{package} (Actual version: {version}, Expected package: {package_name})")
     if bad_results:
         hint_message = f'Check the presence and correctness of the version of the following packages on the ' \
                        f'system: {bad_results}'

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -239,10 +239,12 @@ def check_packages_versions(cluster: KubernetesCluster, tc: TestCase, hosts_to_p
             if version.startswith(package_name):
                 good_results.append(version)
             else:
-                bad_results.append(f"{package} (Actual version: {version}, Expected package version: {package})")
+                bad_results.append(f"Actual version: {version} doesn't match expected package version: {package}")
+
+
     if bad_results:
         hint_message = f'Check the presence and correctness of the version of the following packages on the ' \
-                       f'system: {bad_results}'
+                       f'system: {bad_results}\n'
         if warn_on_bad_result:
             raise TestWarn("detected incorrect packages versions", hint=hint_message)
         raise TestFailure("detected incorrect packages versions", hint=hint_message)

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -239,7 +239,7 @@ def check_packages_versions(cluster: KubernetesCluster, tc: TestCase, hosts_to_p
             if version.startswith(package_name):
                 good_results.append(version)
             else:
-                bad_results.append(f"{package} (Actual version: {version}, Expected package: {package_name})")
+                bad_results.append(f"{package} (Actual version: {version}, Expected package version: {package_name})")
     if bad_results:
         hint_message = f'Check the presence and correctness of the version of the following packages on the ' \
                        f'system: {bad_results}'


### PR DESCRIPTION
### Description
The modification enhances the formatting of messages appended to the bad_results list within the check_packages_versions function. 
* 

Fixes # (issue)
https://tms.netcracker.com/browse/CPREQ-8729

### Solution
The solution involves adjusting the format of the appended message to the bad_results list.
* 



### Test Cases

**TestCase 1**

Steps:

1. Upgrade the containerd version from 1.6.* to 1.7.*
2. Run K=kubemarine check_paas

Results:

| Before | After |
| ------ | ------ |
| Check the presence and correctness of the version of the following packages on the system: ['containerd=1.7.2-0ubuntu1~20.04.1'] | Check the presence and correctness of the version of the following packages on the system: ['containerd=1.6.* (Actual version: containerd=1.7.2-0ubuntu1~20.04.1, Expected package version: containerd=1.6.)']
 |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


