### PR TITLE
[CPDEV-100676]_kubernetes.pods_for_pods_in_CrashLoopBackOff

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -626,7 +626,7 @@ def kubernetes_nodes_condition(cluster: KubernetesCluster, condition_type: str) 
 
 def get_not_running_pods(cluster: KubernetesCluster) -> str:
     # Completed pods should be excluded from the list as well
-    get_pods_cmd = ('kubectl get pods -A --field-selector status.phase!=Running '
+    get_pods_cmd = ('kubectl get pods -A | grep -v Running '
                     '| awk \'{ print $1" "$2" "$4 }\' | grep -vw Completed || true')
     result = cluster.nodes['control-plane'].get_any_member().sudo(get_pods_cmd)
     cluster.log.verbose(result)


### PR DESCRIPTION
### Description
The change involves modifying the command used to retrieve non-running pods in a Kubernetes cluster. Instead of using **kubectl get pods -A --field-selector status.phase!=Running**, which fetches all pods except those in the "Running" state, the revised command **kubectl get pods -A | grep -v Running** is proposed. This new command fetches all pods and then filters out those that are in the "Running" state.


Fixes # ([CPDEV-100676](https://tms.netcracker.com/browse/CPDEV-100676))


### Solution
Adjusting the Command:
Replace **kubectl get pods -A --field-selector status.phase!=Running** with **kubectl get pods -A | grep -v Running** in the shell command string constructed within the function.
This modification ensures that all pods are retrieved first, regardless of their status, and then filters out only the pods that are in the "**Running**" state using grep -v Running.




### Test Cases

**TestCase 1**


Steps:

1. Run **kubemarine check_paas --tasks kubernetes.pods** on a cluster where some of the pods are in CrashLoopBackOff state in system_namespaces 

Results:

| Before | After |
| ------ | ------ |
| Fails to show pods which are in CrashLoopBackOff | Considers pods which are in CrashLoopBackOff  aswell  |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


