### PR TITLE
Procedure `do` does not work

### DIFF
--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -283,12 +283,18 @@ class DynamicResources:
         self._clusters.pop(c.EnrichmentStage.PROCEDURE, None)
 
     def dump_finalized_inventory(self, cluster: c.KubernetesCluster) -> None:
-        finalized_inventory = cluster.make_finalized_inventory(self.finalization_functions())
-        self._store_finalized_inventory(finalized_inventory)
-
-    def _store_finalized_inventory(self, finalized_inventory: dict) -> None:
-        data = yaml.dump(finalized_inventory)
         finalized_filename = "cluster_finalized.yaml"
+        if not self._make_finalized_inventory(finalized_filename):
+            return
+
+        finalized_inventory = cluster.make_finalized_inventory(self.finalization_functions())
+        self._store_finalized_inventory(finalized_inventory, finalized_filename)
+
+    def _make_finalized_inventory(self, finalized_filename: str) -> bool:
+        return utils.is_dump_allowed(self.context, finalized_filename)
+
+    def _store_finalized_inventory(self, finalized_inventory: dict, finalized_filename: str) -> None:
+        data = yaml.dump(finalized_inventory)
         utils.dump_file(self.context, data, finalized_filename)
         utils.dump_file(self.context, data, finalized_filename, dump_location=False)
 

--- a/test/unit/plugins/test_template.py
+++ b/test/unit/plugins/test_template.py
@@ -107,7 +107,7 @@ class TestTemplate(unittest.TestCase):
                 }
 
                 for file in tc["apply_files"]:
-                    result = demo.create_nodegroup_result(cluster.nodes["master"])
+                    result = demo.create_nodegroup_result(cluster.nodes["master"], hide=False)
                     cluster.fake_shell.add(result, "sudo", [f"kubectl apply -f /etc/kubernetes/{file}"], usage_limit=1)
 
                 # If test case is valid just run the function

--- a/test/unit/test_do.py
+++ b/test/unit/test_do.py
@@ -1,0 +1,83 @@
+import contextlib
+import io
+import random
+import unittest
+
+from kubemarine import demo
+from kubemarine.core import flow
+from kubemarine.procedures import do
+
+
+class DoTest(unittest.TestCase):
+    def test_command_run_any_node(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        hosts = [node['address'] for node in inventory['nodes']]
+        context = do.create_context(['--', 'whoami'])
+        resources = demo.new_resources(inventory, context=context)
+        # Set make_finalized_inventory=None to invoke real method making it closer to the real work
+        resources.make_finalized_inventory = None
+
+        results = demo.create_hosts_result(hosts, stdout='root\n', hide=False)
+        resources.fake_shell.add(results, 'sudo', ['whoami'])
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            flow.ActionsFlow([do.CLIAction(context)]).run_flow(resources, print_summary=False)
+
+        num_called = sum(resources.fake_shell.called_times(host, 'sudo', ['whoami']) for host in hosts)
+        self.assertEqual(1, num_called, "Command was not run")
+        self.assertEqual('root\n', buf.getvalue(), "Unexpected stdout output")
+
+    def test_command_called_specific_node(self):
+        inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
+        run_on = random.choice(inventory['nodes'])
+        context = do.create_context(['-n', run_on['name'], '--', 'whoami'])
+        resources = demo.new_resources(inventory, context=context)
+
+        results = demo.create_hosts_result([run_on['address']], stdout='root\n', hide=False)
+        resources.fake_shell.add(results, 'sudo', ['whoami'])
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            flow.ActionsFlow([do.CLIAction(context)]).run_flow(resources, print_summary=False)
+
+        for node in inventory['nodes']:
+            expected_called = node is run_on
+            self.assertEqual(expected_called, resources.fake_shell.is_called(node['address'], 'sudo', ['whoami']),
+                             f"Command should be{'' if expected_called else ' not'} run on node {node['name']}")
+
+        self.assertEqual('root\n', buf.getvalue(), "Unexpected stdout output")
+
+    def test_command_called_mixed_nodes(self):
+        inventory = demo.generate_inventory(**demo.FULLHA)
+        context = do.create_context([
+            '-n', 'worker-1,worker-2',
+            '-g', 'balancer,control-plane',
+            '--no_stream',
+            '--', 'whoami'])
+        expected_called_hosts = [
+            node['address'] for node in inventory['nodes']
+            if node['name'] in ('worker-1', 'worker-2') or bool(set(node['roles']) & {'balancer', 'master'})
+        ]
+        resources = demo.new_resources(inventory, context=context)
+
+        results = demo.create_hosts_result(expected_called_hosts, stdout='root\n', hide=True)
+        resources.fake_shell.add(results, 'sudo', ['whoami'])
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            flow.ActionsFlow([do.CLIAction(context)]).run_flow(resources, print_summary=False)
+
+        expected_result = {}
+        for node in inventory['nodes']:
+            host = node['address']
+            expected_called = (node['name'] in ('worker-1', 'worker-2')
+                               or bool(set(node['roles']) & {'balancer', 'master'}))
+            if expected_called:
+                expected_result[host] = results[host]
+            self.assertEqual(expected_called, resources.fake_shell.is_called(node['address'], 'sudo', ['whoami']),
+                             f"Command should be{'' if expected_called else ' not'} run on node {node['name']}")
+
+        expected_result = demo.create_nodegroup_result_by_hosts(resources.cluster_if_initialized(), results)
+        self.assertEqual(f"{expected_result}\n", buf.getvalue(), "Unexpected stdout output")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_group.py
+++ b/test/unit/test_group.py
@@ -128,7 +128,7 @@ class TestGroupCall(unittest.TestCase):
 
     def test_represent_group_exception_with_hide_false(self):
         one_node = self.cluster.nodes["all"].get_first_member()
-        results = demo.create_hosts_result(one_node.get_hosts(), stderr='command failed', code=1)
+        results = demo.create_hosts_result(one_node.get_hosts(), stderr='command failed', hide=False, code=1)
         self.cluster.fake_shell.add(results, "run", ['some command'])
 
         exception = None


### PR DESCRIPTION
### Description
* After #577 `kubemarine do` fails with "KeyError: 'dump_location'"
* After #38 `do --no_stream` no longer prints output.

### Solution
* Added missed keys to `do.create_context()`.
* If `--no_stream`, use print() instead of logger.debug().

### Test Cases

**TestCase 1**

Steps:

1. Run `kubemarine do --no-stream -- whoami`

Results:

| Before | After |
| ------ | ------ |
| Error: "KeyError: 'dump_location'" | Prints formatted output. |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_do.py - new tests to cover `do` procedure.
