### PR TITLE
[CPDEV-98472]-Enabling_strong_crypto_support_by_default_for_kubelet

### DIFF
--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -22,8 +22,10 @@ The whole directory is automatically cleared and reset after new version of Kube
 from typing import List
 
 from kubemarine.core.patch import Patch
+from kubemarine.patches.strong_cipher_suits_for_kubelet import UpdatekubeletCipherSuites
 
 patches: List[Patch] = [
+    UpdatekubeletCipherSuites(),  # Add the new patch to the list
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/strong_cipher_suits_for_kubelet.py
+++ b/kubemarine/patches/strong_cipher_suits_for_kubelet.py
@@ -9,7 +9,7 @@ class TheAction(Action):
         super().__init__("Update kubelet TLS cipher suites (if necessary)")
 
     def run(self, res: DynamicResources) -> None:
-        kubernetes_nodes = res.cluster().make_group_from_roles(['worker'])
+        kubernetes_nodes = res.cluster().make_group_from_roles(['control-plane', 'worker'])
         reconfigure_components(kubernetes_nodes, ['kubelet'])
 
 class UpdatekubeletCipherSuites(RegularPatch):

--- a/kubemarine/patches/strong_cipher_suits_for_kubelet.py
+++ b/kubemarine/patches/strong_cipher_suits_for_kubelet.py
@@ -1,0 +1,29 @@
+from textwrap import dedent
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine.kubernetes.components import reconfigure_components
+
+class TheAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Update kubelet TLS cipher suites (if necessary)")
+
+    def run(self, res: DynamicResources) -> None:
+        kubernetes_nodes = res.cluster().make_group_from_roles(['worker'])
+        reconfigure_components(kubernetes_nodes, ['kubelet'])
+
+class UpdatekubeletCipherSuites(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("kubelet_cipher_suites")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            Patch to update the kubelet TLS cipher suites.
+            """.rstrip()
+        )

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -37,6 +37,7 @@ services:
     podPidsLimit: 4096
     cgroupDriver: systemd
     serializeImagePulls: false
+    tlsCipherSuites: [TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256]
   kubeadm_kube-proxy:
     apiVersion: kubeproxy.config.k8s.io/v1alpha1
     kind: KubeProxyConfiguration


### PR DESCRIPTION
### Description
These cipher suites are configuring the kubelet to support a selection of strong and secure cryptographic algorithms for secure communication over TLS (Transport Layer Security).
* 

Fixes # (issue)
[CPDEV-98472](https://tms.netcracker.com/browse/CPDEV-98472)

### Solution
1. Add tls-cipher-suits by default for new cluster installation.
2. Add a patch to reconfigure kubelet for already installed cluster


### Test Cases

**TestCase 1**

Test Configuration:

- OS: Ubuntu-20.04

Steps:

1. Installed a miniha cluster
2. Installed kube-bench to make KubeMarine CIS aligned. 
3. Run scan using command - kube-bench and check for identifier **4.2.12**.

Results:

| Before | After |
| ------ | ------ |
| Result used to be Warning | Result shows Pass |


**TestCase 2**
Apply the patch for the old clusters where kubelet Cryptographic Ciphers are not update even after even after k8s upgrade.

Test Configuration:
Steps: 
1. Try to upgrade k8s for e.g. from v1.28.4 to v1.28.6 
2. With such upgrade tls-cipher-suites on /var/lib/kubelet/config.yaml will not get updated.
3. Then apply this patch runing kubemarine migrate_kubemarine command.
4. Check the /var/lib/kubelet/config.yaml file to verify if tls-cipher-suites is updated and also run scan using command - kube-bench and check for identifier **4.2.12**.

Results:

| Before | After |
| ------ | ------ |
| Result used to be Warning | Result shows Pass |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


