### PR TITLE
[CPDEV-100884] Validate that kubernetes images are not downgraded

### DIFF
--- a/scripts/thirdparties/src/software/packages.py
+++ b/scripts/thirdparties/src/software/packages.py
@@ -124,6 +124,7 @@ def resolve_new_settings(compatibility_map: CompatibilityMap, package_name: str,
         package_settings = new_settings
         key = utils.version_key
         prev_k8s_version = max((v for v in package_mapping if key(v) < key(k8s_version)),
+                               key=key,
                                default=None)
         if prev_k8s_version is not None:
             print(f"Mapping for package {package_name!r} and Kubernetes {k8s_version} does not exist. "

--- a/test/unit/tools/thirdparties/stub.py
+++ b/test/unit/tools/thirdparties/stub.py
@@ -157,6 +157,7 @@ class FakeSynchronization(Synchronization):
     def __init__(self,
                  compatibility: FakeInternalCompatibility,
                  kubernetes_versions: FakeKubernetesVersions,
+                 images_resolver: FakeKubernetesImagesResolver,
                  manifest_resolver=FAKE_CACHED_MANIFEST_RESOLVER,
                  manifests_enrichment=NoneManifestsEnrichment(),
                  upgrade_config=FakeUpgradeConfig(),
@@ -164,7 +165,7 @@ class FakeSynchronization(Synchronization):
         super().__init__(
             compatibility,
             kubernetes_versions,
-            FakeKubernetesImagesResolver(),
+            images_resolver,
             manifest_resolver,
             FakeThirdpartyResolver(),
             manifests_enrichment,

--- a/test/unit/tools/thirdparties/stub.py
+++ b/test/unit/tools/thirdparties/stub.py
@@ -57,15 +57,23 @@ class FakeKubernetesImagesResolver(KubernetesImagesResolver):
         kubernetes_images: dict = yaml.safe_load(stream)
 
     def resolve(self, k8s_version: str) -> List[str]:
-        kubernetes_images = FakeKubernetesImagesResolver.kubernetes_images
-        if any(k8s_version in mapping for mapping in kubernetes_images.values()):
-            return [f"k8s.gcr.io/{name}:{mapping[k8s_version]['version']}"
-                    for name, mapping in kubernetes_images.items()
-                    if k8s_version in mapping]
+        return [self.stub_image(k8s_version, name)
+                for name in ('kube-apiserver', 'kube-controller-manager', 'kube-scheduler', 'kube-proxy',
+                             'pause', 'etcd', 'coredns/coredns')]
+
+    def stub_image(self, k8s_version: str, name: str) -> str:
+        if name.startswith('kube-'):
+            return f"k8s.gcr.io/{name}:{k8s_version}"
         else:
-            return [f"k8s.gcr.io/{name}:fake-{name}-version"
-                    for name in ['kube-apiserver', 'kube-controller-manager', 'kube-scheduler', 'kube-proxy',
-                                 'pause', 'etcd', 'coredns/coredns']]
+            mapping = FakeKubernetesImagesResolver.kubernetes_images[name]
+            key = utils.version_key
+            near_k8s_version = max((v for v in mapping if key(v) <= key(k8s_version)),
+                                   key=key,
+                                   default=None)
+            if near_k8s_version is None:
+                return f"k8s.gcr.io/{name}:fake-{name}-version"
+            else:
+                return f"k8s.gcr.io/{name}:{mapping[near_k8s_version]['version']}"
 
 
 class FakeManifest(Manifest):

--- a/test/unit/tools/thirdparties/test_sync.py
+++ b/test/unit/tools/thirdparties/test_sync.py
@@ -22,13 +22,14 @@ from unittest import mock
 from test.unit import utils as test_utils
 from test.unit.tools.thirdparties.stub import (
     FakeSynchronization, FakeInternalCompatibility, FakeKubernetesVersions,
-    FAKE_CACHED_MANIFEST_RESOLVER, FakeManifest, NoneManifestsEnrichment, FakeUpgradeConfig
+    FAKE_CACHED_MANIFEST_RESOLVER, FakeManifest, NoneManifestsEnrichment, FakeUpgradeConfig,
+    FakeKubernetesImagesResolver
 )
 
 from kubemarine.core import utils, static
 from kubemarine.plugins import builtin
 from kubemarine.plugins.manifest import Manifest, Processor, Identity
-from scripts.thirdparties.src.software import thirdparties, plugins
+from scripts.thirdparties.src.software import thirdparties, plugins, kubernetes_images
 from scripts.thirdparties.src.software.plugins import (
     ManifestResolver, ManifestsEnrichment,
     ERROR_UNEXPECTED_IMAGE, ERROR_SUSPICIOUS_ABA_VERSIONS
@@ -48,6 +49,7 @@ class SynchronizationTest(unittest.TestCase):
     def setUp(self) -> None:
         self.compatibility = FakeInternalCompatibility()
         self.kubernetes_versions = FakeKubernetesVersions()
+        self.images_resolver = FakeKubernetesImagesResolver()
         self.manifest_resolver = FAKE_CACHED_MANIFEST_RESOLVER
         self.manifests_enrichment = NoneManifestsEnrichment()
         self.upgrade_config = FakeUpgradeConfig()
@@ -382,6 +384,52 @@ class SynchronizationTest(unittest.TestCase):
                 with self.assertRaisesRegex(Exception, ERROR_SUSPICIOUS_ABA_VERSIONS.format(**kwargs)):
                     self.run_sync()
 
+    def test_kubernetes_images_not_ascending_order(self):
+        k8s_versions = self.latest_patch_k8s_versions()
+        if len(k8s_versions) == 1:
+            self.skipTest("Cannot check kubernetes images ascending order for the only minor Kubernetes version.")
+
+        for image_name in ('pause', 'etcd', 'coredns/coredns'):
+            with self.subTest(image_name):
+                k8s_oldest = k8s_versions[0]
+                k8s_latest = k8s_versions[-1]
+                k8s_new = test_utils.increment_version(k8s_oldest)
+
+                self.kubernetes_versions = FakeKubernetesVersions()
+                self.compatibility_map()[k8s_new] = deepcopy(self.compatibility_map()[k8s_oldest])
+
+                image_oldest = ORIGINAL_COMPATIBILITY_MAPS['kubernetes_images.yaml'][image_name][k8s_oldest]['version']
+                image_latest = ORIGINAL_COMPATIBILITY_MAPS['kubernetes_images.yaml'][image_name][k8s_latest]['version']
+
+                if image_name in ('pause', 'etcd'):
+                    new_image_version = image_latest[:-1] + str(int(image_latest[-1]) + 1)
+                else:
+                    new_image_version = test_utils.increment_version(image_latest)
+
+                class FakeResolver(FakeKubernetesImagesResolver):
+                    def resolve(self, k8s_version: str) -> List[str]:
+                        # pylint: disable=cell-var-from-loop
+
+                        k8s_resolve = k8s_oldest if k8s_version == k8s_new else k8s_version
+                        images = super().resolve(k8s_resolve)
+                        if k8s_version == k8s_new:
+                            for i, image in enumerate(images):
+                                if image_name in image:
+                                    images[i] = image.replace(image_oldest, new_image_version)
+                                    break
+
+                        return images
+
+                self.images_resolver = FakeResolver()
+
+                kwargs = {
+                    'image': re.escape(image_name),
+                    'older_version': re.escape(new_image_version), 'older_k8s_version': re.escape(k8s_new),
+                    'newer_version': '.*', 'newer_k8s_version': '.*',
+                }
+                with self.assertRaisesRegex(Exception, kubernetes_images.ERROR_ASCENDING_VERSIONS.format(**kwargs)):
+                    self.run_sync()
+
     def test_manifests_enrichment_add_new_version(self):
         k8s_latest = self.k8s_versions()[-1]
         new_version = test_utils.increment_version(k8s_latest)
@@ -532,6 +580,7 @@ class SynchronizationTest(unittest.TestCase):
         return FakeSynchronization(
             self.compatibility,
             self.kubernetes_versions,
+            self.images_resolver,
             self.manifest_resolver,
             self.manifests_enrichment,
             self.upgrade_config,

--- a/test/unit/tools/thirdparties/test_sync.py
+++ b/test/unit/tools/thirdparties/test_sync.py
@@ -158,9 +158,11 @@ class SynchronizationTest(unittest.TestCase):
     def _check_added_k8s_images(self, ver: str, _: str):
         for k8s_image in ('kube-apiserver', 'kube-controller-manager', 'kube-scheduler', 'kube-proxy',
                           'pause', 'etcd', 'coredns/coredns'):
+            expected_version = self.images_resolver.stub_image(ver, k8s_image).split(':')[1]
+
             software_mapping = self.compatibility.stored['kubernetes_images.yaml'][k8s_image]
             actual_mapping = software_mapping.get(ver, {})
-            self.assertEqual(f"fake-{k8s_image}-version",
+            self.assertEqual(expected_version,
                              actual_mapping.get('version'),
                              f"Version for {k8s_image!r} and Kubernetes {ver} was not synced")
             self.assertTrue(utils.is_sorted(list(software_mapping), key=utils.version_key),


### PR DESCRIPTION
### Description
* If some kubernetes image version downgrades in the compatibility map, it may still not downgrade during Kubernetes upgrade.
* This leads to inconsistency of expected and actual versions, PaaS check may fail, and behavior of `kubemarine add_node`, `kubemarine reconfigure` is undefined.

### Solution
* Validate that kubernetes images are not downgraded for allowed upgrade cases.
* The PR can be merged once the problem with downgrade of etcd for v1.28.8 -> v1.29.1 is solved.

### Test Cases

**TestCase 1**

Steps:

1. Run `scripts/thirdparties/sync.py`

ER: Until v1.29.1 is the latest patch version for Kubernetes v1.29, the tools fails.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_sync.py - cover new case of validation