### PR TITLE
Avoid interactive constants (exit) from site module

### DIFF
--- a/kubemarine/procedures/migrate_kubemarine.py
+++ b/kubemarine/procedures/migrate_kubemarine.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import argparse
 import re
+import sys
 from abc import ABC, abstractmethod
 from textwrap import dedent
 from typing import List, Union
@@ -454,32 +455,32 @@ def run(context: dict) -> None:
                 print(patch_id)
         else:
             print("No patches available.")
-        exit(0)
+        sys.exit(0)
 
     if args['describe']:
         for patch in patches:
             if patch.identifier == args['describe']:
                 print(patch.description)
-                exit(0)
+                sys.exit(0)
         print(f"Unknown patch '{args['describe']}'")
-        exit(1)
+        sys.exit(1)
 
     skip = [] if not args['skip'] else args['skip'].split(",")
     apply = [] if not args['apply'] else args['apply'].split(",")
 
     if apply and (set(apply) - set(patch_ids)):
         print(f"Unknown patches {list(set(apply) - set(patch_ids))}")
-        exit(1)
+        sys.exit(1)
 
     if skip and (set(skip) - set(patch_ids)):
         print(f"Unknown patches {list(set(skip) - set(patch_ids))}")
-        exit(1)
+        sys.exit(1)
 
     if apply:
         positions = [patch_ids.index(apply_id) for apply_id in apply]
         if not all(positions[i] < positions[i + 1] for i in range(len(positions) - 1)):
             print("Incorrect order of patches to apply. See --list for correct order of patches.")
-            exit(1)
+            sys.exit(1)
 
     actions = []
     for patch in patches:
@@ -494,7 +495,7 @@ def run(context: dict) -> None:
 
     if not actions:
         print("No patches to apply")
-        exit(0)
+        sys.exit(0)
 
     flow.ActionsFlow(actions).run_flow(context)
 

--- a/kubemarine/resources/scripts/check_url_availability.py
+++ b/kubemarine/resources/scripts/check_url_availability.py
@@ -30,7 +30,7 @@ try:
     status_code = urllib.urlopen(source, timeout=timeout).getcode()
     if status_code != 200:
         sys.stderr.write("Error status code: %s" % status_code)
-        exit(1)
+        sys.exit(1)
 except Exception as e:
     sys.stderr.write(str(e))
-    exit(1)
+    sys.exit(1)

--- a/kubemarine/resources/scripts/simple_port_client.py
+++ b/kubemarine/resources/scripts/simple_port_client.py
@@ -53,4 +53,4 @@ finally:
 if action == 'send' and len(data) != sz:
     sys.stdout.write("Data is lost\n")
     sys.stdout.flush()
-    exit(1)
+    sys.exit(1)

--- a/kubemarine/resources/scripts/simple_port_listener.py
+++ b/kubemarine/resources/scripts/simple_port_listener.py
@@ -41,7 +41,7 @@ try:
         if "Address already in use" in str(e):
             sys.stdout.write("In use\n")
             sys.stdout.flush()
-            exit(1)
+            sys.exit(1)
         else:
             raise
 

--- a/scripts/ci/build_binary.py
+++ b/scripts/ci/build_binary.py
@@ -29,7 +29,7 @@ PYINSTALLER_HOOK_CONTRIB_VERSION = "2023.10"
 def call(args: List[str]) -> None:
     return_code = subprocess.call(args)
     if return_code != 0:
-        exit(return_code)
+        sys.exit(return_code)
 
 # Copy ipip_check from package
 with open('kubemarine/version', 'r') as version_file:


### PR DESCRIPTION
### Description
* `kubemarine migrate_kubemarine` fails with `NameError: name 'exit' is not defined` if run as executable file.

Fixes #612

### Solution
* Avoid using of interactive constants from site module. https://docs.python.org/3/library/constants.html#constants-added-by-the-site-module

### Test Cases

**TestCase 1**

Steps:

1. Run `kubemarine migrate_kubemarine --list` using Kubemarine v0.27.0 executable.

Results:

| Before | After |
| ------ | ------ |
| NameError: name 'exit' is not defined | Prints "No patches available." |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
