### PR TITLE
[PSUPCLPL-15188] Add a note about balancers to add_node procedure to MG

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -830,11 +830,26 @@ nodes:
 **Note**:
 
 * The connection information for new nodes can be used from defaults as described in the [Kubemarine Inventory Node Defaults](Installation.md#nodedefaults) section in _Kubemarine Installation Procedure_. If the connection information is not present by default, define the information in each new node configuration.
-* If you intend to add the new `balancer` node with VRRP IP, and have previously not configured the `vrrp_ips` section, you need to do the following preliminarily:
+* If you intend to add a new `balancer` node with VRRP IP, and have previously not configured the `vrrp_ips` section, you need to do the following preliminarily:
   * And the section to the main `cluster.yaml`.
   * If you already have balancers without VRRP IPs, reconfigure the balancers and DNS,
     for example, using `kubemarine install --tasks prepare.dns.etc_hosts,deploy.loadbalancer.haproxy.configure,deploy.loadbalancer.keepalived,deploy.coredns`.
-* If you intend to add the new `balancer` node with VRRP IP, and have previously configured the `vrrp_ips` section in the `cluster.yaml`, you have to add the adding node to the `vrrp_ips` section in the `cluster.yaml` the same way as the old balancer nodes.
+* If you intend to add a new `balancer` node with VRRP IP, and have previously configured the `vrrp_ips` section in the `cluster.yaml` with `hosts` subsection, you should add the new balancer node to the `vrrp_ips.*.hosts` section in the `cluster.yaml` the same way as the old balancer nodes, if this new node has to share the same VRRP IP address.
+
+For example, if you want the `new-balancer-node-1` to be added to a subset of balancer nodes who share VRRP IP `192.168.0.100`:
+
+```
+vrrp_ips:
+- hosts:
+  - name: balancer-node-1
+    priority: 254
+  - name: balancer-node-2
+    priority: 253
+  - name: new-balancer-node-1
+  ip: 192.168.0.100
+```
+
+It may be useful, if you have some VRRP IPs working at different subsets of balancer nodes. If you have one VRRP IP and all the balancer nodes must share it, just remove `hosts` section from `vrrp_ips`.
 
 ### Add Node Tasks Tree
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -834,9 +834,9 @@ nodes:
   * And the section to the main `cluster.yaml`.
   * If you already have balancers without VRRP IPs, reconfigure the balancers and DNS,
     for example, using `kubemarine install --tasks prepare.dns.etc_hosts,deploy.loadbalancer.haproxy.configure,deploy.loadbalancer.keepalived,deploy.coredns`.
-* If you intend to add a new `balancer` node with VRRP IP, and have previously configured the `vrrp_ips` section in the `cluster.yaml` with `hosts` subsection, you should add the new balancer node to the `vrrp_ips.*.hosts` section in the `cluster.yaml` the same way as the old balancer nodes, if this new node has to share the same VRRP IP address.
+* If you intend to add a new `balancer` node with VRRP IP, and have previously configured the `vrrp_ips` section in the `cluster.yaml` with the `hosts` subsection, then add the new balancer node to the `vrrp_ips.*.hosts` section in the `cluster.yaml` in the same way as the old balancer nodes if this new node has to share the same VRRP IP address.
 
-For example, if you want the `new-balancer-node-1` to be added to a subset of balancer nodes who share VRRP IP `192.168.0.100`:
+For example, if you want `new-balancer-node-1` to be added to a subset of balancer nodes that share VRRP IP `192.168.0.100`:
 
 ```
 vrrp_ips:
@@ -849,7 +849,7 @@ vrrp_ips:
   ip: 192.168.0.100
 ```
 
-It may be useful, if you have some VRRP IPs working at different subsets of balancer nodes. If you have one VRRP IP and all the balancer nodes must share it, just remove `hosts` section from `vrrp_ips`.
+It may be useful, if you have some VRRP IPs working at different subsets of balancer nodes. If you have one VRRP IP and all the balancer nodes must share it, just remove the `hosts` section from `vrrp_ips`.
 
 ### Add Node Tasks Tree
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -833,7 +833,8 @@ nodes:
 * If you intend to add the new `balancer` node with VRRP IP, and have previously not configured the `vrrp_ips` section, you need to do the following preliminarily:
   * And the section to the main `cluster.yaml`.
   * If you already have balancers without VRRP IPs, reconfigure the balancers and DNS,
-    for example, using `kubemarine install --tasks prepare.dns.etc_hosts,deploy.loadbalancer.haproxy.configure,deploy.loadbalancer.keepalived,deploy.coredns`
+    for example, using `kubemarine install --tasks prepare.dns.etc_hosts,deploy.loadbalancer.haproxy.configure,deploy.loadbalancer.keepalived,deploy.coredns`.
+* If you intend to add the new `balancer` node with VRRP IP, and have previously configured the `vrrp_ips` section in the `cluster.yaml`, you have to add the adding node to the `vrrp_ips` section in the `cluster.yaml` the same way as the old balancer nodes.
 
 ### Add Node Tasks Tree
 


### PR DESCRIPTION
### Description
When a balancer node is added with `add_node`, keepalived is not installed/configured at the newly added node in case of `vrrp_ip` section is already configured in the `cluster.yaml`. 

Maintenance guide omits this case.

Fixes # (issue)
PSUPCLPL-15188

### Solution
Update MG: a note is added to the `add_node` procedure description, covering the case when `vrrp_ips` section exists in the `cluster.yaml` and a balancer node is being added.

### How to apply
-

### Test Cases
Deploy a k8s cluster with 1 or more balancer nodes and the vrrp_ip address.
Run `add_node` procedure to add a node with the `balancer` role configuring procedure.yaml according to the [documentation](https://github.com/Netcracker/KubeMarine/blob/PSUPCLPL-15188_doc_update_on_add_lb_node/documentation/Maintenance.md#configuring-add-node-procedure).

**ER**: the new node is added, keepalived is installed, configured and running at this node.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
-


