### PR TITLE
[CPDEV-101094] possibility to override etcdctl parameters

### DIFF
--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -23,9 +23,11 @@ from typing import List
 
 from kubemarine.core.patch import Patch
 from kubemarine.patches.preserve_compatibility_kernel import PreserveCompatibilityKernel
+from kubemarine.patches.reinstall_etcdctl_thirdparty import ReinstallEtcdctl
 
 patches: List[Patch] = [
     PreserveCompatibilityKernel(),
+    ReinstallEtcdctl(),
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/reinstall_etcdctl_thirdparty.py
+++ b/kubemarine/patches/reinstall_etcdctl_thirdparty.py
@@ -24,12 +24,7 @@ class TheAction(Action):
         super().__init__("Reinstall etcdctl thirdparty")
 
     def run(self, res: DynamicResources) -> None:
-        logger = res.logger()
         cluster = res.cluster()
-        if cluster.inventory['services']['cri']['containerRuntime'] == 'docker':
-            logger.info("Docker cri is used, updating etcdctl thirdparty is not needed")
-            return
-
         cluster.log.info("Update /usr/bin/etcdctl thirdparty")
         install_thirdparty(cluster.nodes['all'], '/usr/bin/etcdctl')
 

--- a/kubemarine/patches/reinstall_etcdctl_thirdparty.py
+++ b/kubemarine/patches/reinstall_etcdctl_thirdparty.py
@@ -1,0 +1,51 @@
+# Copyright 2021-2023 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from textwrap import dedent
+
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine.thirdparties import install_thirdparty
+
+
+class TheAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Reinstall etcdctl thirdparty")
+
+    def run(self, res: DynamicResources) -> None:
+        logger = res.logger()
+        cluster = res.cluster()
+        if cluster.inventory['services']['cri']['containerRuntime'] == 'docker':
+            logger.info("Docker cri is used, updating etcdctl thirdparty is not needed")
+            return
+
+        cluster.log.info("Update /usr/bin/etcdctl thirdparty")
+        install_thirdparty(cluster.nodes['all'], '/usr/bin/etcdctl')
+
+
+class ReinstallEtcdctl(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("reinstall_etcdctl")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            This patch reinstalls etcdctl thirdparty.
+            """.rstrip()
+        )

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -201,7 +201,8 @@ def import_etcd(cluster: KubernetesCluster) -> None:
         control_plane_conn.sudo(
             f'chmod 777 {snap_name} && '
             f'sudo ls -la {snap_name} && '
-            f'sudo etcdctl snapshot restore {snap_name} '
+            f'sudo ETCD_IMAGE="{etcd_image}" ETCD_CERT="{etcd_cert}" ETCD_KEY="{etcd_key}" ETCD_CA="{etcd_cacert}" '
+            f'ETCD_ENDPOINTS="{initial_cluster}" ETCD_MOUNTS="{mount_options}" etcdctl snapshot restore {snap_name} '
             f'--name={control_plane["name"]} '
             f'--data-dir=/var/lib/etcd/snapshot '
             f'--initial-cluster={initial_cluster} '


### PR DESCRIPTION
### Description
During restore procedure user can override etcd image with `restore_plan.etcd.image` parameter. But in real, this image is applied only to etcd container, but not in etcdctl.
As result etcdctl gets the image from the manifests, pulls it and restores snapshot, but when etcd runs then, it fails with image not found exception.

Fixes # (issue)


### Solution
* Added the possibility to override the image (and other etcd parameters in etcdctl);
* Fixed `etcdctl restore snapshot` command in `restore` procedure with custom etcd image/certs/mounts, that is calculated before;
* Provided the patch, that uploads the new etcdctl thirdparty on the nodes;


### How to apply

### Test Cases
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: kubernetes version v1.28.4 (it uses etcd 3.5.9);

Steps:

1. Run `kubemarine install`;
2. Run `kubemarine backup`;
3. Run `kubemarine restore` with `restore_plan.etcd.image=registry.k8s.io/etcd:3.5.10-0`;

Results:

| Before | After |
| ------ | ------ |
| `restore` procedure fails with `ctr: image "artifactorycn.netcracker.com:17115/etcd:3.5.10-0": not found` | Successful procedure |
| `etcdctl restore snapshot` uses etcd:3.5.9 (from the manifest) | `etcdctl restore snapshot` uses etcd:3.5.10 |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


