### PR TITLE
[CPDEV-100414] Install and check thirdparties skipping SSL verification

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -399,7 +399,7 @@ def thirdparties_hashes(cluster: KubernetesCluster) -> None:
                 cluster.log.verbose('Temporary path: %s' % random_path)
                 remote_commands = "mkdir -p %s" % ('/'.join(random_path.split('/')[:-1]))
                 # Load thirdparty to temporary dir
-                remote_commands += "&& sudo curl -f -g -s --show-error -L %s -o %s" % (config['source'], random_path)
+                remote_commands += "&& sudo curl -k -f -g -s --show-error -L %s -o %s" % (config['source'], random_path)
                 results = first_control_plane.sudo(remote_commands, warn=True)
                 if results.is_any_failed():
                     host = first_control_plane_host

--- a/kubemarine/resources/scripts/check_url_availability.py
+++ b/kubemarine/resources/scripts/check_url_availability.py
@@ -16,6 +16,7 @@
 # The script is for testing purpose only.
 # The first argv parameter is source. The second argv parameter is the timeout.
 
+import ssl
 import sys
 
 major_version = sys.version_info.major
@@ -37,8 +38,14 @@ try:
 
     password_mgr = urllib.HTTPPasswordMgrWithDefaultRealm()
     password_mgr.add_password(None, no_auth_url, parsed_url.username or '', parsed_url.password or '')
-    handler = urllib.HTTPBasicAuthHandler(password_mgr)
-    opener = urllib.build_opener(handler)
+    basic_auth_handler = urllib.HTTPBasicAuthHandler(password_mgr)
+
+    ssl_ctx = ssl.create_default_context()
+    ssl_ctx.check_hostname = False
+    ssl_ctx.verify_mode = ssl.CERT_NONE
+    https_handler = urllib.HTTPSHandler(context=ssl_ctx)
+
+    opener = urllib.build_opener(https_handler, basic_auth_handler)
 
     status_code = opener.open(no_auth_url, timeout=timeout).getcode()
     if status_code != 200:

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -345,7 +345,7 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> Optional[Ru
             # if hash equal, then stop further actions immediately! unpack should not be performed too
             remote_commands += ' && FILE_HASH=$(sudo openssl sha1 %s | sed "s/^.* //"); ' \
                                '[ "%s" == "${FILE_HASH}" ] && exit 0 || true ' % (destination, config['sha1'])
-        remote_commands += (' && sudo rm -f %s && sudo curl --max-time %d -f -g -L %s -o %s && '
+        remote_commands += (' && sudo rm -f %s && sudo curl --max-time %d -k -f -g -L %s -o %s && '
                             % (destination, cluster.inventory['globals']['timeout_download'], config['source'], destination))
     else:
         cluster.log.verbose('Installation via sftp upload detected')


### PR DESCRIPTION
### Description
* Install and check thirdparties skipping SSL verification.

### Solution
* Added `curl -k` option during install.
* Disable SSL verification in `check_url_availability.py` using custom SSL context in HTTPSHandler.
* `software.thirdparties.availability` check now respects probably not yet installed resolv.conf.

### Test Cases

**TestCase 1**

Test Configuration:

- OS: Ubuntu 22.04 / Centos 7
- Inventory: `services.thirdparties.source` with self-signed certificate.

Steps:

1. Install the cluster.

Results:

| Before | After |
| ------ | ------ |
| Installation fails | Installation succeeds |

**TestCase 2**

Test Configuration:

- OS: Ubuntu 22.04 / Centos 7
- Inventory: `services.thirdparties.source` with self-signed certificate.

Steps:

1. Run `check_iaas --tasks software.thirdparties.availability`

Results:

| Before | After |
| ------ | ------ |
| Check fails | Check succeeds |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
