### PR TITLE
[CPDEV-100505] Always dump finalized inventory for all procedures except `do`

### DIFF
--- a/kubemarine/core/flow.py
+++ b/kubemarine/core/flow.py
@@ -232,6 +232,7 @@ def create_empty_context(args: dict, procedure: str) -> dict:
         "execution_arguments": deepcopy(args),
         'initial_procedure': procedure,
         'preserve_inventory': True,
+        'make_finalized_inventory': True,
         'load_inventory_silent': False,
         'runtime_vars': {},
         'result': ['summary_report'],

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -284,14 +284,14 @@ class DynamicResources:
 
     def dump_finalized_inventory(self, cluster: c.KubernetesCluster) -> None:
         finalized_filename = "cluster_finalized.yaml"
-        if not self._make_finalized_inventory(finalized_filename):
+        if not self.context['make_finalized_inventory']:
             return
 
-        finalized_inventory = cluster.make_finalized_inventory(self.finalization_functions())
+        finalized_inventory = self.make_finalized_inventory(cluster)
         self._store_finalized_inventory(finalized_inventory, finalized_filename)
 
-    def _make_finalized_inventory(self, finalized_filename: str) -> bool:
-        return utils.is_dump_allowed(self.context, finalized_filename)
+    def make_finalized_inventory(self, cluster: c.KubernetesCluster) -> dict:
+        return cluster.make_finalized_inventory(self.finalization_functions())
 
     def _store_finalized_inventory(self, finalized_inventory: dict, finalized_filename: str) -> None:
         data = yaml.dump(finalized_inventory)

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -201,7 +201,7 @@ class FakeClusterStorage(utils.ClusterStorage):
 class FakeKubernetesCluster(KubernetesCluster):
 
     def __init__(self, *args: Any, **kwargs: Any):
-        self.resources: FakeResources = kwargs.pop("resources")
+        self.resources: FakeClusterResources = kwargs.pop("resources")
         self.fake_shell = self.resources.fake_shell
         self.fake_fs = self.resources.fake_fs
         self.uploaded_archives: List[str] = []
@@ -217,20 +217,16 @@ class FakeKubernetesCluster(KubernetesCluster):
         return FakeNodeGroup(ips, self)
 
 
-class FakeResources(DynamicResources):
-    def __init__(self, context: dict, inventory: dict = None, procedure_inventory: dict = None,
+class FakeClusterResources(DynamicResources):
+    def __init__(self, context: dict,
+                 *,
                  nodes_context: Dict[str, Any] = None,
-                 fake_shell: FakeShell = None, fake_fs: FakeFS = None, make_finalized_inventory: Optional[bool] = False):
+                 fake_shell: FakeShell = None, fake_fs: FakeFS = None):
         super().__init__(context)
-        self.inventory_filepath = None
-        self.procedure_inventory_filepath = None
         self.fake_shell = fake_shell if fake_shell else FakeShell()
         self.fake_fs = fake_fs if fake_fs else FakeFS()
-        self._inventory = inventory
-        self._procedure_inventory = procedure_inventory
 
         self.finalized_inventory: dict = {}
-        self.make_finalized_inventory = make_finalized_inventory
 
         self._enrichment_functions = super().enrichment_functions()
         # Let's do not assign self._nodes_context directly to make it more close to the real enrichment.
@@ -247,18 +243,13 @@ class FakeResources(DynamicResources):
 
         return {}
 
-    def _store_inventory(self, inventory: dict) -> None:
-        pass
-
-    def _make_finalized_inventory(self, finalized_filename: str) -> bool:
-        if self.make_finalized_inventory is None:
-            return super()._make_finalized_inventory(finalized_filename)
-
-        return self.make_finalized_inventory
-
     def _store_finalized_inventory(self, finalized_inventory: dict, finalized_filename: str) -> None:
         self.finalized_inventory = finalized_inventory
-        utils.dump_file(self, yaml.dump(finalized_inventory), finalized_filename)
+        super()._store_finalized_inventory(finalized_inventory, finalized_filename)
+
+    def cluster_if_initialized(self) -> Optional[FakeKubernetesCluster]:
+        cluster = super().cluster_if_initialized()
+        return None if cluster is None else cast(FakeKubernetesCluster, cluster)
 
     def cluster(self, stage: EnrichmentStage = EnrichmentStage.PROCEDURE) -> FakeKubernetesCluster:
         return cast(FakeKubernetesCluster, super().cluster(stage))
@@ -288,6 +279,26 @@ class FakeResources(DynamicResources):
 
     def enrichment_functions(self) -> List[EnrichmentFunction]:
         return self._enrichment_functions
+
+
+class FakeResources(FakeClusterResources):
+    def __init__(self, context: dict, inventory: dict = None,
+                 *,
+                 procedure_inventory: dict = None,
+                 nodes_context: Dict[str, Any] = None,
+                 fake_shell: FakeShell = None, fake_fs: FakeFS = None):
+        super().__init__(context, nodes_context=nodes_context, fake_shell=fake_shell, fake_fs=fake_fs)
+        self.inventory_filepath = None
+        self.procedure_inventory_filepath = None
+        self._inventory = inventory
+        self._procedure_inventory = procedure_inventory
+
+    def _store_inventory(self, inventory: dict) -> None:
+        pass
+
+    def _store_finalized_inventory(self, finalized_inventory: dict, finalized_filename: str) -> None:
+        self.finalized_inventory = finalized_inventory
+        utils.dump_file(self, yaml.dump(finalized_inventory), finalized_filename)
 
 
 class FakeConnection(fabric.connection.Connection):  # type: ignore[misc]
@@ -462,6 +473,7 @@ def create_silent_context(args: list = None, procedure: str = 'install') -> dict
 
     context: dict = procedures.import_procedure(procedure).create_context(args)
     context['preserve_inventory'] = False
+    context['make_finalized_inventory'] = False
     context['load_inventory_silent'] = True
 
     parsed_args: dict = context['execution_arguments']

--- a/kubemarine/procedures/do.py
+++ b/kubemarine/procedures/do.py
@@ -97,6 +97,7 @@ def create_context(cli_arguments: List[str] = None) -> dict:
         'config': configfile_path,
     }, procedure='do')
     context['preserve_inventory'] = False
+    context['make_finalized_inventory'] = False
     context['load_inventory_silent'] = True
 
     context['do_arguments'] = arguments

--- a/test/unit/test_do.py
+++ b/test/unit/test_do.py
@@ -28,8 +28,6 @@ class DoTest(unittest.TestCase):
         hosts = [node['address'] for node in inventory['nodes']]
         context = do.create_context(['--', 'whoami'])
         resources = demo.new_resources(inventory, context=context)
-        # Set make_finalized_inventory=None to invoke real method making it closer to the real work
-        resources.make_finalized_inventory = None
 
         results = demo.create_hosts_result(hosts, stdout='root\n', hide=False)
         resources.fake_shell.add(results, 'sudo', ['whoami'])


### PR DESCRIPTION
### Description
* After #621 cluster_finalized.yaml is not longer dumped in current working directory, if `--disable-dump --without-act` args are used simultaneously.

### Solution
* Revert the behavior. Introduce `context['make_finalized_inventory']` that manages if the cluster_finalized.yaml should be collected and dumped, that is `True` for all procedures except `do`.

### Test Cases

**TestCase 1**

Steps:

1. Run `kubemarine install --disable-dump --without-act`

Results:

| Before | After |
| ------ | ------ |
| cluster_finalized.yaml is not collected neither dumped | cluster_finalized.yaml is collected and dumped in current working directory only |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_run_actions.py - add test to cover cluster_finalized.yaml with the combination of options.
