### PR TITLE
[CPDEV-98972] Kubemarine process is stuck if remote command is stuck

### DIFF
--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -3,7 +3,7 @@ This section provides troubleshooting information for Kubemarine and Kubernetes 
 - [Kubemarine Errors](#kubemarine-errors)
   - [KME0001: Unexpected exception](#kme0001-unexpected-exception)
   - [KME0002: Remote group exception](#kme0002-remote-group-exception)
-  - [KME0003: Action took too long to complete and timed out](#kme0003-action-took-too-long-to-complete-and-timed-out)
+    - [Command did not complete within a number of seconds](#command-did-not-complete-within-a-number-of-seconds)
   - [KME0004: There are no workers defined in the cluster scheme](#kme0004-there-are-no-workers-defined-in-the-cluster-scheme)
   - [KME0005: {hostnames} are not sudoers](#kme0005-hostnames-are-not-sudoers)
 - [Troubleshooting Tools](#troubleshooting-tools)
@@ -114,23 +114,8 @@ KME0002: Remote group exception
 	
 	Exit code: 127
 	
-	Stdout:
-	
-	
-	
-	Stderr:
-	
+	=== stderr ===
 	bash: apt: command not found
-```
-
-Hierarchical error:
-
-```
-FAILURE!
-TASK FAILED xxx
-KME0002: Remote group exception
-10.101.10.1:
-	KME0003: Action took too long to complete and timed out
 ```
 
 An error indicating an unexpected runtime bash command exit on a remote cluster host. This error 
@@ -138,7 +123,7 @@ occurs when a command is terminated unexpectedly with a non-zero error code.
 
 The error prints the status of the command execution for each node in the group on which the bash command 
 was executed. The status can be a correct result (shell results), a result with an error 
-(shell error), as well as a hierarchical KME with its own code.
+(shell error), as well as a [timeout](#command-did-not-complete-within-a-number-of-seconds) error.
 
 To fix it, first try checking the nodes and the cluster with 
 [IAAS checker](Kubecheck.md#iaas-procedure) and [PAAS checker](Kubecheck.md#paas-procedure). If you 
@@ -152,14 +137,20 @@ If you still can't resolve this error yourself, start
 error with its stacktrace. We will try to help as soon as possible.
 
 
-## KME0003: Action took too long to complete and timed out
+### Command did not complete within a number of seconds
 
 ```
 FAILURE!
 TASK FAILED xxx
 KME0002: Remote group exception
 10.101.10.1:
-	KME0003: Action took too long to complete and timed out
+ 	Command did not complete within 2700 seconds!
+ 	
+ 	Command: 'echo "sleeping..." && sleep 3000'
+ 	
+ 	=== stdout ===
+ 	sleeping...
+	
 ```
 
 An error that occurs when a command did not have time to execute at the specified time.

--- a/kubemarine/core/errors.py
+++ b/kubemarine/core/errors.py
@@ -16,7 +16,6 @@ import sys
 import traceback
 from abc import ABC, abstractmethod
 
-from concurrent.futures import TimeoutError
 from textwrap import dedent
 from typing import Type, List
 
@@ -32,10 +31,6 @@ def get_kme_dictionary() -> dict:
         "KME0002": {
             "instance": GroupException,
             "name": "Remote group exception\n{reason}"
-        },
-        "KME0003": {
-            "instance": TimeoutError,
-            "name": "Action took too long to complete and timed out"
         },
         "KME0004": {
             "name": "There are no workers defined in the cluster scheme"

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -647,11 +647,11 @@ class NodeGroup(AbstractGroup[RunnersGroupResult]):
     def _make_defer(self, executor: RemoteExecutor) -> DeferredGroup:
         return DeferredGroup(self.nodes, self.cluster, executor)
 
-    def new_defer(self, timeout: int = None) -> DeferredGroup:
-        return self.new_executor(timeout).group
+    def new_defer(self) -> DeferredGroup:
+        return self.new_executor().group
 
-    def new_executor(self, timeout: int = None) -> RemoteExecutor:
-        return RemoteExecutor(self, timeout=timeout)
+    def new_executor(self) -> RemoteExecutor:
+        return RemoteExecutor(self)
 
     def get(self, remote_file: str, local_file: str) -> None:
         self._do_exec("get", remote_file, local_file)
@@ -679,7 +679,7 @@ class NodeGroup(AbstractGroup[RunnersGroupResult]):
     def _do_exec(self, do_type: str, *args: object, **kwargs: Any) -> HostToResult:
         callback: Callback = kwargs.pop('callback', None)
 
-        executor = RawExecutor(self.cluster, timeout=kwargs.get('timeout'))
+        executor = RawExecutor(self.cluster)
         executor.queue(self.get_hosts(), (do_type, args, kwargs), callback=callback)
         executor.flush()
 
@@ -825,8 +825,8 @@ class DeferredGroup(AbstractGroup[Token]):
 
 
 class RemoteExecutor(RawExecutor):
-    def __init__(self, group: NodeGroup, connection_pool: ConnectionPool = None, timeout: int = None) -> None:
-        super().__init__(group.cluster, connection_pool, timeout)
+    def __init__(self, group: NodeGroup, connection_pool: ConnectionPool = None) -> None:
+        super().__init__(group.cluster, connection_pool)
         self.group: DeferredGroup = group._make_defer(self)
         self.cluster = group.cluster
 

--- a/test/unit/core/test_executor.py
+++ b/test/unit/core/test_executor.py
@@ -17,9 +17,13 @@ import tempfile
 import unittest
 
 from concurrent.futures import TimeoutError
+from typing import Union, List
+
+import fabric
+import invoke
 
 from kubemarine import demo
-from kubemarine.core.executor import RunnersResult, UnexpectedExit
+from kubemarine.core.executor import RunnersResult, UnexpectedExit, GenericResult, CommandTimedOut
 from kubemarine.core.group import GroupException, RemoteGroupException, CollectorCallback
 
 
@@ -359,6 +363,264 @@ class RemoteExecutorTest(unittest.TestCase):
 
             for host in self.cluster.nodes["all"].get_hosts():
                 self.assertEqual('a' * 100000, self.cluster.fake_fs.read(host, '/fake/path'))
+
+
+class ReparseFabricResultTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cluster = cluster = demo.new_cluster(demo.generate_inventory(**demo.ALLINONE))
+        node = cluster.nodes['all']
+        cls.host = node.get_host()
+        cls.executor = executor = node.new_executor()
+        cls.sep = executor._command_separator
+
+    def tearDown(self):
+        self.executor._connections_queue = {}
+
+    def _get_patch(self):
+        return self.executor._get_callables()[0]
+
+    def _reparse_results(self, result: Union[invoke.UnexpectedExit, invoke.CommandTimedOut, fabric.runners.Result]) \
+            -> List[GenericResult]:
+        batch = self._get_patch()
+        reparsed_result = self.executor._reparse_results({self.host: result}, batch)
+        return list(reparsed_result[self.host].values())
+
+    def _create_result(self, stdout: str = '', stderr: str = '',
+                       code: int = 0) -> fabric.runners.Result:
+        batch = self._get_patch()
+        _, args, _ = self.executor._prepare_merged_action(self.host, batch[self.host])
+        result = fabric.runners.Result(stdout=stdout, stderr=stderr, exited=code,
+                                       connection=self.cluster.connection_pool.get_connection(self.host),
+                                       command=args[0])
+        return result
+
+    def _queue(self, num: int, warn=False):
+        for i in range(num):
+            self.executor.queue([self.host], ('run', (f'fake command {i}',), {'warn': warn}))
+
+    def test_reparse_single_command(self):
+        self._queue(1)
+        result = self._create_result(stdout='test\n', code=0)
+        reparsed_result = self._reparse_results(result)
+        self.assertEqual(1, len(reparsed_result))
+        self.assertEqual('test\n', reparsed_result[0].stdout)
+        self.assertEqual(0, reparsed_result[0].exited)
+        self.assertEqual('fake command 0', reparsed_result[0].command)
+
+    def test_reparse_single_command_empty(self):
+        self._queue(1)
+        result = self._create_result(stdout='', code=13)
+        reparsed_result = self._reparse_results(result)
+        self.assertEqual(1, len(reparsed_result))
+        self.assertEqual('', reparsed_result[0].stdout)
+        self.assertEqual(13, reparsed_result[0].exited)
+        self.assertEqual('fake command 0', reparsed_result[0].command)
+
+    def test_reparse_few_commands_warn(self):
+        self._queue(3, warn=True)
+        result = self._create_result(stdout=f'out0\n{self.sep}\n0\n{self.sep}\n'
+                                            f'out1\n{self.sep}\n13\n{self.sep}\n'
+                                            f'out2\n',
+                                     stderr=f'err0\n{self.sep}\n'
+                                            f'err1\n{self.sep}\n'
+                                            f'err2\n',
+                                     code=1)
+        reparsed_result = self._reparse_results(result)
+        self.assertEqual(3, len(reparsed_result))
+        for i in range(3):
+            self.assertEqual(f'out{i}\n', reparsed_result[i].stdout)
+            self.assertEqual(f'err{i}\n', reparsed_result[i].stderr)
+            expected_exited = 0 if i == 0 else 13 if i == 1 else 1
+            self.assertEqual(expected_exited, reparsed_result[i].exited)
+            self.assertEqual(f'fake command {i}', reparsed_result[i].command)
+
+    def test_reparse_few_commands_unexpected_exit(self):
+        self._queue(3)
+        result = self._create_result(stdout=f'out0\n{self.sep}\n0\n{self.sep}\n'
+                                            f'out1\n{self.sep}\n0\n{self.sep}\n'
+                                            f'out2\n',
+                                     stderr=f'err0\n{self.sep}\n'
+                                            f'err1\n{self.sep}\n'
+                                            f'err2\n',
+                                     code=1)
+        result = invoke.UnexpectedExit(result)
+        reparsed_results = self._reparse_results(result)
+        self.assertEqual(3, len(reparsed_results))
+        for i in range(3):
+            reparsed_result = reparsed_results[i]
+            if i == 2:
+                self.assertIsInstance(reparsed_result, UnexpectedExit)
+                reparsed_result = reparsed_result.result
+
+            self.assertIsInstance(reparsed_result, RunnersResult)
+            self.assertEqual(f'out{i}\n', reparsed_result.stdout)
+            self.assertEqual(f'err{i}\n', reparsed_result.stderr)
+            self.assertEqual(1 if i == 2 else 0, reparsed_result.exited)
+            self.assertEqual(f'fake command {i}', reparsed_result.command)
+
+    def test_reparse_few_commands_timeout_last(self):
+        self._queue(3)
+        result = self._create_result(stdout=f'out0{self.sep}\n0\n{self.sep}\n'
+                                            f'{self.sep}\n0\n{self.sep}\n'
+                                            f'out2\n',
+                                     stderr=f'err0\n{self.sep}\n'
+                                            f'{self.sep}\n'
+                                            f'err2',
+                                     code=-1)
+        result = invoke.CommandTimedOut(result, 10)
+        reparsed_results = self._reparse_results(result)
+        self.assertEqual(3, len(reparsed_results))
+        for i in range(3):
+            reparsed_result = reparsed_results[i]
+            if i == 2:
+                self.assertIsInstance(reparsed_result, CommandTimedOut)
+                reparsed_result = reparsed_result.result
+
+            self.assertIsInstance(reparsed_result, RunnersResult)
+            expected_out = 'out0' if i == 0 else '' if i == 1 else 'out2\n'
+            self.assertEqual(expected_out, reparsed_result.stdout)
+            expected_err = 'err0\n' if i == 0 else '' if i == 1 else 'err2'
+            self.assertEqual(expected_err, reparsed_result.stderr)
+            self.assertEqual(-1 if i == 2 else 0, reparsed_result.exited)
+            self.assertEqual(f'fake command {i}', reparsed_result.command)
+
+    def test_reparse_few_commands_timeout_intermediate(self):
+        # emulate partial separator
+        for i, second_out in enumerate((
+                '',
+                'out1',
+                'out1\n'
+        )):
+            with self.subTest(i):
+                self._queue(3)
+                result = self._create_result(stdout=f'out0\n{self.sep}\n0\n{self.sep}\n' + second_out,
+                                             stderr=f'err0\n{self.sep}\n',
+                                             code=-1)
+                result = invoke.CommandTimedOut(result, 10)
+                reparsed_results = self._reparse_results(result)
+                self.assertEqual(2, len(reparsed_results))
+
+                reparsed_result = reparsed_results[0]
+                self.assertIsInstance(reparsed_result, RunnersResult)
+                self.assertEqual(f'out0\n', reparsed_result.stdout)
+                self.assertEqual(f'err0\n', reparsed_result.stderr)
+                self.assertEqual(0, reparsed_result.exited)
+                self.assertEqual('fake command 0', reparsed_result.command)
+
+                reparsed_result = reparsed_results[1]
+                self.assertIsInstance(reparsed_result, CommandTimedOut)
+                self.assertEqual(second_out, reparsed_result.result.stdout)
+                self.assertEqual('', reparsed_result.result.stderr)
+                self.assertEqual(-1, reparsed_result.result.exited)
+                self.assertEqual('fake command 1', reparsed_result.result.command)
+
+                self.tearDown()
+
+    def test_reparse_few_commands_timeout_intermediate_partial_separator1(self):
+        self._queue(3)
+        # emulate partial separator
+        result = self._create_result(stdout=f'out0\n{self.sep}\n0\n{self.sep}\n'
+                                            f'out1\n{self.sep[:5]}',
+                                     stderr=f'err0\n{self.sep}\n'
+                                            f'err1\n{self.sep[:5]}',
+                                     code=-1)
+        result = invoke.CommandTimedOut(result, 10)
+        reparsed_results = self._reparse_results(result)
+        self.assertEqual(2, len(reparsed_results))
+
+        reparsed_result = reparsed_results[0]
+        self.assertIsInstance(reparsed_result, RunnersResult)
+        self.assertEqual(f'out0\n', reparsed_result.stdout)
+        self.assertEqual(f'err0\n', reparsed_result.stderr)
+        self.assertEqual(0, reparsed_result.exited)
+        self.assertEqual('fake command 0', reparsed_result.command)
+
+        reparsed_result = reparsed_results[1]
+        self.assertIsInstance(reparsed_result, CommandTimedOut)
+        self.assertEqual(f'out1\n{self.sep[:5]}', reparsed_result.result.stdout)
+        self.assertEqual(f'err1\n{self.sep[:5]}', reparsed_result.result.stderr)
+        self.assertEqual(-1, reparsed_result.result.exited)
+        self.assertEqual('fake command 1', reparsed_result.result.command)
+
+    def test_reparse_few_commands_timeout_intermediate_partial_separator2(self):
+        # emulate partial separator
+        for i, out in enumerate((
+                f'out0{self.sep}',
+                f'out0{self.sep}\n',
+                f'out0\n{self.sep}',
+                f'out0\n{self.sep}\n',
+                f'out0\n{self.sep}\n1',
+        )):
+            with self.subTest(i):
+                self._queue(3)
+                result = self._create_result(stdout=out,
+                                             stderr=f'err0{self.sep}',
+                                             code=-1)
+                result = invoke.CommandTimedOut(result, 10)
+                reparsed_results = self._reparse_results(result)
+                self.assertEqual(1, len(reparsed_results))
+
+                reparsed_result = reparsed_results[0]
+                self.assertIsInstance(reparsed_result, CommandTimedOut)
+                self.assertEqual('out0' if i < 2 else 'out0\n', reparsed_result.result.stdout)
+                self.assertEqual('err0', reparsed_result.result.stderr)
+                self.assertEqual(-1, reparsed_result.result.exited)
+                self.assertEqual('fake command 0', reparsed_result.result.command)
+
+                self.tearDown()
+
+    def test_reparse_few_commands_timeout_intermediate_partial_separator3(self):
+        # emulate partial separator
+        for i, out in enumerate((
+                f'out0\n{self.sep}\n13\n',
+                f'out0\n{self.sep}\n13\n{self.sep[:5]}',
+                f'out0\n{self.sep}\n13\n{self.sep}',
+                f'out0\n{self.sep}\n13\n{self.sep}\n',
+                f'out0\n{self.sep}\n13\n{self.sep}\nout1',
+        )):
+            with self.subTest(i):
+                self._queue(3)
+                result = self._create_result(stdout=out,
+                                             stderr=f'err0{self.sep}',
+                                             code=-1)
+                result = invoke.CommandTimedOut(result, 10)
+                reparsed_results = self._reparse_results(result)
+                self.assertEqual(2, len(reparsed_results))
+
+                reparsed_result = reparsed_results[0]
+                self.assertIsInstance(reparsed_result, RunnersResult)
+                self.assertEqual(f'out0\n', reparsed_result.stdout)
+                self.assertEqual(f'err0', reparsed_result.stderr)
+                self.assertEqual(13, reparsed_result.exited)
+                self.assertEqual('fake command 0', reparsed_result.command)
+
+                reparsed_result = reparsed_results[1]
+                self.assertIsInstance(reparsed_result, CommandTimedOut)
+                expected_out = 'out1' if i == 4 else ''
+                self.assertEqual(expected_out, reparsed_result.result.stdout)
+                self.assertEqual('', reparsed_result.result.stderr)
+                self.assertEqual(-1, reparsed_result.result.exited)
+                self.assertEqual('fake command 1', reparsed_result.result.command)
+
+                self.tearDown()
+
+    def test_reparse_few_commands_timeout_intermediate_partial_separator4(self):
+        self._queue(3)
+        # emulate partial separator
+        result = self._create_result(stdout=f'out0\n{self.sep}\n255\n{self.sep}\n',
+                                     stderr=f'err0{self.sep[:5]}',
+                                     code=-1)
+        result = invoke.CommandTimedOut(result, 10)
+        reparsed_results = self._reparse_results(result)
+        self.assertEqual(1, len(reparsed_results))
+
+        reparsed_result = reparsed_results[0]
+        self.assertIsInstance(reparsed_result, CommandTimedOut)
+        self.assertEqual(f'out0\n', reparsed_result.result.stdout)
+        self.assertEqual(f'err0{self.sep[:5]}', reparsed_result.result.stderr)
+        self.assertEqual(255, reparsed_result.result.exited)
+        self.assertEqual('fake command 0', reparsed_result.result.command)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description
* If `concurrent.futures` timeout occures, RemoteExecutor tries to join nodes gracefully and becomes stuck as the remote command is not killed. This was broken after #468 when we stopped passing timeout to fabric's `Connection.run|sudo`

### Solution
* Timeout for `Connection.run|sudo` is returned.
* Implement parsing of output if timeout occures for merged commands.
* Remove timeout for `concurrent.futures` because it does not help to stop the command, but hides what command was timed out and what its stdout and stderr were.
* No longer try to use timeout for get/put operations.

### Test Cases

**TestCase 1**

Steps:

1. Run `kubemarine do -- sleep 3600`

Results:

| Before | After |
| ------ | ------ |
| "Action took too long to complete and timed out" after **1 hour** | "Command did not complete within 2700 seconds! Command: 'sleep 3600'" after **45 minutes** |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_executor.py - cover parsing of output for merged commands in case of timeout.
