### PR TITLE
[CPDEV-98822] Remove default resolvConf from kubelet-config ConfigMap

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -491,7 +491,10 @@ def init_first_control_plane(group: NodeGroup) -> None:
     kubeconfig_filepath = fetch_admin_config(cluster)
     summary.schedule_report(cluster.context, summary.SummaryItem.KUBECONFIG, kubeconfig_filepath)
 
-    # Invoke method from admission module for applying default PSS or privileged PSP if they are enabled
+    # Remove default resolvConf from kubelet-config ConfigMap for debian OS family
+    first_control_plane.call(components.patch_kubelet_configmap)
+
+    # Invoke method from admission module for applying the privileged PSP if it is enabled
     first_control_plane.call(admission.apply_admission)
 
     # Preparing join_dict to init other nodes

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -22,8 +22,10 @@ The whole directory is automatically cleared and reset after new version of Kube
 from typing import List
 
 from kubemarine.core.patch import Patch
+from kubemarine.patches.patch_kubelet_configmap import KubeletResolvConf
 
 patches: List[Patch] = [
+    KubeletResolvConf(),
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/patch_kubelet_configmap.py
+++ b/kubemarine/patches/patch_kubelet_configmap.py
@@ -1,0 +1,45 @@
+from textwrap import dedent
+
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine.kubernetes import components
+
+
+class TheAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Remove default resolvConf from kubelet-config ConfigMap")
+
+    def run(self, res: DynamicResources) -> None:
+        cluster = res.cluster()
+        control_plane = cluster.nodes['control-plane'].get_first_member()
+
+        kubeadm_config = components.KubeadmConfig(cluster)
+        if 'resolvConf' in kubeadm_config.maps['kubelet-config']:
+            return cluster.log.info("KubeletConfiguration.resolvConf is redefined in the inventory. "
+                                    "Patch is not applicable.")
+
+        if 'resolvConf' not in kubeadm_config.load('kubelet-config', control_plane):
+            return cluster.log.info("KubeletConfiguration.resolvConf is already absent in the kubelet-config ConfigMap.")
+
+        control_plane.call(components.patch_kubelet_configmap)
+
+
+class KubeletResolvConf(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("kubelet_resolvConf")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            If KubeletConfiguration.resolvConf is not redefined in the inventory,
+            remove it from the kubelet-config ConfigMap if present.
+            
+            This is necessary for smoother migration of the operating systems.
+            """.rstrip()
+        )


### PR DESCRIPTION
### Description
Default value of resolvConf is uploaded to kubelet-config ConfigMap by kubeadm.
This causes problems in migration of operating systems, because resolvConf is taken from the ConfigMap,
while it should be different on different OS.

Fixes #586

### Solution
If resolvConf is not redefined in the inventory, remove it from kubelet-config ConfigMap
* during `kubeadm init` of the first control plane.
* during `kubemarine reconfigure`
* in `services.kubelet.configuration` PaaS check when generating the CM for comparison.

### How to apply
Run `kubemarine migrate_kubemarine --force-apply kubelet_resolvConf`

### Test Cases

**TestCase 1**

Migrate from Ubuntu 22.04 to RHEL9.

Steps:

1. Install cluster on Ubuntu 22.04.
2. Add node on RHEL9.

Results:

| Before | After |
| ------ | ------ |
| Node is not joined. journalctl for kubelet contains error "open /run/systemd/resolve/resolv.conf: no such file or directory"  | Node is joined |

**TestCase 2**

Migrate from Centos 7 to Ubuntu 22.04

Steps:

1. Install cluster on Centos 7.
2. Migrate on Ubuntu 22.04.
3. Run `check_paas --tasks services.kubelet.configuration`

Results:

| Before | After |
| ------ | ------ |
| failed: "kubelet-config ConfigMap is not consistent with services.kubeadm_kubelet section" | Check is successful |

**TestCase 3**

Migration of old clusters.

Steps:

1. Install cluster on Ubuntu 22.04 using **older** version of Kubemarine.

Next steps should be done using **new** version of Kubemarine.

2. Run `check_paas --tasks services.kubelet.configuration`

ER: failed: "kubelet-config ConfigMap is not consistent with services.kubeadm_kubelet section"

3. Run `kubemarine migrate_kubemarine --force-apply kubelet_resolvConf`
4. Run `check_paas --tasks services.kubelet.configuration`

ER: check is successful.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
