### PR TITLE
[CPDEV-98878] Expect calico-typha pods and deployment if enabled

### DIFF
--- a/kubemarine/jinja.py
+++ b/kubemarine/jinja.py
@@ -52,8 +52,8 @@ def new(_: log.EnhancedLogger, *,
 
     # we need these filters because rendered cluster.yaml can contain variables like 
     # enable: 'true'
-    env.filters['is_true'] = lambda v: v is True or utils.strtobool(_precompile('is_true', v))
-    env.filters['is_false'] = lambda v: v is False or not utils.strtobool(_precompile('is_false', v))
+    env.filters['is_true'] = lambda v: v if isinstance(v, bool) else utils.strtobool(_precompile('is_true', v))
+    env.filters['is_false'] = lambda v: not v if isinstance(v, bool) else not utils.strtobool(_precompile('is_false', v))
     return env
 
 

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -528,15 +528,18 @@ plugins:
             method: apply_yaml
             arguments:
               plugin_name: calico
-        - expect:
+        - &plugins-calico-expect
+          expect:
             daemonsets:
               - calico-node
             deployments:
               - calico-kube-controllers
+              - '{% if plugins.calico.typha.enabled | is_true %}calico-typha{% endif %}'
             pods:
               - coredns
               - calico-kube-controllers
               - calico-node
+              - '{% if plugins.calico.typha.enabled | is_true %}calico-typha{% endif %}'
         - thirdparty: /usr/bin/calicoctl
         - template:
             source: templates/plugins/calicoctl.cfg.j2
@@ -551,15 +554,7 @@ plugins:
             source: templates/plugins/calico-rr.sh.j2
             destination: /tmp/calico_rr.sh
             apply_command: /bin/sh /tmp/calico_rr.sh
-        - expect:
-            daemonsets:
-              - calico-node
-            deployments:
-              - calico-kube-controllers
-            pods:
-              - coredns
-              - calico-kube-controllers
-              - calico-node
+        - *plugins-calico-expect
         - python:
             module: plugins/builtin.py
             method: apply_yaml

--- a/test/unit/plugins/test_calico.py
+++ b/test/unit/plugins/test_calico.py
@@ -14,6 +14,7 @@
 
 import io
 import unittest
+from typing import List
 from unittest import mock
 
 import yaml
@@ -414,6 +415,43 @@ class APIServerManifestEnrichment(_AbstractManifestEnrichmentTest):
                     container['resources'], "Unexpected calico-apiserver resources")
 
 
+def get_default_expect_config(typha_enabled: bool) -> dict:
+    config = {
+        'daemonsets': {'list': ['calico-node']},
+        'deployments': {'list': ['calico-kube-controllers']},
+        'pods': {'list': ['coredns', 'calico-kube-controllers', 'calico-node']},
+    }
+    if typha_enabled:
+        config['deployments']['list'].append('calico-typha')
+        config['pods']['list'].append('calico-typha')
+
+    return config
+
+
+class EnrichmentTest(unittest.TestCase):
+    def test_expect_typha_default(self):
+        for nodes in (3, 4):
+            with self.subTest(f"Kubernetes nodes: {nodes}"):
+                scheme = {'master': [], 'worker': []}
+                for i in range(nodes):
+                    scheme['master'].append(f'master-{i+1}')
+                    scheme['worker'].append(f'master-{i+1}')
+
+                inventory = demo.generate_inventory(**scheme)
+                inventory.setdefault('plugins', {})['calico'] = {
+                    'install': True,
+                }
+
+                cluster = demo.new_cluster(inventory)
+
+                expected_expect_step = get_default_expect_config(nodes > 3)
+
+                steps = cluster.inventory['plugins']['calico']['installation']['procedures']
+                actual_expect_steps = [step['expect'] for step in steps if 'expect' in step]
+                self.assertEqual([expected_expect_step, expected_expect_step], actual_expect_steps,
+                                 "Unexpected expect procedures")
+
+
 class RedeployIfNeeded(unittest.TestCase):
     def prepare_context(self, procedure: str):
         task = 'deploy.plugins' if procedure == 'add_node' else 'update.plugins'
@@ -447,6 +485,11 @@ class RedeployIfNeeded(unittest.TestCase):
 
         return resources
 
+    @staticmethod
+    def get_actual_step_configs(inventory: dict, procedure: str) -> List[dict]:
+        steps = inventory['plugins']['calico']['installation']['procedures']
+        return [step[procedure] for step in steps if procedure in step]
+
     def test_add_fourth_kubernetes_node_redeploy_needed(self):
         for role in ('master', 'worker'):
             for typha_disabled_redefined in (False, True):
@@ -462,13 +505,21 @@ class RedeployIfNeeded(unittest.TestCase):
 
                     res = self._run_and_check(not typha_disabled_redefined)
 
+                    expected_expect_step = get_default_expect_config(not typha_disabled_redefined)
+
                     typha_enabled = res.working_inventory['plugins']['calico']['typha']['enabled']
                     self.assertEqual(not typha_disabled_redefined, typha_enabled,
                                      "Typha is not enabled in enriched inventory")
 
+                    actual_expect_steps = self.get_actual_step_configs(res.working_inventory, 'expect')
+                    self.assertEqual([expected_expect_step, expected_expect_step], actual_expect_steps)
+
                     typha_enabled = res.finalized_inventory['plugins']['calico']['typha']['enabled']
                     self.assertEqual(not typha_disabled_redefined, typha_enabled,
                                      "Typha is not enabled in enriched inventory")
+
+                    actual_expect_steps = self.get_actual_step_configs(res.finalized_inventory, 'expect')
+                    self.assertEqual([expected_expect_step, expected_expect_step], actual_expect_steps)
 
                     typha_enabled = res.inventory()['plugins']['calico']['typha'].get('enabled')
                     expected_enabled = None if not typha_disabled_redefined else False
@@ -490,13 +541,21 @@ class RedeployIfNeeded(unittest.TestCase):
 
                     res = self._run_and_check(False)
 
+                    expected_expect_step = get_default_expect_config(True)
+
                     typha_enabled = res.working_inventory['plugins']['calico']['typha']['enabled']
                     self.assertEqual(True, typha_enabled,
                                      "Typha is not enabled in enriched inventory")
 
+                    actual_expect_steps = self.get_actual_step_configs(res.working_inventory, 'expect')
+                    self.assertEqual([expected_expect_step, expected_expect_step], actual_expect_steps)
+
                     typha_enabled = res.finalized_inventory['plugins']['calico']['typha']['enabled']
                     self.assertEqual(True, typha_enabled,
                                      "Typha is not enabled in enriched inventory")
+
+                    actual_expect_steps = self.get_actual_step_configs(res.finalized_inventory, 'expect')
+                    self.assertEqual([expected_expect_step, expected_expect_step], actual_expect_steps)
 
                     typha_enabled = res.inventory()['plugins']['calico']['typha'].get('enabled')
                     self.assertEqual(True, typha_enabled,


### PR DESCRIPTION
### Description
* Kubemarine does not wait for healthy Calico Typha deployment and pods.

### Solution
* Added calico-typha to the list for expect in defaults.yaml.
* Fix bug in is_true, is_false jinja filters for boolean values.

### Test Cases

**TestCase 1**

Steps:

1. Enable Calico Typha in All-in-One scheme, and install the cluster.

Results:

| Before | After |
| ------ | ------ |
| Cluster is installed successfully | Installation is failed because one of pods is in Pending state. |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_calico.py - added tests for expect procedure enrichment if Calico Typha is enabled/disabled.
