### PR TITLE
[CPDEV-98652] - parse url and provide creds as header in check_url_availability script

### DIFF
--- a/kubemarine/resources/scripts/check_url_availability.py
+++ b/kubemarine/resources/scripts/check_url_availability.py
@@ -24,7 +24,7 @@ if major_version == 3:
     import urllib.parse as urlparse
 else:
     import urllib2 as urllib  # type: ignore[import-not-found, no-redef]
-    import urlparse as urlparse
+    import urlparse as urlparse # type: ignore[import-not-found, no-redef]
 
 try:
     source = sys.argv[1]
@@ -34,7 +34,7 @@ try:
     no_auth_url = parsed_url._replace(netloc="{}".format(no_auth_netloc)).geturl()
 
     password_mgr = urllib.HTTPPasswordMgrWithDefaultRealm()
-    password_mgr.add_password(None, no_auth_url, parsed_url.username, parsed_url.password)
+    password_mgr.add_password(None, no_auth_url, parsed_url.username or '', parsed_url.password or '')
     handler = urllib.HTTPBasicAuthHandler(password_mgr)
     opener = urllib.build_opener(handler)
 


### PR DESCRIPTION
### Description
If user specify credentials for thirdparties in url, `check_iaas` can not check availability for them, because `urllib` package does not support user-info fields in url: https://bugs.python.org/issue34628
Fixes # (issue)


### Solution
Modified `check_url_availability` script to extract credentials from url and apply them using official authorization mechanism.


### Test Cases

**TestCase 1**: with python3

Test Configuration:

- Hardware: 
- OS: ubuntu or another OS with python3 installed
- Inventory: some thirdparties sources use secure registries

Steps:
1. Run `check_iaas`

Results:

| Before | After |
| ------ | ------ |
| `software.thirdparties.availability` fails for secured thirdparties with `nonnumeric port` exception | `software.thirdparties.availability` finishes successfully |

**TestCase 1**: with python2

Test Configuration:

- Hardware: 
- OS: OS with only python2 installed
- Inventory: some thirdparties sources use secure registries

Steps:
1. Run `check_iaas`

Results:

| Before | After |
| ------ | ------ |
| `software.thirdparties.availability` fails for secured thirdparties with `nonnumeric port` exception | `software.thirdparties.availability` finishes successfully |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


