### PR TITLE
[CPDEV-100496] Ensure to use kubectl after wait for first control plane pods

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -727,10 +727,6 @@ def upgrade_first_control_plane(upgrade_group: NodeGroup, cluster: KubernetesClu
 
     copy_admin_config(cluster.log, first_control_plane)
 
-    # In some versions, kubeadm reverts resolvConf to the default during `upgrade apply`
-    # Remove default resolvConf from kubelet-config ConfigMap for debian OS family
-    first_control_plane.call(components.patch_kubelet_configmap)
-
     expect_kubernetes_version(cluster, version, apply_filter=node_name)
     components.wait_for_pods(first_control_plane)
     exclude_node_from_upgrade_list(first_control_plane, node_name)

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -28,6 +28,7 @@ from ordered_set import OrderedSet
 from kubemarine import kubernetes, system, plugins, thirdparties
 from kubemarine.core import errors, utils as kutils, static, log, flow, schema
 from kubemarine.core.cluster import KubernetesCluster, EnrichmentStage
+from kubemarine.kubernetes import components
 from kubemarine.procedures import upgrade, install
 from kubemarine import demo
 
@@ -1151,6 +1152,7 @@ class RunTasks(_AbstractUpgradeEnrichmentTest):
     def _run_kubernetes_task(self) -> demo.FakeResources:
         with utils.mock_call(kubernetes.upgrade_first_control_plane), \
                 utils.mock_call(install.deploy_coredns), \
+                utils.mock_call(components.patch_kubelet_configmap), \
                 utils.mock_call(kubernetes.upgrade_other_control_planes), \
                 utils.mock_call(kubernetes.upgrade_workers), \
                 utils.mock_call(upgrade.kubernetes_cleanup_nodes_versions):


### PR DESCRIPTION
### Description
* After #627 upgrade sometimes fail during call to `components.patch_kubelet_configmap`. Reproduced on rhel 9.2, upgrade v1.26.11 -> v1.27.8, full HA.
* The reason is because `kubeadm apply` updates kubelet-config ConfigMap using not yet upgraded node with working control plane components, while `components.patch_kubelet_configmap` may randomly go through node with not yet working kube-apiserver.

### Solution
* Move `components.patch_kubelet_configmap` after waiting for readiness of control plane pods.

### Test Cases

**TestCase 1**

Test Configuration:

- OS: rhel 9.2
- Inventory: Kubernetes v1.26.11, 1 balancer, 3 control-plane & worker nodes.

Steps:

1. Install the cluster
2. Upgrade to v1.27.8

Results:

| Before | After |
| ------ | ------ |
| Upgrade sometimes fail on `kubernetes` task | Upgrade is successful. |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
