### PR TITLE
[PSUPCLPL-14914] FS mount options check

### DIFF
--- a/documentation/Kubecheck.md
+++ b/documentation/Kubecheck.md
@@ -22,6 +22,7 @@ This section provides information about the Kubecheck functionality.
       - [007 RAM Amount - Control-planes](#007-ram-amount---control-planes)
       - [007 RAM Amount - Workers](#007-ram-amount---workers)
     - [008 Distributive](#008-distributive)
+    - [018 FS mount options](#018-fs-mount-options)
     - Network
       - [009 PodSubnet](#009-podsubnet)
       - [010 ServiceSubnet](#010-servicesubnet)
@@ -296,11 +297,18 @@ This test checks the amount of RAM on nodes with the `control-plane` role.
 
 This test checks the amount of RAM on nodes with the `worker` role.
 
+
 ##### 008 Distributive
 
 *Task*: `system.distributive`
 
 This test checks the family and release version of the operating system on the hosts.
+
+##### 018 FS mount options
+
+*Task*: `system.fs_mount_options`
+
+This test checks the presence of filesystem mount option that affects contatiner functionality
 
 ##### 009 PodSubnet
 

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -1376,6 +1376,7 @@ def fs_mount_options(cluster: KubernetesCluster) -> None:
     with TestCase(cluster, '018', 'System', 'Filesystem mount options') as tc:
 
         failed_nodes: Set[str] = set()
+        cri_root = ""
         # Only Kubernetes nodes should be checked
         group = cluster.make_group_from_roles(['control-plane', 'worker']).get_sudo_nodes()
         # Get CRI root
@@ -1392,6 +1393,8 @@ def fs_mount_options(cluster: KubernetesCluster) -> None:
                 cri_root = cluster.inventory['services']['cri']['dockerConfig']['data-root']
             else:
                 cri_root = "/var/lib/docker"
+        if not cri_root:
+                raise TestWarn("Check cannot be completed, unknown CRI")
         cluster.log.debug("Mount options check")
         # Check the mount options for filesystem where containerd root is located.
         # If containerd root doesn't exist the script check the parent directory and so forth.

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -1389,7 +1389,7 @@ def fs_mount_options(cluster: KubernetesCluster) -> None:
                 cri_root = "/var/lib/containerd"
         # Get rid of that part after KubeMarine stop supporting Kubernetes version lower v1.24
         if cluster.inventory['services']['cri']['containerRuntime'] == "docker":
-            # Docker
+            # Docker root
             if cluster.inventory['services']['cri']['dockerConfig'].get('data-root', ""):
                 cri_root = cluster.inventory['services']['cri']['dockerConfig']['data-root']
             else:
@@ -1462,10 +1462,10 @@ tasks = OrderedDict({
             'control-planes': lambda cluster: hardware_ram(cluster, 'control-plane'),
             'workers': lambda cluster: hardware_ram(cluster, 'worker')
         },
-        'fs_mount_options': fs_mount_options
     },
     'system': {
-        'distributive': system_distributive
+        'distributive': system_distributive,
+        'fs_mount_options': fs_mount_options
     },
     'software': {
         'kernel': {

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -1395,10 +1395,9 @@ def fs_mount_options(cluster: KubernetesCluster) -> None:
                 warn_nodes.add(f"{node_name}")
 
         if warn_nodes:
-            raise TestWarn(f"Some of the filesystems are mounted with options that might "
-                           f"affect container functionality. Please make sure that following "
-                           f"nodes do not use 'nosuid' option for filesystems where "
-                           f"'containerd' root is located",
+            raise TestWarn(f"The 'nosuid' mount option affect container functionality. "
+                           f"Please make sure that following nodes do not use that option "
+                           f"for filesystems where 'containerd' root is located",
                            hint='\n'.join(warn_nodes))
 
 

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -1373,8 +1373,7 @@ def check_ipip_tunnel(group: NodeGroup) -> Set[str]:
 
 
 def fs_mount_options(cluster: KubernetesCluster) -> None:
-    with TestCase(cluster, '018', 'System', 'Filesystem mount options') as tc,\
-            suspend_firewalld(cluster):
+    with TestCase(cluster, '018', 'System', 'Filesystem mount options') as tc:
 
         failed_nodes: Set[str] = set()
         # Only Kubernetes nodes should be checked
@@ -1398,7 +1397,7 @@ def fs_mount_options(cluster: KubernetesCluster) -> None:
         # Check the mount options for filesystem where containerd root is located.
         # If containerd root doesn't exist the script check the parent directory and so forth.
         # At the end of the script 'findmnt' return the filesytem mount point, device,
-        # and mount options for nearest parent directory of containerd root.
+        # and mount options for nearest parent directory of CRI root.
         # 'findmnt' perform the recursive search of mount point for filesystem
         # from the given path to the root, that's exactly what we need.
         cmd = f"CRI_PATH={cri_root}; while [ ! -d \"${{CRI_PATH}}\" ]; do CRI_PATH=$(dirname \"${{CRI_PATH}}\"); " \
@@ -1416,8 +1415,8 @@ def fs_mount_options(cluster: KubernetesCluster) -> None:
 
         if failed_nodes:
             raise TestFailure(f"The 'nosuid' mount option affects container functionality. "
-                              f"Please change mount options for filesystem where 'containerd' "
-                              f"root is located on the following nodes.",
+                              f"Please change mount options for filesystem where CRI "
+                              f"root is located on the following nodes. CRI root path is '{cri_root}'",
                               hint='\n'.join(failed_nodes))
 
 


### PR DESCRIPTION
### Description
* `nosuid` mount option affects files capabilities, that makes impossible to use some features of containers


### Solution
* Implement new task into `check_iaas` procedure


### How to apply
Not applicable

### Test Cases

**TestCase 1**
Verify if the check is working for `containerd` CRI

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 22.04/CentOS 7/RHEL8
- Inventory: AllinOne

Steps:

1. Prepare node without `nosuid` mount option for filesystem where `containerd` root directory is located
2. Run `check_iaas` procedure with `--tasks="system.fs_mount_options"` option
3. Prepare node with `nosuid` mount option for filesystem where `containerd` root directory is located (`/var/lib/containerd` or `/var/lib` or `/var` could be mounted with the `nosuid` option, if the `containerd` root is default)
4. Run `check_iaas` procedure with `--tasks="system.fs_mount_options"` option

Results:

| Before | After |
| ------ | ------ |
| not applicable | check succeeded |
| not applicable | check failed |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] There is no merge conflicts


