### PR TITLE
[PSUPCLPL-13377] - Restrictive File permission for kubelet configuration file 

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -382,6 +382,8 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
 
     components.wait_for_pods(node)
 
+    # modifies file permissions for kubelet configuration file
+    node.sudo("chmod 600 /var/lib/kubelet/config.yaml")
 
 @contextmanager
 def local_admin_config(nodes: NodeGroup) -> Iterator[str]:
@@ -519,6 +521,9 @@ def init_first_control_plane(group: NodeGroup) -> None:
     # refresh cluster installation status in cluster context
     is_cluster_installed(cluster)
 
+    # modifies file permissions for kubelet configuration file
+    first_control_plane.sudo("chmod 600 /var/lib/kubelet/config.yaml")
+
 
 def wait_uncordon(node: NodeGroup) -> None:
     cluster = node.cluster
@@ -607,6 +612,9 @@ def init_workers(group: NodeGroup) -> None:
             hide=False)
 
         components.wait_for_pods(node)
+
+        # modifies file permissions for kubelet configuration file
+        node.sudo("chmod 600 /var/lib/kubelet/config.yaml")
 
 
 def apply_labels(group: NodeGroup) -> RunnersGroupResult:


### PR DESCRIPTION
### Description
* This change is to modify the file permission for kubelet configuration file (/var/lib/kubelet/config.yaml)

Fixes # (issue)
kube-bench identifier **4.1.9**

### Solution
* Set file permission for /var/lib/kubelet/config.yaml as 600 or more restrictive 




### Test Cases


**TestCase 1**

Steps:

1. `Install` kubenernetes cluster or run `migrate_kubemarine` on existing k8s cluster with latest kubemarine distribution
2. Download and install latest kube-bench on master and worker nodes -
* Download `kube-bench_0.7.2_linux_amd64` package from `https://github.com/aquasecurity/kube-bench`
* Install downloaded pkg using `sudo dpkg -i kube-bench_0.7.2_linux_amd64.deb`
3. Run kube-bench

Results:

| Before | After |
| ------ | ------ |
| [FAIL] 4.1.9 If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Automated) | [PASS] 4.1.9 If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Automated) |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


