### PR TITLE
[CPREQ-9137] - RockyLinux 9.3 support for Kubemarine

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -169,7 +169,7 @@ For cluster machines, ensure the following requirements are met:
   * Centos 7.5+, 8.4, 9
   * RHEL 7.5+, 8.4, 8.6, 8.7, 8.8, 8.9, 9.2
   * Oracle Linux 7.5+, 8.4, 9.2
-  * RockyLinux 8.6, 8.7, 8.8, 9.2
+  * RockyLinux 8.6, 8.7, 8.8, 9.2, 9.3
   * Ubuntu 20.04
   * Ubuntu 22.04.1
 

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -360,6 +360,7 @@ compatibility_map:
       - os_family: 'rhel9'
         versions:
           - '9.2'
+          - '9.3'
     ubuntu:
       - os_family: 'debian'
         versions:


### PR DESCRIPTION
### Description
* To add support for k8s installation on servers running on operation system Rocky Linux 9.3 using kubemarine


### Solution
* Add Rocky Linux's latest version i.e. `9.3` in the supported OS family in `globals.yaml` file 


### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: Opensatck VMs
- OS: RockyLinux 9.3
- Inventory: miniHA scheme for k8s cluster

Steps:

1. Kubemarine check_iaas
AR: Check_iaas succeeded

2. Kubemarine install
AR: Installation succeeded

3. Kubemarine check_paas
AR: check_paas succeeded

4. kubemarine upgrade
AR: Kubernetes version upgraded successfully to the k8s version provided in upgrade plan through `procedure.yaml` as below
```
upgrade_plan:
  - v1.29.1
```

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] There is no merge conflicts





