### PR TITLE
Fix unit tests on macos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        # macos-latest resolves to macos-14-arm64 which does not have python 3.7
+        os: [ macos-13, ubuntu-latest, windows-latest ]
         python-version:
           - "3.7"
           - "3.8"


### PR DESCRIPTION
### Description
* Unit tests on macos-latest fail with "Error: The version '3.7' with architecture 'arm64' was not found for macOS 14.4.1."

### Solution
* Use macos-13

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


