### PR TITLE
[CPDEV-95355] add_node and remove_node if there are notready workers

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -801,6 +801,7 @@ Also pay attention to the following:
 * System configurations like `selinux`, `modprobe`, `sysctl`, and others should be verified and configured only on new nodes.
 * Only new nodes can be rebooted.
 * The file `/etc/hosts` is updated and uploaded to all nodes in the cluster.
+* If there are some offline workers during the procedure, you should exclude `prepare.dns.etc_hosts` task and update `/etc/hosts` on new nodes manually.
 
 **Note**: It is not possible to change a node's role by adding an existing node again with a new role. You have to remove the node and add it again.
 
@@ -907,6 +908,7 @@ Also pay attention to the following:
   such hosts are ignored with warnings.
 * The file `/etc/hosts` is updated and uploaded to all remaining nodes in the cluster. The control plane address may change.
 * This procedure only removes nodes and does not restore nodes to their original state. Packages, configurations, and Thirdparties are also not deleted.
+* If there are some offline workers during the procedure, you should exclude `update.etc_hosts` task.
 
 Removing a node from a Kubernetes cluster is done in the following order:
 

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -523,13 +523,18 @@ class KubernetesCluster(Environment):
         procedure: str = self.context['initial_procedure']
         if procedure == 'check_iaas' and skip_check_iaas:
             return
+        
+        if procedure == 'remove_node':
+            group = self.make_group_from_roles(['control-plane', 'balancer'])
+        else:
+            group = self.make_group_from_roles(['control-plane', 'balancer']).include_group(self.get_new_nodes_or_self())
 
-        # Check that only subset of nodes for removal can be offline
-        remained_offline = self.nodes['all'].get_online_nodes(False)
+        # Check that nodes are online
+        remained_offline = group.get_online_nodes(False)
 
-        # Check that all online nodes are accessible.
-        all_nodes = self._get_all_nodes()
-        inaccessible_online = all_nodes.get_online_nodes(True).exclude_group(all_nodes.get_accessible_nodes())
+        # Check that nodes are accessible.
+        nodes = group.include_group(self.get_changed_nodes())
+        inaccessible_online = nodes.get_online_nodes(True).exclude_group(nodes.get_accessible_nodes())
 
         if not remained_offline.is_empty() or not inaccessible_online.is_empty():
             raise KME0006(remained_offline.get_hosts(), inaccessible_online.get_hosts())

--- a/kubemarine/coredns.py
+++ b/kubemarine/coredns.py
@@ -148,7 +148,7 @@ data:'''
 def apply_configmap(cluster: KubernetesCluster, config: str) -> RunnersGroupResult:
     utils.dump_file(cluster, config, 'coredns-configmap.yaml')
 
-    group = cluster.make_group_from_roles(['control-plane', 'worker'])
+    group = cluster.make_group_from_roles(['control-plane'])
     group.put(io.StringIO(config), '/etc/kubernetes/coredns-configmap.yaml', backup=True, sudo=True)
 
     return cluster.nodes['control-plane'].get_first_member()\
@@ -173,7 +173,7 @@ def apply_patch(cluster: KubernetesCluster) -> Union[RunnersGroupResult, str]:
 
         utils.dump_file(cluster, config, filename)
 
-        group = cluster.make_group_from_roles(['control-plane', 'worker'])
+        group = cluster.make_group_from_roles(['control-plane'])
         group.put(io.StringIO(config), filepath, backup=True, sudo=True)
 
         apply_command = 'kubectl patch %s coredns -n kube-system --type merge -p \"$(sudo cat %s)\"' % (config_type, filepath)

--- a/kubemarine/packages.py
+++ b/kubemarine/packages.py
@@ -289,7 +289,9 @@ def cache_package_versions(cluster: KubernetesCluster, inventory: dict, by_initi
         cluster.log.debug("Skip caching of packages for unsupported OS.")
         return inventory
 
-    group = (cluster.previous_nodes if by_initial_nodes else cluster.nodes)['all']
+    group = (cluster.previous_nodes if by_initial_nodes else cluster.nodes)['all'] \
+        .exclude_group(cluster.nodes['all'].get_online_nodes(False))
+
     if group.nodes_amount() != group.get_sudo_nodes().nodes_amount():
         # For add_node/install procedures we check that all nodes are sudoers in prepare.check.sudoer task.
         # For check_iaas procedure the nodes might still be not sudoers.


### PR DESCRIPTION
### Description
It is not possible to run add_node and remove_node if there are unavailable workers in cluster.yaml.

### Solution
The accessibility check will be performed only for control-plains, balancers and new nodes.
The same for `prepare.check.sudoer` task
`coredns-configmap.yaml` and `coredns-deployment-patch.yaml` will save only on control-plains
Excluded offline nodes for the `cache_packages` task
Updating etc_hosts will not be executed for offline nodes during the `prepare.dns.etc_hosts` task

### Test Cases

Steps:
1. Stop worker node in the cluster
2.  Create new VM and add the following entries to `/etc/hosts` on it:
```
<cluster_ip>                 <cluster_name> control-plain
<internal_new_node_ip>       <new_node_name>
```
3. Run  `add_node` for new VM with `--exclude=prepare.dns.etc_hosts`
4. Run  `remove_node` for new VM with `--exclude=update.etc_hosts`


Results:

| Before | After |
| -------- | -------- |
| failed | succeeded |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

Added the `test_remove_node_if_worker_offline` and `test_add_node_if_worker_offline` to test add_node and remove_node procedures if there are offline workers in the cluster.




