### PR TITLE
[CPDEV-99413] Patch kubelet-config ConfigMap during upgrade

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -700,6 +700,10 @@ def upgrade_first_control_plane(upgrade_group: NodeGroup, cluster: KubernetesClu
 
     copy_admin_config(cluster.log, first_control_plane)
 
+    # In some versions, kubeadm reverts resolvConf to the default during `upgrade apply`
+    # Remove default resolvConf from kubelet-config ConfigMap for debian OS family
+    first_control_plane.call(components.patch_kubelet_configmap)
+
     expect_kubernetes_version(cluster, version, apply_filter=node_name)
     components.wait_for_pods(first_control_plane)
     exclude_node_from_upgrade_list(first_control_plane, node_name)


### PR DESCRIPTION
### Description
* After upgrade from v1.25.7 to v1.26.11 on Ubuntu 22.04, `check_paas` fails on task `services.kubelet.configuration`
* The reason is because kubelet-config ConfigMap can be overridden during `kubeadm apply`, and `resolvConf` is reset to the default one. We are not ok with default since #619

### Solution
* Patch kubelet-config ConfigMap during upgrade.

### Test Cases

**TestCase 1**

Test Configuration:

- OS: Ubuntu 22.04

Steps:

1. Install cluster v1.25.7
2. Upgrade to  v1.26.1
3. Run `check_paas`

Results:

| Before | After |
| ------ | ------ |
| kubelet-config ConfigMap is not consistent with services.kubeadm_kubelet section | Check is passed |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
