### PR TITLE
[PSUPCLPL-15272] IPIP connectivity check rework

### DIFF
--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -1325,7 +1325,7 @@ def ipip_connectivity(cluster: KubernetesCluster) -> None:
             raise TestWarn("Check cannot be completed", hint='\n'.join(skipped_msgs))
 
         if failed_nodes:
-            raise TestFailure(f"Check firewall settings, IP in IP traffic is not allowed between nodes.",
+            raise TestFailure(f"Check firewall settings for all nodes in the cluster, IP in IP traffic is not allowed between nodes.",
                               hint='\n'.join(failed_nodes))
 
 
@@ -1350,20 +1350,42 @@ def check_ipip_tunnel(group: NodeGroup) -> Set[str]:
     fake_addr = str(ipaddress.IPv4Address(int_ip))
     # That is used as number of packets for transmitter
     timeout = int(cluster.inventory['globals']['timeout_download'])
-    for node in group.get_ordered_members_configs_list():
-        host = node['internal_address']
-        # Transmitter start command
-        # Transmitter starts first and sends IPIP packets every 1 second until the timeout comes or
-        # the process is killed by terminating command
-        trns_item_cmd: List[str] = []
-        for node_item in group.get_ordered_members_configs_list():
-            if node_item['internal_address'] != host:
-                trns_item_cmd.append(f"nohup {ipip_check} -mode client -src {host} -int {fake_addr} "
-                                     f"-ext {node_item['internal_address']} -dport {random_port} "
-                                     f"-msg {msg} -timeout {timeout} > /dev/null 2>&1 & echo $! >> {ipip_check}.pid")
-        trns_cmd[host] = '& sudo '.join(trns_item_cmd)
-        # Receiver start command
-        # Receiver starts after the transmitter and try to get IPIP packets within 3 seconds from eache node
+    nodes_list = group.get_ordered_members_configs_list()
+    # The ring circuit is used for the procedure. Each node in the ring transmit IPIP packets to the next node in the ring
+    # and receive IPIP packets from the previous node of the ring.
+    # That makes check more robast to some IP filters implementation.
+    recv_neighbor_node: Dict[str, str] = {}
+    trns_neighbor_host = ""
+    if len(nodes_list) > 2:
+        node_number = 0
+        for node in nodes_list:
+            host = node['internal_address']
+            if node_number < len(nodes_list) - 1:
+                recv_neighbor_node[nodes_list[node_number + 1]['name']] = node['name']
+                trns_neighbor_host = nodes_list[node_number + 1]['internal_address']
+            else:
+                recv_neighbor_node[nodes_list[0]['name']] = node['name']
+                trns_neighbor_host = nodes_list[0]['internal_address']
+            # Transmitter start command
+            # Transmitter starts first and sends IPIP packets every 1 second until the timeout comes or
+            # the process is killed by terminating command
+            trns_cmd[host] = f"nohup {ipip_check} -mode client -src {host} -int {fake_addr} " \
+                             f"-ext {trns_neighbor_host} -dport {random_port} " \
+                             f"-msg {msg} -timeout {timeout} > /dev/null 2>&1 & echo $! >> {ipip_check}.pid"
+            # Receiver start command
+            # Receiver starts after the transmitter and try to get IPIP packets within 3 seconds from neighbor node
+            recv_cmd[host] = f"{ipip_check} -mode server -ext {host} -int {fake_addr} -dport {random_port} " \
+                             f"-msg {msg} -timeout 3 2> /dev/null"
+            node_number += 1
+    else:
+        # Two nodes have only one transmitter and only one receiver
+        host = nodes_list[0]['internal_address']
+        recv_neighbor_node[nodes_list[1]['name']] = nodes_list[0]['name']
+        trns_neighbor_host = nodes_list[1]['internal_address']
+        trns_cmd[host] = f"nohup {ipip_check} -mode client -src {host} -int {fake_addr} " \
+                         f"-ext {trns_neighbor_host} -dport {random_port} " \
+                         f"-msg {msg} -timeout {timeout} > /dev/null 2>&1 & echo $! >> {ipip_check}.pid"
+        host = nodes_list[1]['internal_address']
         recv_cmd[host] = f"{ipip_check} -mode server -ext {host} -int {fake_addr} -dport {random_port} " \
                          f"-msg {msg} -timeout 3 2> /dev/null"
 
@@ -1373,18 +1395,20 @@ def check_ipip_tunnel(group: NodeGroup) -> Set[str]:
         group.put(binary_check_path, f"{ipip_check}.gz")
         group.sudo(f"gzip -d {ipip_check}.gz")
         group.sudo(f"sudo chmod +x {ipip_check}")
-        # Run transmitters
+        # Run transmitters if it's applicable for node
         cluster.log.debug("Run transmitters")
         with group.new_executor() as exe:
             for node_exe in exe.group.get_ordered_members_list():
                 host_int = node_exe.get_config()['internal_address']
-                node_exe.sudo(f"{trns_cmd[host_int]}")
-        # Run receivers and get results
+                if trns_cmd.get(host_int, ""):
+                    node_exe.sudo(f"{trns_cmd[host_int]}")
+        # Run receivers and get results if it's applicable for node
         cluster.log.debug("Run receivers")
         with group.new_executor() as exe:
             for node_exe in exe.group.get_ordered_members_list():
                 host_int = node_exe.get_config()['internal_address']
-                node_exe.sudo(f"{recv_cmd[host_int]}", warn=True, callback=collector)
+                if recv_cmd.get(host_int, ""):
+                    node_exe.sudo(f"{recv_cmd[host_int]}", warn=True, callback=collector)
 
         for host, item in collector.result.items():
             node_name = cluster.get_node_name(host)
@@ -1392,9 +1416,10 @@ def check_ipip_tunnel(group: NodeGroup) -> Set[str]:
             if len(item.stdout) > 0:
                 for log_item in item.stdout.split("\n")[:-1]:
                     item_list.add(log_item)
-            for node in group.get_ordered_members_configs_list():
-                if node['internal_address'] not in item_list and node['connect_to'] != host:
-                    failed_nodes.add(f"{node['name']} -> {node_name}")
+            # Check if the neighbor IP is in logs
+            trns_node = group.get_member_by_name(recv_neighbor_node[node_name]).get_config()
+            if trns_node['internal_address'] not in item_list:
+                failed_nodes.add(f"{trns_node['name']} -> {node_name}")
 
         return failed_nodes
     finally:

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -1384,11 +1384,11 @@ def check_ipip_tunnel(group: NodeGroup) -> Set[str]:
         recv_neighbor_node[nodes_list[1]['name']] = nodes_list[0]['name']
         trns_neighbor_host = nodes_list[1]['internal_address']
         trns_cmd[host] = f"nohup {ipip_check} -mode client -src {host} -int {fake_addr} " \
-                         f"-ext {trns_neighbor_host} -dport {random_port} " \
+                         f"-ext {trns_neighbor_host} -sport {random_sport} -dport {random_dport} " \
                          f"-msg {msg} -timeout {timeout} > /dev/null 2>&1 & echo $! >> {ipip_check}.pid"
         host = nodes_list[1]['internal_address']
-        recv_cmd[host] = f"{ipip_check} -mode server -ext {host} -int {fake_addr} -dport {random_port} " \
-                         f"-msg {msg} -timeout 3 2> /dev/null"
+        recv_cmd[host] = f"{ipip_check} -mode server -ext {host} -int {fake_addr} -sport {random_sport} " \
+                         f"-dport {random_dport} -msg {msg} -timeout 3 2> /dev/null"
 
     try:
         collector = CollectorCallback(group.cluster)

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -1335,7 +1335,8 @@ def check_ipip_tunnel(group: NodeGroup) -> Set[str]:
     cluster = group.cluster
 
     # Copy binaries to the nodes
-    random_port = str(random.randint(50000, 65535))
+    random_sport = str(random.randint(50000, 65535))
+    random_dport = str(random.randint(50000, 65535))
     failed_nodes: Set[str] = set()
     recv_cmd: Dict[str, str] = {}
     trns_cmd: Dict[str, str] = {}
@@ -1370,12 +1371,12 @@ def check_ipip_tunnel(group: NodeGroup) -> Set[str]:
             # Transmitter starts first and sends IPIP packets every 1 second until the timeout comes or
             # the process is killed by terminating command
             trns_cmd[host] = f"nohup {ipip_check} -mode client -src {host} -int {fake_addr} " \
-                             f"-ext {trns_neighbor_host} -dport {random_port} " \
+                             f"-ext {trns_neighbor_host} -sport {random_sport} -dport {random_dport} " \
                              f"-msg {msg} -timeout {timeout} > /dev/null 2>&1 & echo $! >> {ipip_check}.pid"
             # Receiver start command
             # Receiver starts after the transmitter and try to get IPIP packets within 3 seconds from neighbor node
-            recv_cmd[host] = f"{ipip_check} -mode server -ext {host} -int {fake_addr} -dport {random_port} " \
-                             f"-msg {msg} -timeout 3 2> /dev/null"
+            recv_cmd[host] = f"{ipip_check} -mode server -ext {host} -int {fake_addr} -sport {random_sport}" \
+                             f" -dport {random_dport} -msg {msg} -timeout 3 2> /dev/null"
             node_number += 1
     else:
         # Two nodes have only one transmitter and only one receiver

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -1328,6 +1328,11 @@ def ipip_connectivity(cluster: KubernetesCluster) -> None:
             raise TestFailure(f"Check firewall settings for all nodes in the cluster, "
                               "IP in IP traffic is not allowed between nodes.", hint='\n'.join(failed_nodes))
 
+        if group.nodes_amount() == 2:
+            skipped_msgs.append("Change nodes order in 'cluster.yaml' and run the check "
+                                "10 minutes later")
+            raise TestWarn("Check has been succeded for the second node but cannot be completed for "
+                           "the first node", hint='\n'.join(skipped_msgs))
 
 def check_ipip_tunnel(group: NodeGroup) -> Set[str]:
 

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -1325,8 +1325,8 @@ def ipip_connectivity(cluster: KubernetesCluster) -> None:
             raise TestWarn("Check cannot be completed", hint='\n'.join(skipped_msgs))
 
         if failed_nodes:
-            raise TestFailure(f"Check firewall settings for all nodes in the cluster, IP in IP traffic is not allowed between nodes.",
-                              hint='\n'.join(failed_nodes))
+            raise TestFailure(f"Check firewall settings for all nodes in the cluster, "
+                              "IP in IP traffic is not allowed between nodes.", hint='\n'.join(failed_nodes))
 
 
 def check_ipip_tunnel(group: NodeGroup) -> Set[str]:


### PR DESCRIPTION
### Description
* The `network.ipip_connectivity` task in `check_iaas` could return incorrect results due to IaaS level firewall rules. For instance, in OpenStack set of `Iptables` rules that implements the `Security Group`. That `Iptables` rules allow the `ESTABLISHED` and `RELATED` packets which leads to the following case. IPIP packets moving from VM-1 to VM-2 are blocked, but the IPIP packets from VM-2 to VM-1 are allowed as they look like `RELATED` packets whereas, IPIP traffic is not allowed in `Security Group` at all for VM-1 and VM-2.
* In this case, the only way to check the IPIP connectivity in cluster is to avoid IPIP packets movement from VM-1 to VM-2 and vice versa. Therefore, VM-1 must send packets to VM-2 and VM-2 to VM-3 and VM-3 must send packets to VM-1 (if there are three nodes in the cluster). That approach is not comprehensive (it doesn't take in to account the connectivity from VM-1 to VM-3 and from VM-2 to VM-1 ), but allows to check IPIP connectivity in general in the particular cluster.
* There is no possibility to set the source port in `ipip_check`

### Solution
* Organize ring topology in the `network.ipip_connectivity` procedure
* Add input `sport` parameter

### How to apply
Not applicable


### Test Cases

**TestCase 1**
Check if the new approach is working

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 

Steps:

1. Prepare OpenStack instances as Kubernetes cluster nodes. 
2. Set `Security Group` to allow all IPv4 egress traffic and not allow IPIP ingress traffic.  
3. Run `check_iaas` with `--tasks "network.ipip_connectivity"` option several times in a row.
4. Change `Security Group` to allow IPIP ingress traffic for some of the cluster nodes. 
5. Run `check_iaas` with `--tasks "network.ipip_connectivity"` option several time in a row.

Results:

| Before | After |
| ------ | ------ |
| Results vary; Results do not match the `Security Group` rules | Results are the same; Results match the `Security Group` rules |
| Results vary; Results do not match the `Security Group` rules | Results are the same; Results match the `Security Group` rules |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Integration CI passed
- [x] There is no merge conflicts


