### PR TITLE
[PSUPCLPL-15213]-Node_not_found_error_when_running_add_node_procedure

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -275,7 +275,11 @@ def drain_nodes(group: NodeGroup, disable_eviction: bool = False,
 
     for node in group.get_ordered_members_list():
         node_name = node.get_node_name()
-        if node_name in stdout:
+
+        # Split stdout into lines
+        stdout_lines = stdout.split('\n')
+        # Check if node_name exactly matches any line
+        if node_name in stdout_lines:
             log.debug("Draining node %s..." % node_name)
             drain_cmd = prepare_drain_command(
                 cluster, node_name,
@@ -299,7 +303,11 @@ def delete_nodes(group: NodeGroup) -> RunnersGroupResult:
 
     for node in group.get_ordered_members_list():
         node_name = node.get_node_name()
-        if node_name in stdout:
+        
+        # Split stdout into lines
+        stdout_lines = stdout.split('\n')
+        # Check if node_name exactly matches any line
+        if node_name in stdout_lines:
             log.debug("Deleting node %s from the cluster..." % node_name)
             control_plane.sudo("kubectl delete node %s" % node_name, hide=False)
         else:

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -277,7 +277,7 @@ def drain_nodes(group: NodeGroup, disable_eviction: bool = False,
         node_name = node.get_node_name()
 
         # Split stdout into lines
-        stdout_lines = stdout.split('\n')
+        stdout_lines = stdout.split('\n')[1:]
         # Check if node_name exactly matches any line
         if node_name in stdout_lines:
             log.debug("Draining node %s..." % node_name)
@@ -305,7 +305,7 @@ def delete_nodes(group: NodeGroup) -> RunnersGroupResult:
         node_name = node.get_node_name()
         
         # Split stdout into lines
-        stdout_lines = stdout.split('\n')
+        stdout_lines = stdout.split('\n')[1:]
         # Check if node_name exactly matches any line
         if node_name in stdout_lines:
             log.debug("Deleting node %s from the cluster..." % node_name)


### PR DESCRIPTION
### Description
The issue is in the drain_nodes function where the condition if node_name in stdout incorrectly evaluates to true if node_name is a substring of one or more active node names in the cluster.
* 

Fixes # ([PSUPCLPL-15213](https://tms.netcracker.com/browse/PSUPCLPL-15213))


### Solution
To address this issue, modified the condition to ensure that it checks for exact matches rather than substring matches. We can achieve this by splitting the stdout into lines and then checking if node_name exactly matches any line in the output.
* 



### Test Cases

**TestCase 1**

Test Configuration:

Steps:

1. Run add node procedure with a node name which will be a substring of one or more active node names
Example - There is already a node in the cluster with name **test-worker-3-10** and then try to add a new node with name **test-worker-3-1**

Results:

| Before | After |
| ------ | ------ |
| Procedure fails with error `Error from server (NotFound): nodes "test-worker-3-1" not found` | Procedure succeeds |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


