### PR TITLE
[CPDEV-101596] Rework of inventory compilation

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -5802,7 +5802,7 @@ Application of the list merge strategy is allowed in the following sections:
 
 There are settings in the configuration file that borrow their contents from the settings of the other sections. To avoid any duplication of the settings, the mechanism of dynamic variables is used.
 
-This mechanism allows you to specify a link to one variable to another.
+This mechanism allows you to specify a link from one variable to another.
 
 For example, the following parameters:
 
@@ -5908,7 +5908,7 @@ Dynamic variables have some limitations that should be considered when working w
     kubemarine_variable: '{{ values.custom_variable }}'
   ```
 * The start pointer of the Jinja2 template must be inside a pair of single or double quotes. The `{{` or `{%` out of quotes leads to a parsing error of the yaml file.
-* The variable cannot refer to itself. It does not lead to any result, but it slows down the compilation process.
+* The variable cannot refer to itself.
 * The variables cannot mutually refer to each other. For example, the following configuration:
 
   ```yaml
@@ -5917,23 +5917,26 @@ Dynamic variables have some limitations that should be considered when working w
    variable_two: '{{ section.variable_one }}'
   ```
   
-  This leads to the following result:
-   
-  ```yaml
-  section:
-   variable_one: '{{ section.variable_one }}'
-   variable_two: '{{ section.variable_one }}'
-  ```
-  The variables copy each other, but since none of them lead to any result, there is a cyclic link to one of them.
+  This leads to the "cyclic reference" error.
 
 #### Jinja2 Expressions Escaping
 
-Inventory strings can have strings containing characters that Jinja2 considers as their expressions. For example, if you specify a golang template. To avoid rendering errors for such expressions, it is possible to wrap them in exceptions `{% raw %}``{% endraw %}`. 
+Inventory strings can have strings containing characters that Jinja2 considers as their expressions.
+For example, if you specify a golang template.
+To avoid rendering errors for such expressions, it is possible to escape the special characters. 
 For example:
+
+```yaml
+authority: '{{ "{{ .Name }}" }} 3600 IN SOA'
+```
+
+or
 
 ```yaml
 authority: '{% raw %}{{ .Name }}{% endraw %} 3600 IN SOA'
 ```
+
+For more information, refer to https://jinja.palletsprojects.com/en/3.1.x/templates/#escaping
 
 ### Environment Variables
 

--- a/kubemarine/core/defaults.py
+++ b/kubemarine/core/defaults.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import re
-from typing import Optional, Dict, Any, Tuple, List, Callable, Union
+from typing import Optional, Dict, Any, Tuple, List, Callable, Union, Sequence, cast, Type
 
 import yaml
 
@@ -20,6 +21,7 @@ from kubemarine.core.cluster import KubernetesCluster, EnrichmentStage, enrichme
 from kubemarine.core.errors import KME
 from kubemarine import jinja, keepalived, haproxy, controlplane, kubernetes, thirdparties
 from kubemarine.core import utils, static, log, os
+from kubemarine.core.proxytypes import Primitive, Index, Node
 from kubemarine.core.yaml_merger import default_merger
 from kubemarine.cri.containerd import contains_old_format_properties
 
@@ -53,8 +55,6 @@ ssh_access_node_properties = ssh_access_default_properties + [
 
 
 invalid_node_name_regex = re.compile("[^a-z-.\\d]", re.M)
-escaped_expression_regex = re.compile('({%[\\s*|]raw[\\s*|]%}.*?{%[\\s*|]endraw[\\s*|]%})', re.M)
-jinja_query_regex = re.compile("{{ .* }}", re.M)
 
 
 @enrichment(EnrichmentStage.LIGHT, procedures=['add_node'])
@@ -469,41 +469,33 @@ def _merge_inventory(cluster: KubernetesCluster, base: dict) -> dict:
 
 @enrichment(EnrichmentStage.LIGHT)
 def compile_connections(cluster: KubernetesCluster) -> None:
-    return _compile_inventory(cluster, inject_globals=False)
+    return _compile_inventory(cluster, light=True)
 
 
 @enrichment(EnrichmentStage.FULL)
 def compile_inventory(cluster: KubernetesCluster) -> None:
-    return _compile_inventory(cluster, inject_globals=True)
+    return _compile_inventory(cluster, light=False)
 
 
-def _compile_inventory(cluster: KubernetesCluster, *, inject_globals: bool) -> None:
+def _compile_inventory(cluster: KubernetesCluster, *, light: bool) -> None:
     inventory = cluster.inventory
-    # convert references in yaml to normal values
-    iterations = 100
-    root = utils.deepcopy_yaml(inventory)
-    if inject_globals:
-        root['globals'] = static.GLOBALS
-    root['env'] = os.Environ()
 
-    while iterations > 0:
+    extra: Dict[str, Any] = {'env': os.Environ()}
+    if not light:
+        extra['globals'] = static.GLOBALS
 
-        cluster.log.verbose('Inventory is not rendered yet...')
-        inventory = compile_object(cluster.log, inventory, root)
+    if light:
+        # Management of primitive values is currently not necessary for LIGHT stage.
+        env = Environment(cluster.log, inventory, recursive_compile=True, recursive_extra=extra)
+        jinja.compile_node(inventory, [], env)
+    else:
+        primitives_config = _get_primitive_values_registry()
+        env = Environment(cluster.log, inventory, recursive_compile=True, recursive_extra=extra,
+                          primitives_config=primitives_config)
+        compile_node_with_primitives(inventory, [], env, primitives_config)
 
-        temp_dump = yaml.dump(inventory)
+    remove_empty_items(inventory)
 
-        # remove golang specific
-        temp_dump = re.sub(escaped_expression_regex, '', temp_dump.replace('\n', ''))
-
-        # it is necessary to carry out several iterations,
-        # in case we have dynamic variables that reference each other
-        if '{{' in temp_dump or '{%' in temp_dump:
-            iterations -= 1
-        else:
-            iterations = 0
-
-    compile_object(cluster.log, inventory, root, ignore_jinja_escapes=False)
     dump_inventory(cluster, cluster.context, "cluster_precompiled.yaml")
 
 
@@ -518,46 +510,59 @@ def dump_inventory(cluster: KubernetesCluster, context: dict, filename: str) -> 
     utils.dump_file(context, data, filename)
 
 
-def compile_object(logger: log.EnhancedLogger, struct: Any, root: dict, ignore_jinja_escapes: bool = True) -> Any:
+PrimitivesConfig = List[Tuple[List[str], Callable[[Any], Any]]]
+
+
+def compile_node_with_primitives(struct: Union[list, dict],
+                                 path: List[Union[str, int]],
+                                 env: jinja.Environment,
+                                 primitives_config: PrimitivesConfig) -> Union[list, dict]:
     if isinstance(struct, list):
-        new_struct = []
         for i, v in enumerate(struct):
-            struct[i] = compile_object(logger, v, root, ignore_jinja_escapes=ignore_jinja_escapes)
-            # delete empty list entries, which can appear after jinja compilation
-            if struct[i] != '':
-                new_struct.append(struct[i])
-        struct = new_struct
-    elif isinstance(struct, dict):
+            struct[i] = compile_object_with_primitives(v, path, i, env, primitives_config)
+    else:
         for k, v in struct.items():
-            struct[k] = compile_object(logger, v, root, ignore_jinja_escapes=ignore_jinja_escapes)
-    elif isinstance(struct, str) and jinja.is_template(struct):
-        struct = compile_string(logger, struct, root, ignore_jinja_escapes=ignore_jinja_escapes)
+            struct[k] = compile_object_with_primitives(v, path, k, env, primitives_config)
 
     return struct
 
 
-def compile_string(logger: log.EnhancedLogger, struct: str, root: dict,
-                   ignore_jinja_escapes: bool = True) -> str:
-    logger.verbose("Rendering \"%s\"" % struct)
+def compile_object_with_primitives(struct: Union[Primitive, list, dict],
+                                   path: List[Index], index: Index,
+                                   env: jinja.Environment,
+                                   primitives_config: PrimitivesConfig) -> Union[Primitive, list, dict]:
+    depth = len(path)
+    primitives_config = choose_nested_primitives_config(primitives_config, depth, index)
 
-    def precompile(struct: str) -> str:
-        return compile_string(logger, struct, root)
-
-    if ignore_jinja_escapes:
-        iterator = escaped_expression_regex.finditer(struct)
-        struct = re.sub(escaped_expression_regex, '', struct)
-        struct = jinja.new(logger, recursive_compiler=precompile, precompile_filters={
-            'kubernetes_version': kubernetes.verify_allowed_version
-        }).from_string(struct).render(**root)
-
-        # TODO this does not work for {raw}{jinja}{raw}{jinja}
-        for match in iterator:
-            span = match.span()
-            struct = struct[:span[0]] + match.group() + struct[span[0]:]
+    path.append(index)
+    if isinstance(struct, (list, dict)):
+        if primitives_config:
+            struct = compile_node_with_primitives(struct, path, env, primitives_config)
+        else:
+            struct = jinja.compile_node(struct, path, env)
     else:
-        struct = jinja.new(logger, recursive_compiler=precompile).from_string(struct).render(**root)
+        if isinstance(struct, str) and jinja.is_template(struct):
+            struct = env.compile_string(struct, jinja.Path(path))
 
-    logger.verbose("\tRendered as \"%s\"" % struct)
+        struct = convert_primitive(struct, path, primitives_config)
+
+    path.pop()
+    return struct
+
+
+def remove_empty_items(struct: Any) -> Any:
+    if isinstance(struct, list):
+        new_struct = []
+        for v in struct:
+            v = remove_empty_items(v)
+            # delete empty list entries, which can appear after jinja compilation
+            if v != '':
+                new_struct.append(v)
+        struct = new_struct
+    elif isinstance(struct, dict):
+        for k, v in struct.items():
+            struct[k] = remove_empty_items(v)
+
     return struct
 
 
@@ -574,15 +579,13 @@ def escape_jinja_characters_for_inventory(cluster: KubernetesCluster, obj: Any) 
 
 
 def _escape_jinja_character(value: str) -> str:
-    if '{{' in value and '}}' in value and re.search(jinja_query_regex, value):
-        matches = re.findall(jinja_query_regex, value)
-        for match in matches:
-            # TODO: rewrite to correct way of match replacement: now it can cause "{raw}{raw}xxx.." circular bug
-            value = value.replace(match, '{% raw %}'+match+'{% endraw %}')
+    if jinja.is_template(value):
+        value = '{{ %s }}' % (json.JSONEncoder().encode(value),)
+
     return value
 
 
-def _get_primitive_values_registry() -> List[Tuple[List[str], Callable[[Any], Any]]]:
+def _get_primitive_values_registry() -> PrimitivesConfig:
     return [
         (['services', 'cri', 'containerdConfig',
           'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options',
@@ -601,42 +604,118 @@ def _get_primitive_values_registry() -> List[Tuple[List[str], Callable[[Any], An
     ]
 
 
-@enrichment(EnrichmentStage.FULL)
-def manage_primitive_values(cluster: KubernetesCluster) -> None:
-    paths_func_strip = _get_primitive_values_registry()
-    for search_path, func in paths_func_strip:
-        _convert_primitive_values(cluster.inventory, [], search_path, func)
+def choose_nested_primitives_config(primitives_config: PrimitivesConfig, depth: int, index: Index) -> PrimitivesConfig:
+    nested_config = []
+    for search in primitives_config:
+        search_path = search[0]
+        if depth == len(search_path):
+            continue
+
+        section = search_path[depth]
+        if section in ('*', index):
+            nested_config.append(search)
+
+    return nested_config
 
 
-def _convert_primitive_values(struct: Union[Any], path: List[Union[str, int]],
-                              search_path: List[str], func: Callable[[Any], Any]) -> None:
-    depth = len(path)
-    section = search_path[depth]
-    if section == '*':
-        if isinstance(struct, list):
-            for i in reversed(range(len(struct))):
-                _convert_primitive_value_section(struct, i, path, search_path, func)
+def convert_primitive(struct: Primitive, path: Sequence[Index], primitives_config: PrimitivesConfig) -> Primitive:
+    for search_path, func in primitives_config:
+        if len(search_path) == len(path):
+            try:
+                struct = func(struct)
+            except ValueError as e:
+                raise ValueError(f"{str(e)} in section {utils.pretty_path(path)}") from None
 
-        elif isinstance(struct, dict):
-            for k in list(struct):
-                _convert_primitive_value_section(struct, k, path, search_path, func)
-
-    elif isinstance(struct, dict) and section in struct:
-        _convert_primitive_value_section(struct, section, path, search_path, func)
+    return struct
 
 
-def _convert_primitive_value_section(struct: Union[dict, list], section: Union[str, int],
-                                     path: List[Union[str, int]],
-                                     search_path: List[str], func: Callable[[Any], Any]) -> None:
-    value = struct[section]  # type: ignore[index]
-    path.append(section)
-    depth = len(path)
-    if depth < len(search_path):
-        _convert_primitive_values(value, path, search_path, func)
-    else:
-        try:
-            struct[section] = func(value)  # type: ignore[index]
-        except ValueError as e:
-            raise ValueError(f"{str(e)} in section {utils.pretty_path(path)}") from None
+class NodePrimitives(jinja.JinjaNode):
+    def __init__(self, delegate: Union[dict, list], *,
+                 path: jinja.Path, env: jinja.Environment,
+                 primitives_config: PrimitivesConfig):
+        super().__init__(delegate, path=path, env=env)
+        self.primitives_config = primitives_config
 
-    path.pop()
+    def _child(self, index: Index, val: Union[list, dict]) -> jinja.Node:
+        primitives_config = self._nested_primitives_config(index)
+        return self._child_type(index)(val, path=self.path + (index,), env=self.env,
+                                       primitives_config=primitives_config)
+
+    def _child_type(self, _: Index) -> Type['NodePrimitives']:
+        return NodePrimitives
+
+    def _convert(self, index: Index, val: Primitive) -> Primitive:
+        val = super()._convert(index, val)
+
+        primitives_config = self._nested_primitives_config(index)
+        val = convert_primitive(val, self.path + (index,), primitives_config)
+
+        return val
+
+    def _nested_primitives_config(self, index: Index) -> PrimitivesConfig:
+        depth = len(self.path)
+        return choose_nested_primitives_config(self.primitives_config, depth, index)
+
+
+class NodesCustomization:
+    # pylint: disable=no-self-argument
+
+    def __init__(nodes) -> None:
+        class Kubeadm(Node):
+            def descend(self, index: Index) -> Union[Primitive, Node]:
+                child: Union[Primitive, Node] = super().descend(index)
+
+                if index == 'kubernetesVersion':
+                    kubernetes.verify_allowed_version(cast(str, child))
+
+                return child
+
+        class Services(Node):
+            def _child_type(self, index: Index) -> Type[Node]:
+                if index == 'kubeadm':
+                    return nodes.Kubeadm
+
+                return super()._child_type(index)
+
+        class Root(Node):
+            def _child_type(self, index: Index) -> Type[Node]:
+                if index == 'services':
+                    return nodes.Services
+
+                return super()._child_type(index)
+
+        nodes.Kubeadm: Type[Node] = Kubeadm
+        nodes.Services: Type[Node] = Services
+        nodes.Root: Type[Node] = Root
+
+    def derive(nodes, Base: Type[Node], delegate: dict, **kwargs: Any) -> Node:
+        nodes.Kubeadm = cast(Type[Node], type("Kubeadm", (nodes.Kubeadm, Base), {}))
+        nodes.Services = cast(Type[Node], type("Services", (nodes.Services, Base), {}))
+        nodes.Root = cast(Type[Node], type("Root", (nodes.Root, Base), {}))
+
+        return nodes.Root(delegate, **kwargs)
+
+
+class Environment(jinja.Environment):
+    def __init__(self, logger: log.EnhancedLogger, recursive_values: dict,
+                 *,
+                 recursive_compile: bool = False,
+                 recursive_extra: Dict[str, Any] = None,
+                 primitives_config: PrimitivesConfig = None):
+        self.recursive_compile = recursive_compile
+        self.primitives_config = primitives_config
+        super().__init__(logger, recursive_values, recursive_extra=recursive_extra)
+
+    def create_root(self, delegate: dict) -> Node:
+        kwargs = {}
+        Base: Type[Node]
+        if not self.recursive_compile:
+            Base = Node
+        else:
+            Base = jinja.JinjaNode
+            kwargs = {"path": jinja.Path(), "env": self}
+            if self.primitives_config is not None:
+                Base = NodePrimitives
+                kwargs = {**kwargs, "primitives_config": self.primitives_config}
+
+        return NodesCustomization().derive(Base, delegate, **kwargs)

--- a/kubemarine/core/errors.py
+++ b/kubemarine/core/errors.py
@@ -89,7 +89,7 @@ def get_kme_dictionary() -> dict:
     }
 
 
-class _BaseKME(RuntimeError, ABC):
+class BaseKME(RuntimeError, ABC):
     def __init__(self, code: str):
         self.code = code
         if self.code not in get_kme_dictionary():
@@ -105,7 +105,7 @@ class _BaseKME(RuntimeError, ABC):
         return self.code + ": " + self.message
 
 
-class KME(_BaseKME):
+class KME(BaseKME):
     def __init__(self, code: str, **kwargs: object):
         self.kwargs = kwargs
         super().__init__(code)
@@ -118,7 +118,7 @@ class KME(_BaseKME):
         return name.format_map(self.kwargs)
 
 
-class KME0006(_BaseKME):
+class KME0006(BaseKME):
     def __init__(self, offline: List[str], inaccessible: List[str]):
         self.offline = offline
         self.inaccessible = inaccessible
@@ -179,7 +179,7 @@ def pretty_print_error(message: str = '', reason: Exception = None, log: klog.En
 
     reason = wrap_kme_exception(reason)
 
-    if isinstance(reason, _BaseKME):
+    if isinstance(reason, BaseKME):
         error_logger(reason)
         return
 

--- a/kubemarine/core/proxytypes.py
+++ b/kubemarine/core/proxytypes.py
@@ -1,0 +1,159 @@
+import json
+from abc import ABC, abstractmethod
+from typing import Any, Union, Sequence, List, Iterator, Mapping, Type, Dict
+
+import yaml
+
+Index = Union[str, int]
+Primitive = Union[str, int, bool, float]
+
+
+class Proxy(ABC):
+    def __repr__(self) -> str:
+        return repr(self._KM_materialize())
+
+    @abstractmethod
+    def _KM_materialize(self) -> Any: ...
+
+
+class DelegatingProxy(Proxy, ABC):
+    @abstractmethod
+    def _KM_unsafe(self) -> Union[dict, list]: ...
+
+    @abstractmethod
+    def _KM__getitem__(self, index: Index) -> Union[Primitive, Proxy]: ...
+
+
+class MappingProxy(DelegatingProxy, Mapping[str, Any], ABC):
+    def __getitem__(self, k: str) -> Any:
+        return self._KM__getitem__(k)
+
+    def __len__(self) -> int:
+        return len(self._KM_unsafe())
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._KM_unsafe())
+
+    def _KM_materialize(self) -> Any:
+        return dict(self)
+
+
+class SequenceProxy(DelegatingProxy, Sequence[Any], ABC):
+    def __getitem__(self, index: Union[int, slice]) -> Any:
+        if isinstance(index, slice):
+            indexes = list(range(len(self)))[index]
+            return SliceProxy(self, indexes)
+
+        return self._KM__getitem__(index)
+
+    def __len__(self) -> int:
+        return len(self._KM_unsafe())
+
+    def _KM_materialize(self) -> Any:
+        return list(self)
+
+
+class SliceProxy(Proxy, Sequence[Any]):
+    def __init__(self, sequence: SequenceProxy, indexes: List[int]):
+        self._KM_sequence = sequence
+        self._KM_indexes = indexes
+
+    def __getitem__(self, index: Union[int, slice]) -> Any:
+        if isinstance(index, slice):
+            indexes = self._KM_indexes[index]
+            return SliceProxy(self._KM_sequence, indexes)
+
+        return self._KM_sequence[self._KM_indexes[index]]
+
+    def __len__(self) -> int:
+        return len(self._KM_indexes)
+
+    def _KM_materialize(self) -> Any:
+        return list(self)
+
+
+class Node:
+    def __init__(self, delegate: Union[dict, list]):
+        self.delegate = delegate
+
+    def descend(self, index: Index) -> Union[Primitive, 'Node']:
+        val: Union[Primitive, list, dict] = self.delegate[index]  # type: ignore[index]
+        if isinstance(val, (list, dict)):
+            return self._child(index, val)
+
+        return val
+
+    def _child(self, index: Index, val: Union[list, dict]) -> 'Node':
+        return self._child_type(index)(val)
+
+    def _child_type(self, _: Index) -> Type['Node']:
+        return Node
+
+
+class MutableNode(Node, ABC):
+    def descend(self, index: Index) -> Union[Primitive, Node]:
+        child = super().descend(index)
+        if isinstance(child, Node):
+            return child
+
+        val = self._convert(index, child)
+        self.delegate[index] = val  # type: ignore[index]
+
+        return val
+
+    @abstractmethod
+    def _convert(self, index: Index, val: Primitive) -> Primitive: ...
+
+    def _child_type(self, _: Index) -> Type[Node]:
+        return MutableNode
+
+
+class NodeProxy(DelegatingProxy, ABC):
+    def __init__(self, node: Node):
+        self._KM_node = node
+        self._KM_cached: Dict[Index, Union[Primitive, Proxy]] = {}
+
+    def _KM_unsafe(self) -> Union[dict, list]:
+        return self._KM_node.delegate
+
+    def _KM__getitem__(self, index: Index) -> Union[Primitive, Proxy]:
+        if index not in self._KM_cached:
+            child = self._KM_node.descend(index)
+            val = ((NodeMapping(child) if isinstance(child.delegate, dict) else NodeSequence(child))
+                   if isinstance(child, Node)
+                   else child)
+
+            self._KM_cached[index] = val
+            return val
+
+        return self._KM_cached[index]
+
+
+class NodeMapping(NodeProxy, MappingProxy):
+    pass
+
+
+class NodeSequence(NodeProxy, SequenceProxy):
+    pass
+
+
+class ProxyJSONEncoder(json.JSONEncoder):
+    def default(self, o: Any) -> Any:
+        if isinstance(o, Proxy):
+            return o._KM_materialize()  # pylint: disable=protected-access
+
+        return super().default(o)
+
+
+def proxy_representer(dumper: yaml.Dumper, data: Proxy) -> Any:
+    val = data._KM_materialize()  # pylint: disable=protected-access
+    return dumper.yaml_representers[type(val)](dumper, val)
+
+
+class ProxyDumper(yaml.Dumper):  # pylint: disable=too-many-ancestors
+    pass
+
+
+ProxyDumper.add_representer(NodeMapping, proxy_representer)
+ProxyDumper.add_representer(NodeSequence, proxy_representer)
+ProxyDumper.add_representer(SliceProxy, proxy_representer)

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -433,10 +433,6 @@ class DynamicResources:
             kubemarine.core.defaults.remove_service_roles,
             # Enrichment of inventory for LIGHT stage should be finished at this step.
 
-            # Should be just after compilation, but currently not necessary for LIGHT stage.
-            # Sections with primitive values may be potentially split in the future if necessary for LIGHT.
-            kubemarine.core.defaults.manage_primitive_values,
-
             # Validation of procedure inventory enrichment after compilation
             kubemarine.kubernetes.verify_version,
             kubemarine.admission.verify_manage_enrichment,

--- a/kubemarine/jinja.py
+++ b/kubemarine/jinja.py
@@ -12,59 +12,173 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import base64
-from typing import Callable, Dict, Any
+import json
+from typing import Callable, Dict, Any, List, Union, Set, Type
 from urllib.parse import quote_plus
 
 import yaml
 import jinja2
 
-from kubemarine.core import log, utils
+from kubemarine.core import log, utils, errors
+from kubemarine.core.proxytypes import (
+    Index, Primitive, NodeMapping, ProxyDumper, ProxyJSONEncoder, MutableNode, Node
+)
 
+Path = tuple
 FILTER = Callable[[str], Any]
 
 
-def new(_: log.EnhancedLogger, *,
-        recursive_compiler: Callable[[str], str] = None,
-        precompile_filters: Dict[str, FILTER] = None) -> jinja2.Environment:
-    def _precompile(filter_: str, struct: str, *args: Any, **kwargs: Any) -> str:
+class JinjaNode(MutableNode):
+    def __init__(self, delegate: Union[dict, list],
+                 *, path: Path, env: 'Environment'):
+        super().__init__(delegate)
+        self.path = path
+        self.env = env
+
+    def _child(self, index: Index, val: Union[list, dict]) -> Node:
+        return self._child_type(index)(val, path=self.path + (index,), env=self.env)
+
+    def _child_type(self, _: Index) -> Type['JinjaNode']:
+        return JinjaNode
+
+    def _convert(self, index: Index, val: Primitive) -> Primitive:
+        if isinstance(val, str) and is_template(val):
+            val = self.env.compile_string(val, self.path + (index,))
+
+        return val
+
+
+class Context(jinja2.runtime.Context):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.environment: Environment = self.environment
+
+    def resolve_or_missing(self, key: str) -> Any:
+        # pylint: disable=protected-access
+
+        v = super().resolve_or_missing(key)
+
+        if v is jinja2.runtime.missing and key in self.environment._recursive_values:
+            return self.environment._proxy_values[key]
+
+        return v
+
+
+class Environment(jinja2.Environment):
+    context_class = Context
+
+    def __init__(self, logger: log.EnhancedLogger, recursive_values: dict, *, recursive_extra: Dict[str, Any] = None):
+        super().__init__()
+        self.logger = logger
+
+        self._recursive_values = recursive_values
+        self._proxy_values = NodeMapping(self.create_root(self._recursive_values))
+
+        self._compiled: Set[Path] = set()
+        self._compiling: List[Path] = []
+
+        self._recursive_extra = {}
+        if recursive_extra is not None:
+            self._recursive_extra = recursive_extra
+
+        self.policies['json.dumps_function'] = jinja_tojson
+        self.filters['toyaml'] = jinja_toyaml
+
+        simple_string_filters: Dict[str, FILTER] = {
+            'isipv4': lambda ip: utils.isipv(ip, [4]),
+            'isipv6': lambda ip: utils.isipv(ip, [6]),
+            'minorversion': utils.minor_version,
+            'majorversion': utils.major_version,
+            'versionkey': utils.version_key,
+            'b64encode': lambda s: base64.b64encode(s.encode()).decode(),
+            'b64decode': lambda s: base64.b64decode(s.encode()).decode(),
+            'url_quote': quote_plus
+        }
+
+        for name, filter_ in simple_string_filters.items():
+            def make_filter(n: str, f: FILTER) -> FILTER:
+                return lambda s, *args, **kwargs: f(self._check_filter(n, s, *args, *kwargs))
+
+            self.filters[name] = make_filter(name, filter_)
+
+        self.tests['has_role'] = lambda node, role: role in node['roles']
+        self.tests['has_roles'] = lambda node, roles: bool(set(node['roles']) & set(roles))
+
+        # we need these filters because rendered cluster.yaml can contain variables like
+        # enable: 'true'
+        self.filters['is_true'] = utils.strtobool
+        self.filters['is_false'] = lambda v: not utils.strtobool(v)
+
+    def create_root(self, delegate: dict) -> Node:
+        return JinjaNode(delegate, path=Path(), env=self)
+
+    def compile_string(self, struct: str, path: Path) -> str:
+        if path in self._compiled:
+            return struct
+
+        if path in self._compiling:
+            idx = self._compiling.index(path)
+            raise Exception(
+                f"Cyclic dynamic variables in inventory{' -> '.join(map(utils.pretty_path, self._compiling[idx:]))}")
+
+        self.logger.verbose("Rendering \"%s\"" % struct)
+
+        self._compiling.append(path)
+
+        try:
+            struct = self.from_string(struct).render(self._recursive_extra)
+        except errors.BaseKME:
+            raise
+        except Exception as e:
+            raise ValueError(f"Failed to render {struct!r}\nin section {utils.pretty_path(path)}: {e}") from None
+
+        self._compiling.pop()
+
+        self._compiled.add(path)
+
+        self.logger.verbose("\tRendered as \"%s\"" % struct)
+        return struct
+
+    def _check_filter(self, filter_: str, struct: str, *args: Any, **kwargs: Any) -> str:
         if args or kwargs:
             raise ValueError(f"Filter {filter_!r} does not support extra arguments")
 
         if not isinstance(struct, str):
             raise ValueError(f"Filter {filter_!r} can be applied only on string")
 
-        # maybe we have non compiled string like templates/plugins/calico-{{ globals.compatibility_map }} ?
-        return recursive_compiler(struct) if recursive_compiler is not None and is_template(struct) else struct
+        return struct
 
-    env = jinja2.Environment()
 
-    if precompile_filters is None:
-        precompile_filters = {}
-    precompile_filters['isipv4'] = lambda ip: utils.isipv(ip, [4])
-    precompile_filters['isipv6'] = lambda ip: utils.isipv(ip, [6])
-    precompile_filters['minorversion'] = utils.minor_version
-    precompile_filters['majorversion'] = utils.major_version
-    precompile_filters['versionkey'] = utils.version_key
-    precompile_filters['b64encode'] = lambda s: base64.b64encode(s.encode()).decode()
-    precompile_filters['b64decode'] = lambda s: base64.b64decode(s.encode()).decode()
-    precompile_filters['url_quote'] = quote_plus
+def jinja_tojson(obj: Any, **kwargs: Any) -> str:
+    return json.dumps(obj, cls=ProxyJSONEncoder, **kwargs)
 
-    for name, filter_ in precompile_filters.items():
-        def make_filter(n: str, f: FILTER) -> FILTER:
-            return lambda s, *args, **kwargs: f(_precompile(n, s, *args, *kwargs))
 
-        env.filters[name] = make_filter(name, filter_)
-
-    env.filters['toyaml'] = lambda data: yaml.dump(data, default_flow_style=False)
-    env.tests['has_role'] = lambda node, role: role in node['roles']
-    env.tests['has_roles'] = lambda node, roles: bool(set(node['roles']) & set(roles))
-
-    # we need these filters because rendered cluster.yaml can contain variables like 
-    # enable: 'true'
-    env.filters['is_true'] = lambda v: v if isinstance(v, bool) else utils.strtobool(_precompile('is_true', v))
-    env.filters['is_false'] = lambda v: not v if isinstance(v, bool) else not utils.strtobool(_precompile('is_false', v))
-    return env
+def jinja_toyaml(data: Any) -> str:
+    return yaml.dump(data, Dumper=ProxyDumper)
 
 
 def is_template(struct: str) -> bool:
     return '{{' in struct or '{%' in struct
+
+
+def compile_node(struct: Union[list, dict], path: List[Union[str, int]], env: Environment) -> Union[list, dict]:
+    if isinstance(struct, list):
+        for i, v in enumerate(struct):
+            struct[i] = compile_object(v, path, i, env)
+    else:
+        for k, v in struct.items():
+            struct[k] = compile_object(v, path, k, env)
+
+    return struct
+
+
+def compile_object(struct: Union[Primitive, list, dict],
+                   path: List[Index], index: Index, env: Environment) -> Union[Primitive, list, dict]:
+    path.append(index)
+    if isinstance(struct, (list, dict)):
+        struct = compile_node(struct, path, env)
+    elif isinstance(struct, str) and is_template(struct):
+        struct = env.compile_string(struct, Path(path))
+
+    path.pop()
+    return struct

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -446,14 +446,14 @@ services:
               zone: '{{ cluster_name }}'
               data:
                 match: '^(.*\.)?{{ cluster_name }}\.$'
-                answer: '{% raw %}{{ .Name }}{% endraw %} 3600 IN A {{ control_plain["internal"] }}'
+                answer: '{{ "{{ .Name }}" }} 3600 IN A {{ control_plain["internal"] }}'
             reject-aaaa:
               enabled: '{{ nodes[0]["internal_address"]|isipv4 }}'
               priority: 1
               class: IN
               type: AAAA
               data:
-                authority: '{% raw %}{{ .Name }}{% endraw %} 3600 IN SOA coredns.kube-system.svc.cluster.local. hostmaster.coredns.kube-system.svc.cluster.local. (3600 3600 3600 3600 3600)'
+                authority: '{{ "{{ .Name }}" }} 3600 IN SOA coredns.kube-system.svc.cluster.local. hostmaster.coredns.kube-system.svc.cluster.local. (3600 3600 3600 3600 3600)'
           forward:
             - .
             - /etc/resolv.conf
@@ -557,7 +557,7 @@ plugin_defaults:
 plugins:
 
   calico:
-    version: '{{ globals.compatibility_map.software["calico"][services.kubeadm.kubernetesVersion|kubernetes_version].version }}'
+    version: '{{ globals.compatibility_map.software["calico"][services.kubeadm.kubernetesVersion].version }}'
     install: true
     installation:
       priority: 0
@@ -573,12 +573,12 @@ plugins:
               - calico-node
             deployments:
               - calico-kube-controllers
-              - '{% if plugins.calico.typha.enabled | is_true %}calico-typha{% endif %}'
+              - '{% if plugins.calico.typha.enabled %}calico-typha{% endif %}'
             pods:
               - coredns
               - calico-kube-controllers
               - calico-node
-              - '{% if plugins.calico.typha.enabled | is_true %}calico-typha{% endif %}'
+              - '{% if plugins.calico.typha.enabled %}calico-typha{% endif %}'
         - thirdparty: /usr/bin/calicoctl
         - template:
             source: templates/plugins/calicoctl.cfg.j2
@@ -701,7 +701,7 @@ plugins:
           retries: 40
 
   nginx-ingress-controller:
-    version: '{{ globals.compatibility_map.software["nginx-ingress-controller"][services.kubeadm.kubernetesVersion|kubernetes_version].version }}'
+    version: '{{ globals.compatibility_map.software["nginx-ingress-controller"][services.kubeadm.kubernetesVersion].version }}'
     install: true
     installation:
       registry: registry.k8s.io
@@ -729,7 +729,7 @@ plugins:
       # redefine default value for controller >= v1.9.0 because we need to use snippet annotations for dashboard
       allow-snippet-annotations: "true"
     webhook:
-      image: 'ingress-nginx/kube-webhook-certgen:{{ globals.compatibility_map.software["nginx-ingress-controller"][services.kubeadm.kubernetesVersion|kubernetes_version]["webhook-version"] }}'
+      image: 'ingress-nginx/kube-webhook-certgen:{{ globals.compatibility_map.software["nginx-ingress-controller"][services.kubeadm.kubernetesVersion]["webhook-version"] }}'
       # resources values are based on https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.7.1/charts/ingress-nginx/values.yaml#L598
       resources:
         requests:
@@ -769,7 +769,7 @@ plugins:
         protocol: TCP
 
   kubernetes-dashboard:
-    version: '{{ globals.compatibility_map.software["kubernetes-dashboard"][services.kubeadm.kubernetesVersion|kubernetes_version].version }}'
+    version: '{{ globals.compatibility_map.software["kubernetes-dashboard"][services.kubeadm.kubernetesVersion].version }}'
     install: false
     installation:
       priority: 2
@@ -806,7 +806,7 @@ plugins:
           cpu: 1
           memory: 200Mi
     metrics-scraper:
-      image: 'kubernetesui/metrics-scraper:{{ globals.compatibility_map.software["kubernetes-dashboard"][services.kubeadm.kubernetesVersion|kubernetes_version]["metrics-scraper-version"] }}'
+      image: 'kubernetesui/metrics-scraper:{{ globals.compatibility_map.software["kubernetes-dashboard"][services.kubeadm.kubernetesVersion]["metrics-scraper-version"] }}'
       nodeSelector:
         kubernetes.io/os: linux
       resources:
@@ -846,7 +846,7 @@ plugins:
                         number: 443
 
   local-path-provisioner:
-    version: '{{ globals.compatibility_map.software["local-path-provisioner"][services.kubeadm.kubernetesVersion|kubernetes_version].version }}'
+    version: '{{ globals.compatibility_map.software["local-path-provisioner"][services.kubeadm.kubernetesVersion].version }}'
     install: false
     installation:
       priority: 2
@@ -864,7 +864,7 @@ plugins:
       is-default: "false"
     volume-dir: /opt/local-path-provisioner
     image: 'rancher/local-path-provisioner:{{ plugins["local-path-provisioner"].version }}'
-    helper-pod-image: 'library/busybox:{{ globals.compatibility_map.software["local-path-provisioner"][services.kubeadm.kubernetesVersion|kubernetes_version]["busybox-version"] }}'
+    helper-pod-image: 'library/busybox:{{ globals.compatibility_map.software["local-path-provisioner"][services.kubeadm.kubernetesVersion]["busybox-version"] }}'
     # resources values are based on https://github.com/rancher/local-path-provisioner/blob/v0.0.24/deploy/chart/local-path-provisioner/values.yaml#L69
     resources:
       requests:

--- a/test/unit/core/test_cluster.py
+++ b/test/unit/core/test_cluster.py
@@ -12,9 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+import re
 import unittest
+from unittest import mock
+from test.unit import utils as test_utils
 
-from kubemarine import demo
+from kubemarine import demo, kubernetes
 from kubemarine.core.cluster import EnrichmentStage
 from kubemarine.demo import FakeKubernetesCluster
 
@@ -252,6 +256,54 @@ class LightClusterTest(unittest.TestCase):
 
         self.assertIn('control-plane', cluster.inventory['nodes'][0]['roles'])
         self.assertEqual('control-plane-1', cluster.nodes['control-plane'].get_node_name())
+
+    def test_recursive_compile_inventory(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['values'] = {
+            'var1': '{{ values.var2 }}',
+            'var2': '{{ "test-cluster" | upper }}',
+        }
+        inventory['cluster_name'] = '{{ values.var1 }}'
+
+        cluster = demo.new_resources(inventory).cluster(EnrichmentStage.LIGHT)
+        self.assertEqual('TEST-CLUSTER', cluster.inventory['cluster_name'])
+
+    def test_compile_env_variables(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['values'] = {
+            'variable': '{{ env.ENV_NAME }}',
+        }
+
+        with mock.patch.dict(os.environ, {'ENV_NAME': 'value1'}):
+            cluster = demo.new_resources(inventory).cluster(EnrichmentStage.LIGHT)
+
+        self.assertEqual('value1', cluster.inventory['values']['variable'])
+
+    def test_recursive_compile_invalid_inventory_reference(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        services_ref = '{{ services.kubeadm.kubernetesVersion }}'
+        inventory['values'] = {
+            'var1': '{{ values.var2 }}',
+            'var2': services_ref,
+        }
+
+        with test_utils.assert_raises_regex(self, ValueError, re.escape(
+                f"Failed to render {services_ref!r}\n"
+                "in section ['values']['var2']: 'services' is undefined")):
+            demo.new_resources(inventory).cluster(EnrichmentStage.LIGHT)
+
+    def test_compile_invalid_globals_reference(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        kubernetes_version = kubernetes.get_kubernetes_version(inventory)
+        globals_ref = f'{{{{ globals.compatibility_map.software["calico"]["{kubernetes_version}"].version }}}}'
+        inventory['values'] = {
+            'var1': globals_ref,
+        }
+
+        with test_utils.assert_raises_regex(self, ValueError, re.escape(
+                f"Failed to render {globals_ref!r}\n"
+                "in section ['values']['var1']: 'globals' is undefined")):
+            demo.new_resources(inventory).cluster(EnrichmentStage.LIGHT)
 
 
 if __name__ == '__main__':

--- a/test/unit/core/test_jinja.py
+++ b/test/unit/core/test_jinja.py
@@ -1,0 +1,197 @@
+import json
+import re
+import unittest
+from test.unit import utils as test_utils
+
+import yaml
+
+from kubemarine import demo
+
+
+class TestCompilation(unittest.TestCase):
+    def test_escapes(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['values'] = {
+            'var1': "{{ '{{ .Name }}' }}",
+            'var2': "{% raw %}{{ .Name }}{% endraw %}",
+            'var3': '{% raw %}{{ raw1 }}{% endraw %}text1{% raw %}{{ raw2 }}{% endraw %}text2',
+            'var4': 'A',
+            'var5': '{% raw %}{{ raw1 }}{% endraw %}{{ values.var4 }}{% raw %}{{ raw2 }}{% endraw %}{{ values.var4 }}',
+            'var6': '{% raw %}{{ raw1 }}{% endraw %}{{ values.var2 }}{% raw %}{{ raw2 }}{% endraw %}{{ values.var2 }}',
+        }
+
+        def test(cluster_: demo.FakeKubernetesCluster):
+            values = cluster_.inventory['values']
+            self.assertEqual('{{ .Name }}', values['var1'])
+            self.assertEqual('{{ .Name }}', values['var2'])
+            self.assertEqual('{{ raw1 }}text1{{ raw2 }}text2', values['var3'])
+            self.assertEqual('{{ raw1 }}A{{ raw2 }}A', values['var5'])
+            self.assertEqual('{{ raw1 }}{{ .Name }}{{ raw2 }}{{ .Name }}', values['var6'])
+
+        cluster = demo.new_cluster(inventory)
+        test(cluster)
+
+        cluster = demo.new_cluster(test_utils.make_finalized_inventory(cluster))
+        test(cluster)
+
+    def test_recursive_filters(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['values'] = {
+            'var1': "{{ values.template | b64encode | b64decode | upper }}",
+            'var2': "{{ (values.int1 | int) + (values.int2 | int) }}",
+            'var3': "{{ '{{ values.TEST }}' | b64encode | b64decode | lower }}",
+            'var4': "{{ '{{ values.TEST }}' | lower }}",
+            'template': '{{ "text" }}',
+            'int1': '{{ 1 }}',
+            'int2': '{{ 2 }}',
+            'test': 'unexpected'
+        }
+
+        cluster = demo.new_cluster(inventory)
+        values = cluster.inventory['values']
+
+        self.assertEqual('TEXT', values['var1'])
+        self.assertEqual('3', values['var2'])
+        self.assertEqual('{{ values.test }}', values['var3'])
+        self.assertEqual('{{ values.test }}', values['var4'])
+
+    def test_not_existing_variables(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['values'] = {
+            'var1': '{{ values.notexists | default("not exists") }}',
+            'var2': [],
+            'var3': '{{ values.var2[0] | lower }}',
+            'var4': '{{ values.var2[:10][0] | default("not exists") }}',
+        }
+
+        cluster = demo.new_cluster(inventory)
+        values = cluster.inventory['values']
+
+        self.assertEqual('not exists', values['var1'])
+        self.assertEqual('', values['var3'])
+        self.assertEqual('not exists', values['var4'])
+
+    def test_mappings(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        template_map = {
+            'foo': 'bar', 'array': ['{{ values.ref }}', 2],
+        }
+        expected_map = {
+            'foo': 'bar', 'array': ['text', 2],
+        }
+        inventory['values'] = {
+            'var1': '{{ values.map }}',
+            'var2': '{{ values.map | tojson }}',
+            'map': template_map,
+            'var3': '{{ values.map | toyaml }}',
+            'var4': '{{ values is mapping }}',
+            'var5': '{{ "ref" in values }}',
+            'var6': '{{ "missed" in values }}',
+            'ref': 'text',
+        }
+
+        cluster = demo.new_cluster(inventory)
+        values = cluster.inventory['values']
+
+        self.assertEqual("{'foo': 'bar', 'array': ['text', 2]}", values['var1'])
+        self.assertEqual(expected_map, json.loads(values['var2']))
+        self.assertEqual(expected_map, yaml.safe_load(values['var3']))
+        self.assertEqual('True', values['var4'])
+        self.assertEqual('True', values['var5'])
+        self.assertEqual('False', values['var6'])
+
+    def test_sequences(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        template_list = [1, 2, {'3': '{{ values.ref }}'}, 4, 5, 6, 7, 8, 9]
+        expected_list = [1, 2, {'3': 'text'}, 4, 5, 6, 7, 8, 9]
+        inventory['values'] = {
+            'list': template_list,
+            'var1': '{{ values.list }}',
+            'var2': '{{ values.list | tojson }}',
+            'var3': '{{ values.list | toyaml }}',
+            'var4': '{{ values.list is sequence }}',
+            'var5': '{{ 5 in values.list }}',
+            'var6': '{{ 0 in values.list }}',
+            'ref': 'text',
+        }
+
+        cluster = demo.new_cluster(inventory)
+        values = cluster.inventory['values']
+
+        self.assertEqual("[1, 2, {'3': 'text'}, 4, 5, 6, 7, 8, 9]", values['var1'])
+        self.assertEqual(expected_list, json.loads(values['var2']))
+        self.assertEqual(expected_list, yaml.safe_load(values['var3']))
+        self.assertEqual('True', values['var4'])
+        self.assertEqual('True', values['var5'])
+        self.assertEqual('False', values['var6'])
+
+    def test_slices(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        template_list = [1, 2, {'3': '{{ values.ref }}'}, 4, 5, 6, 7, 8, 9]
+        expected_slice = [1, {'3': 'text'}]
+        inventory['values'] = {
+            'list': template_list,
+            'var1': '{{ values.list[:4:2] }}',
+            'var2': '{{ values.list[:4:2] | tojson }}',
+            'var3': '{{ values.list[:4:2] | toyaml }}',
+            'var4': '{{ values.list[:4:2] is sequence }}',
+            'var5': '{{ 1 in values.list[:4:2] }}',
+            'var6': '{{ 2 in values.list[:4:2] }}',
+            'var7': '{{ values.list[:6:2][1:][1] }}',
+            'ref': 'text',
+        }
+
+        cluster = demo.new_cluster(inventory)
+        values = cluster.inventory['values']
+
+        self.assertEqual("[1, {'3': 'text'}]", values['var1'])
+        self.assertEqual(expected_slice, json.loads(values['var2']))
+        self.assertEqual(expected_slice, yaml.safe_load(values['var3']))
+        self.assertEqual('True', values['var4'])
+        self.assertEqual('True', values['var5'])
+        self.assertEqual('False', values['var6'])
+        self.assertEqual('5', values['var7'])
+
+    def test_redefine_inventory_section(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['cluster_name'] = 'test-cluster'
+        inventory['values'] = {
+            'var1': '{% set cluster_name = "redefined" %}{{ cluster_name }}',
+            'var2': '{{ cluster_name }}',
+        }
+
+        cluster = demo.new_cluster(inventory)
+        values = cluster.inventory['values']
+
+        self.assertEqual("redefined", values['var1'])
+        self.assertEqual("test-cluster", values['var2'])
+
+    def test_cyclic_references(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['values'] = {
+            'var0': '{{ values.var1 }}',
+            'var1': '{{ values.var3 }}',
+            'var2': '{{ values.var1 }}',
+            'var3': '{{ values.var2 }}',
+        }
+
+        with test_utils.assert_raises_regex(self, ValueError, re.escape(
+                "Cyclic dynamic variables in inventory['values']['var1'] -> ['values']['var3'] -> ['values']['var2']")):
+            demo.new_cluster(inventory)
+
+    def test_cyclic_references_proxy_types(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['values'] = {
+            'var1': [1, '{{ values.var3 }}', '{{ values.var2 }}', 4],
+            'var2': '{{ values.var1[1] }}',
+            'var3': '{{ values.var1[1:][:2][1] }}',
+        }
+
+        with test_utils.assert_raises_regex(self, ValueError, re.escape(
+                "Cyclic dynamic variables in inventory"
+                "['values']['var1'][1] -> ['values']['var3'] -> ['values']['var1'][2] -> ['values']['var2']")):
+            demo.new_cluster(inventory)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/core/test_run_actions.py
+++ b/test/unit/core/test_run_actions.py
@@ -25,7 +25,7 @@ from test.unit import utils as test_utils
 import yaml
 
 from kubemarine import demo, kubernetes, testsuite, procedures
-from kubemarine.core import flow, errors, action, utils, schema, resources as res, summary, defaults
+from kubemarine.core import flow, action, utils, schema, resources as res, summary, defaults
 from kubemarine.core.cluster import KubernetesCluster, EnrichmentStage
 from kubemarine.core.yaml_merger import default_merger
 from kubemarine.procedures import upgrade, install, check_iaas, check_paas, migrate_kubemarine
@@ -116,11 +116,8 @@ class RunActionsTest(test_utils.CommonTest):
         if exception_message is None:
             flow.run_actions(resources, actions)
         else:
-            with self.assertRaisesRegex(Exception, exception_message):
-                try:
-                    flow.run_actions(resources, actions)
-                except errors.FailException as e:
-                    raise e.reason
+            with test_utils.assert_raises_regex(self, Exception, exception_message):
+                flow.run_actions(resources, actions)
 
         return resources.cluster(EnrichmentStage.LIGHT).uploaded_archives
 

--- a/test/unit/test_defaults.py
+++ b/test/unit/test_defaults.py
@@ -438,6 +438,18 @@ class PrimitiveValuesAsString(unittest.TestCase):
 
         self.assertEqual(True, inventory['plugins']['kubernetes-dashboard']['install'])
 
+    def test_recursive_reference_primitive_template(self):
+        inventory = demo.generate_inventory(**demo.ALLINONE)
+        inventory['plugins'] = {'my_plugin': {
+            'var1': '{% if plugins.my_plugin.install %}unexpected{% else %}ok{% endif %}',
+            'install': '{{ "false" }}',
+        }}
+
+        cluster = demo.new_cluster(inventory)
+        inventory = cluster.inventory
+        self.assertEqual(False, inventory['plugins']['my_plugin']['install'])
+        self.assertEqual('ok', inventory['plugins']['my_plugin']['var1'])
+
     def _actual_sysctl_params(self, cluster: demo.FakeKubernetesCluster, node: NodeGroup) -> Set[str]:
         return {
             record.split(' = ')[0]

--- a/test/unit/test_k8s_cert.py
+++ b/test/unit/test_k8s_cert.py
@@ -18,7 +18,7 @@ from unittest import mock
 from test.unit import utils as test_utils
 
 from kubemarine import demo, plugins
-from kubemarine.core import flow, errors
+from kubemarine.core import flow
 from kubemarine.plugins import nginx_ingress
 from kubemarine.procedures import cert_renew
 
@@ -94,15 +94,12 @@ class IngressNginxCertTest(unittest.TestCase):
         return self.cert_renew.setdefault('nginx-ingress-controller', {})
 
     def _run_and_check(self, called: bool) -> demo.FakeResources:
-        with mock.patch.object(plugins, plugins.install_plugin.__name__) as run:
+        with mock.patch.object(plugins, plugins.install_plugin.__name__) as run, test_utils.unwrap_fail():
             resources = test_utils.FakeResources(self.context, self.inventory,
                                                  procedure_inventory=self.cert_renew,
                                                  nodes_context=demo.generate_nodes_context(self.inventory))
             try:
                 flow.run_actions(resources, [cert_renew.CertRenewAction()])
-            except errors.FailException as e:
-                if e.reason is not None:
-                    raise e.reason
             finally:
                 self.assertEqual(called, run.called)
 

--- a/test/unit/test_migrate_kubemarine.py
+++ b/test/unit/test_migrate_kubemarine.py
@@ -1012,7 +1012,7 @@ class RunPatchesSequenceTest(unittest.TestCase):
 
     @contextmanager
     def _assert_raises_kme(self):
-        with self.assertRaisesRegex(errors._BaseKME, "KME"):
+        with self.assertRaisesRegex(errors.BaseKME, "KME"):
             try:
                 yield
             except errors.FailException as e:

--- a/test/unit/test_migrate_kubemarine.py
+++ b/test/unit/test_migrate_kubemarine.py
@@ -1012,11 +1012,8 @@ class RunPatchesSequenceTest(unittest.TestCase):
 
     @contextmanager
     def _assert_raises_kme(self):
-        with self.assertRaisesRegex(errors.BaseKME, "KME"):
-            try:
-                yield
-            except errors.FailException as e:
-                raise e.reason
+        with self.assertRaisesRegex(errors.BaseKME, "KME"), test_utils.unwrap_fail():
+            yield
 
     def test_reinstall_dashboard_change_inventory_run_other_patch_collect_summary(self):
         for change_hostname in (False, True):


### PR DESCRIPTION
### Description
* We have own implementation of compilation of jinja templates with both iterative and recursive compilation.
* Due to iterative compilation, some default features of jinja do not work.
* Recursive compilation is supported only for some custom [filters](https://jinja.palletsprojects.com/en/3.0.x/templates/#filters), but not for the jinja's default ones.
* To use primitive values (like plugins.install) inside templates we have to use filters like `is_true`, `is_false`.
* Finally, there is no control over the compilation process
    * May complicate development (e.g. changing of inventory format)
    * Does not handle infinite recursion.

### Solution
* Instead of iterative and recursive compilation, only recursive compilation is left.
* In recursive compilation, any access to the inventory sections inside templates, is *proxied*.
* Implemented proxies for sequence, mapping, and slice.
* The proxies support recursive compilation in a generic way (not only for custom filters), automatically convert primitive values, and support other customization of work with the particular inventory sections.

### Breaking changes
* Compilation result for templates like `'{{ "{{ values.variable }}" | b64encode }}'` has changed.
  It is necessary to use simpler `'{{ values.variable | b64encode }}'` with the same result.

### Test Cases

**TestCase 1**

Fix a couple of escaping problems.

```yaml
values:
  var1: "{{ '{{ .Name }}' }}"
  var2: A
  var3: '{% raw %}{{ raw1 }}{% endraw %}{{ values.var2 }}{% raw %}{{ raw2 }}{% endraw %}{{ values.var2 }}'
```

ER:
```yaml
values:
  var1: '{{ .Name }}'
  var2: A
  var3: '{{ raw1 }}A{{ raw2 }}A'
```

AR:
* values.var1 is not compiled
* values.var3 is compiled to `{{ raw1 }}AA{{ raw2 }}`

**TestCase 2**

Templates with default filters.

```yaml
values:
  var1: '{{ values.var2 | int }}'
  var2: '{{ 1 }}'
```

ER:

```yaml
values:
  var1: '1'
  var2: '1'
```

AR:

```yaml
values:
  var1: '0'
  var2: '1'
```

**TestCase 3**

Reference to primitive values.

```yaml
plugins:
  my_plugin:
    var1: '{% if plugins.my_plugin.install %}unexpected{% else %}ok{% endif %}'
    install: '{{ "false" }}'
```

ER:

```yaml
plugins:
  my_plugin:
    install: false
    var1: ok
```

AR:

```yaml
plugins:
  my_plugin:
    install: false
    var1: unexpected
```

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_jinja.py - different compilation cases
test_defaults.py - reference to primitive values.
test_cluster.py - compilation at light stage
test_coredns.py, test_templates.py - resolve some gaps in unit testing of compilation.
