### PR TITLE
[CPDEV-101285] Reconfigure sysctl

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2779,6 +2779,8 @@ The following settings are supported in the extended format:
 
 **Note**: Per-node [patches](#patches) are also supported for this section.
 
+**Note**: Kernel parameters can be reconfigured after installation using [Reconfigure Procedure](Maintenance.md#reconfigure-procedure).
+
 **Warning**: Be careful with these settings, they directly affect the hosts operating system.
 
 **Warning**: If the changes to the hosts `sysctl` configurations are detected, a reboot is scheduled. After the reboot, the new parameters are validated to match the expected configuration.
@@ -3844,6 +3846,8 @@ The following settings are supported:
 |**groups**|yes*|`None`|The list of group names to apply the patch to. At least one of `groups` and `nodes` parameters should be provided.|
 |**nodes**|yes*|`None`|The list of node names to apply the patch to. At least one of `groups` and `nodes` parameters should be provided.|
 |**services.sysctl**|no| |Manage the Linux Kernel parameters for the specified nodes in a patch. For more information, see [sysctl](#sysctl).|
+
+**Note**: New patches can be appended after installation using [Reconfigure Procedure](Maintenance.md#reconfigure-procedure).
 
 ### RBAC Admission
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -4058,7 +4058,7 @@ rbac:
 * The custom policies should not have 'oob-' prefix.
 * To manage custom policies on an existing cluster use the `manage_psp` maintenance procedure. 
 
-### Admission PSS
+### Admission pss
 
 Pod Security Standards (PSS) are the replacement for Pod Security Policies (PSP). Originally PSS assumes only three levels 
 (or profiles) of policies. The profiles are the following:

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -150,6 +150,7 @@ System clock should be synchronized the same way as for Cluster nodes system clo
 ### Windows Deployer Restrictions
 
 There are the following restrictions when deploying from Windows:
+
 * [ansible](#ansible) plugin procedures are not supported.
 * All Kubemarine input text files must be in utf-8 encoding.
 
@@ -229,7 +230,7 @@ If you have other solution, remove or switch off the IP firewall before the inst
 unmanaged-devices=interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico
 ```
 
-**Preinstalled software**
+**Preinstalled Software**
 
 * Installation of the following packages is highly recommended; however, Kubernetes can work without them, but may show warnings:
   * ethtool
@@ -272,7 +273,7 @@ For example, specify `conntrack-tools` instead of `conntrack`.
 **Recommended**
 * Logrotate policy for `/var/log/messages` is configured according to the planned load (it is recommended to use limited size and daily rotation)
 
-For more information, refer to _Official Kubernetes Requirements Documentation_
+For more information, refer to the _Official Kubernetes Requirements Documentation_
 at [https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#before-you-begin](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#before-you-begin).
 
 ### Minimal Hardware Requirements
@@ -346,7 +347,7 @@ Mount point:
 ```
 [General H/W recommendations](https://etcd.io/docs/latest/op-guide/hardware/)
 
-### SSH key Recommendation 
+### SSH Key Recommendation 
 
 Before working with the cluster, you need to generate an ssh key. Kubemarine supports following types of keys: *RSA, DSS, ECDSA, Ed25519*.
 
@@ -469,7 +470,7 @@ tolerations:
   effect: <EFFECT>
 ```
 
-A toleration "matches" a taint if the keys are the same and the effects are the same, and:
+A toleration "matches" a taint, if the keys are the same and the effects are the same, and:
 
  * the operator is Exists (in which case no value should be specified), or
  * the operator is Equal and the values are equal.
@@ -601,7 +602,8 @@ For more information about the listed parameters, refer to the following section
 
 Note: To establish an ssh connection, you can use either a keyfile or a password. In case if you are specifying both, keyfile will be considered on priority.
 
-Note: Set an environment variable with the desired password. For example, you can use `export PASS="your_password"`. In the cluster.yaml file, specify the password field using the environment variable syntax. For instance: `password: '{{ env.PASS }}'`. This syntax instructs the code to fetch the value from the PASS environment variable and substitute it into the password field when reading the configuration file. See more details about [environment variables](#environment-variables) 
+Note: Set an environment variable with the desired password. For example, you can use `export PASS="your_password"`. In the cluster.yaml file, specify the password field using the environment variable syntax. For instance: `password: '{{ env.PASS }}'`. This syntax instructs the code to fetch the value from the PASS environment variable and substitute it into the password field when reading the configuration file. See more details about [environment variables](#environment-variables).
+
 ### nodes
 
 In the `nodes` section, it is necessary to describe each node of the future cluster.
@@ -611,7 +613,7 @@ The following options are supported:
 |Name|Type|Mandatory|Default Value|Example|Description|
 |---|---|---|---|---|---|
 |keyfile|string|no| |`/home/username/.ssh/id_rsa`|**Absolute** path to keyfile on local machine to access the cluster machines, Either a keyfile or a password should be provided|
-|password|string|no| |`password@123`|Password to access the cluster machines, Either a keyfile or a password should be provided|
+|password|string|no| |`password@123`|Password to access the cluster machines, either a keyfile or a password should be provided|
 |username|string|no|`root`|`centos`|Username for SSH-access the cluster machines|
 |name|string|no| |`k8s-control-plane-1`|Cluster member name. If omitted, Kubemarine calculates the name by the member role and position in the inventory. Note that this leads to undefined behavior when adding or removing nodes.|
 |address|ip address|no| |`10.101.0.1`|External node's IP-address|
@@ -680,7 +682,6 @@ cluster_name: "k8s-stack.sdntest.example.com"
 For more information, refer to _FQDN_ at https://en.wikipedia.org/wiki/Fully_qualified_domain_name
 
 <!-- #GFCFilterMarkerEnd# -->
-
 
 ### control_plain
 
@@ -857,7 +858,6 @@ registry:
   mirror_registry: "registry.cluster.local"
 ```
 
-
 #### registry (old address-port format)
 
 The following parameters are supported:
@@ -986,6 +986,7 @@ nodes:
 **Note**: If the gateway is not specified on the node, then the connection is direct.
 
 **Note**: To establish an ssh connection, you can use either a keyfile or a password.
+
 ### vrrp_ips
 
 *Installation task*: `deploy.loadbalancer.keepalived`
@@ -998,7 +999,7 @@ nodes:
 For interfaces with the autodetection mode selected, it is automatically detected by the `internal_address` property of the node on which the particular VRRP IP should be set.
 By default, autodetection is enabled.
 
-In order to assign VRRP IP you need to create a `vrrp_ips` section in the inventory and specify the appropriate configuration.
+In order to assign VRRP IP, you need to create a `vrrp_ips` section in the inventory and specify the appropriate configuration.
 You can specify several VRRP IP addresses.
 This configuration will be applied in keepalived configuration on balancer nodes.
 If it's needed, it's possible to specify global parameters or override whole keepalived configuration. More about it is
@@ -1556,7 +1557,7 @@ For more information about these settings, refer to the official Kubernetes docu
 
 *OS specific*: No
 
-In `services.kubeadm_patches` section you can override control-plane pod settings as well as kubelet settings on per node basis.
+In `services.kubeadm_patches` section, you can override control-plane pod settings as well as kubelet settings on per node basis.
 This feature is implemented by using of [kubeadm patches](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/#patches).
 
 **Note**: `patches` feature is available for control-plane pods (etcd, kube-apiserver, kube-controller-manager, kube-scheduler) since Kubernetes **v1.22.0** and for kubelet since Kubernetes **v1.25.0**.
@@ -1599,7 +1600,7 @@ services:
           maxPods: 200
 ```
 
-By default Kubemarine sets `bind-address` parameter of `kube-apiserver` to `node.internal_address` via patches at every control-plane node.
+By default, Kubemarine sets `bind-address` parameter of `kube-apiserver` to `node.internal_address` via patches at every control-plane node.
 
 **Note**: These parameters can be reconfigured after installation using [Reconfigure Procedure](Maintenance.md#reconfigure-procedure).
 
@@ -1671,7 +1672,7 @@ The following parameters are available:
   </tr>
 </table>
 
-**Warning**: It is recommended to use default values. Using values different from default may cause unexpected consequences and no support is provided for consequences.
+**Warning**: It is recommended to use the default values. Using values different from the default may cause an unexpected consequences and no support is provided for consequences.
 
 **Note**: Turning off and then turning on SELinux can lead to the loss of security rules, which were configured earlier.
 
@@ -2361,7 +2362,7 @@ For that kubemarine provide following jinja functions to convert strings:
 * `b64decode` to decode from base64;
 * `url_quote` to use percent-encoding;
 
-**Note**: such functions can be used not only for thirdparties, but in any places and order;
+**Note**: Such functions can be used not only for thirdparties, but in any places and order;
 
 For example, if you use `REG_USERNAME` and `REG_PASSWORD` [environments](#environment-variables) for credentials, you can use following configuration:
 ```yaml
@@ -3031,7 +3032,7 @@ The following parameters are supported:
 |makestep|no|string|`5 -1`|Step the system clock if large correction is needed.|
 |rtcsync|no|boolean|`True`|Specify that RTC should be automatically synchronized by kernel.|
 
-For more information about Chrony configuration, refer to the official documentation at [https://chrony.tuxfamily.org/documentation.html](https://chrony.tuxfamily.org/documentation.html).
+For more information about Chrony configuration, refer to the _Official Chrony Documentation_ at [https://chrony.tuxfamily.org/documentation.html](https://chrony.tuxfamily.org/documentation.html).
 
 The following is a configuration example:
 
@@ -3239,7 +3240,7 @@ Default is `true`.
 
 ##### configmap
 
-This section contains the Configmap parameters that are applied to the Coredns service. By default the following configs are used:
+This section contains the Configmap parameters that are applied to the Coredns service. By default, the following configs are used:
 
 * Corefile - The main Coredns config, which is converted into a template in accordance with the specified parameters.
 * Hosts - IP addresses and names in the format of `/etc/hosts` file. Can be customized with any desired IP addresses and names. 
@@ -3866,7 +3867,7 @@ rbac:
 Pod security policies enable fine-grained authorization of pod creation and updates.
 Pod security policies are enforced by enabling the admission controller. By default, admission controller is enabled during installation.
 
-To configure pod security policies it is required to provide cluster-level `policy/v1beta1/podsecuritypolicy` resource 
+To configure pod security policies, it is required to provide cluster-level `policy/v1beta1/podsecuritypolicy` resource 
 that controls security sensitive aspects of the pod specification. 
 If controller is enabled and no policies are provided, then the system does not allow deployment of new pods.
 Several OOB policies are provided and by default they are enabled during installation. 
@@ -4057,15 +4058,15 @@ rbac:
 * The custom policies should not have 'oob-' prefix.
 * To manage custom policies on an existing cluster use the `manage_psp` maintenance procedure. 
 
-### Admission pss
+### Admission PSS
 
 Pod Security Standards (PSS) are the replacement for Pod Security Policies (PSP). Originally PSS assumes only three levels 
 (or profiles) of policies. The profiles are the following:
-* `Privileged`	- Unrestricted policy, providing the widest possible level of permissions. This policy allows for known privilege 
+* `Privileged` - Unrestricted policy, providing the widest possible level of permissions. This policy allows for known privilege 
 escalations.
-* `Baseline`	- Minimally restrictive policy which prevents known privilege escalations. Allows the default (minimally specified) 
+* `Baseline` - Minimally restrictive policy which prevents known privilege escalations. Allows the default (minimally specified) 
 Pod configuration.
-* `Restricted`	- Heavily restricted policy, following current Pod hardening best practices.
+* `Restricted` - Heavily restricted policy, following current Pod hardening best practices.
 
 There are plenty of rules that included in `baseline` and `restricted` profiles. For more information, refer to 
 [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
@@ -4150,13 +4151,13 @@ The default configuration does not enforce the default policy to any of the pods
       namespaces: ["kube-system"]
 ```
 
-Do not change the namespaces exemption list without strong necessary. In any case check our maintenance guide before any implementation.
+Do not change the namespaces exemption list without strong necessary. In any case, check our Maintenance Guide before any implementation.
 
 #### Application Prerequisites
 
-In case of using PSS the application that installed in Kubernetes cluster should be matched with PSS profiles (`privileged`, 
+In case of using PSS, the application that installed in Kubernetes cluster should be matched with PSS profiles (`privileged`, 
 `baseline`, `restricted`). Those profiles may be set by labeling the namespace so as it described above for predefined plugins. 
-Moreover the application should be compatible with PSS. The `restricted` profile requires the following section in pod description:
+Moreover, the application should be compatible with PSS. The `restricted` profile requires the following section in pod description:
 
 ```yaml
 ...
@@ -4368,7 +4369,7 @@ The plugin configuration supports the following parameters:
 ```
 **Note**: The `CriticalAddonsOnly` toleration key inherits from `Calico` manifest YAML, whereas the rest of toleration keys are represented by Kubemarine itself.
 
-###### Calico metrics configuration
+###### Calico Metrics Configuration
 
 By default, no additional settings are required for Calico metrics. They are enabled by default.
 
@@ -4459,13 +4460,13 @@ plugins:
       FELIX_DEFAULTENDPOINTTOHOSTACTION: DENY
 ```
 
-**Note**: In case of you use IPv6 you have to define `CALICO_ROUTER_ID` with value `hash` in `env` section. This uses a hash of the configured nodename for the router ID.
+**Note**: In case of you use IPv6, you have to define `CALICO_ROUTER_ID` with value `hash` in `env` section. This uses a hash of the configured nodename for the router ID.
 
-For more information about the supported Calico environment variables, refer to the official Calico documentation at [https://docs.projectcalico.org/reference/node/configuration](https://docs.projectcalico.org/reference/node/configuration).
+For more information about the supported Calico environment variables, refer to the _Official Calico Documentation_ at [https://docs.projectcalico.org/reference/node/configuration](https://docs.projectcalico.org/reference/node/configuration).
 
 ###### Calico API server
 
-For details about the Calico API server, refer to the official documentation at [https://docs.tigera.io/calico/latest/operations/install-apiserver](https://docs.tigera.io/calico/latest/operations/install-apiserver).
+For details about the Calico API server, refer to the _Official Documentation_ at [https://docs.tigera.io/calico/latest/operations/install-apiserver](https://docs.tigera.io/calico/latest/operations/install-apiserver).
 
 By default, the Calico API server is not installed. To install it during the Calico installation, specify the following:
 
@@ -4633,7 +4634,8 @@ For example:
 **Warning**: Arguments for ingress-nginx-controller are also added from [nginx-ingress-controller-v*-original.yaml](https://github.com/Netcracker/KubeMarine/blob/main/kubemarine/plugins/yaml/), from other parameters in cluster.yaml (`controller.ssl.enableSslPassthrough` and `controller.ssl.default-certificate`) and `--watch-ingress-without-class=true` is added by default. Make sure there are no conflicts, otherwise the task will be interrupted.
 
 ###### monitoring
-By default 10254 port is opened and provides Prometheus metrics.
+
+By default, 10254 port is opened and provides Prometheus metrics.
 
 ##### kubernetes-dashboard
 
@@ -5125,7 +5127,7 @@ This procedures allows you to automatically compile the Jinja2 template file, up
 
 Inside the templates you can use all the variables defined in the inventory in `cluster.yaml`.
 Moreover, it is possible to dynamically create your own variables in runtime using `python` or `shell` plugin procedures.
-These runtime variables can also be used in templates by accessing `runtime_vars`, for example if you have variable
+These runtime variables can also be used in templates by accessing `runtime_vars`, for example, if you have variable
 `example_var` created in runtime you can access this variable in templates like `runtime_vars['example_var']`
 
 **Note**: You can specify nodes and groups at the same time.
@@ -5617,8 +5619,7 @@ plugins:
  
 ## Advanced Features
 
-Before use, the configuration file **cluster.yaml** is preprocessed. The user settings are merged with default settings, thereby creating the final configuration file, which
-is further used throughout the entire installation.
+Before use, the configuration file **cluster.yaml** is preprocessed. The user settings are merged with default settings, thereby creating the final configuration file, which is further used throughout the entire installation.
 
 **Note**: If [Dump Files](#dump-files) is enabled, then you can see merged **cluster.yaml** file version in the dump directory.
 
@@ -6202,10 +6203,10 @@ $ install --disable-dump-cleanup
 ### Finalized Dump
 
 After any procedure is completed, a final inventory with all the missing variable values is needed, which is pulled from the finished cluster environment.
-This inventory can be found in the `cluster_finalized.yaml` file in the working directory,
+This inventory can be found in the **cluster_finalized.yaml** file in the working directory,
 and can be passed as a source inventory in future runs of Kubemarine procedures.
 
-**Note**: The `cluster_finalized.yaml` inventory file is aimed to reflect the current cluster state together with the Kubemarine version using which it is created.
+**Note**: The **cluster_finalized.yaml** inventory file is aimed to reflect the current cluster state together with the Kubemarine version using which it is created.
 This in particular means that the file cannot be directly used with a different Kubemarine version.
 Though, it still can be migrated together with the managed cluster using the [Kubemarine Migration Procedure](/documentation/Maintenance.md#kubemarine-migration-procedure).
 
@@ -6448,7 +6449,6 @@ For example, if the configurations are not updated, then a reboot for applying t
 For more detailed information, see the description of the tasks and their parameters.
 If the task is skipped, then it is not able to schedule the cumulative point. For example, by skipping certain tasks, you can avoid a reboot.
 
-
 # Supported Versions
 
 **Note**: You can specify Kubernetes version via `kubernetesVersion` parameter. See [Kubernetes version](#kubernetes-version) section for more details.
@@ -6458,6 +6458,7 @@ If the task is skipped, then it is not able to schedule the cumulative point. Fo
 The tables below shows the correspondence of versions that are supported and is used during the installation:
 
 ## Default Dependent Components Versions for Kubernetes Versions v1.23.17
+
 | Type     | Name                                                           | Versions         |                              |              |              |                   |           |           | Note                                                                                                       |
 |----------|----------------------------------------------------------------|------------------|------------------------------|--------------|--------------|-------------------|-----------|-----------|------------------------------------------------------------------------------------------------------------|
 |          |                                                                | CentOS RHEL 7.5+ | CentOS RHEL Oracle Linux 8.4 | Ubuntu 20.04 | Ubuntu 22.04 | Oracle Linux 7.5+ | RHEL 8.6+ | RockyLinux 8.6+ |                                                                                                            |

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -162,7 +162,7 @@ By default, it is not required to provide information about thirdparties.
 They are upgraded automatically as required.
 You can provide this information if you want to have better control over their versions.
 Also, you have to explicitly provide thirdparties `source` if you have specified this information in the `cluster.yaml`.
-It is because in this case, you take full control over the thirdparties' versions and the defaults do not apply.
+It is because in this case, you take a full control over the thirdparties' versions and the defaults do not apply.
 
 #### Packages Upgrade Patches
 
@@ -213,9 +213,9 @@ upgrade:
         image: 'calico/node:v3.25.1'
 ```
 
-After applying, this configuration is merged with the plugins' configuration contained in the current `cluster.yaml`.
+After applying, this configuration is merged with the plugins' configuration contained in the current **cluster.yaml**.
 
-**Note**: If you have changed images for any of the plugins in the `cluster.yaml`,
+**Note**: If you have changed images for any of the plugins in the **cluster.yaml**,
 it is required to explicitly specify new images in the procedure inventory for those plugins.
 The configuration format for the plugins is the same.
 
@@ -269,7 +269,7 @@ UPGRADING KUBERNETES v1.18.8 ⭢ v1.19.3
 ------------------------------------------
 ```
 
-The script upgrades Kubernetes versions one-by-one. After each upgrade, the `cluster.yaml` is regenerated to reflect the actual cluster state. Use the latest updated `cluster.yaml` configuration to further work with the cluster.
+The script upgrades Kubernetes versions one-by-one. After each upgrade, the **cluster.yaml** is regenerated to reflect the actual cluster state. Use the latest updated **cluster.yaml** configuration to further work with the cluster.
 
 Additionally, Kubemarine cleans up the `/etc/kubernetes/tmp` directory before the upgrade, where kubeadm stores the [backup files](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/#recovering-from-a-failure-state)
 during the upgrade. For this reason, only the backups for the latest upgrade through Kubemarine are placed here after the upgrade procedure.
@@ -347,7 +347,7 @@ etcd:
 
 #### Thirdparties Upgrade Section and Task
 
-If the cluster is located in an isolated environment, it is possible to specify the custom paths to new thirdparties with the same syntax as in the `cluster.yaml` as shown in the following script:
+If the cluster is located in an isolated environment, it is possible to specify the custom paths to new thirdparties with the same syntax as in the **cluster.yaml** as shown in the following script:
 
 ```yaml
 v1.24.2:
@@ -362,7 +362,7 @@ v1.24.2:
         source: https://example.com/thirdparty.files/projectcalico/calico/v3.22.2/calicoctl-linux-amd64
 ```
 
-This configuration replaces the configuration contained in the current `cluster.yaml`.
+This configuration replaces the configuration contained in the current **cluster.yaml**.
 
 #### Kubernetes Upgrade Task
 
@@ -1031,13 +1031,13 @@ You can find description and examples of the accepted parameters in the next sec
 The JSON schema for procedure inventory is available by [URL](../kubemarine/resources/schemas/reconfigure.json?raw=1).
 For more information, see [Validation by JSON Schemas](Installation.md#inventory-validation).
 
-**Common considerations**
+**Common Considerations**
 
-Each section from the procedure inventory is merged with the corresponding section in the main `cluster.yaml`,
+Each section from the procedure inventory is merged with the corresponding section in the main **cluster.yaml**,
 and the related services are reconfigured based on the resulting inventory.
 
 Additionally, it is possible to supply empty section describing a particular service for most services.
-This does not introduce new changes in the `cluster.yaml`, but still triggers the reconfiguring,
+This does not introduce new changes in the **cluster.yaml**, but still triggers the reconfiguring,
 and thus allows to make the cluster and the inventory consistent to each other.
 
 Also, Kubemarine detects effectively changed settings of the services, if ones depend on the others, and reconfigures the dependent services accordingly.
@@ -1135,14 +1135,14 @@ services:
 
 </details>
 
-The above configuration is merged with the corresponding sections in the main `cluster.yaml`,
+The above configuration is merged with the corresponding sections in the main **cluster.yaml**,
 and the related Kubernetes components are reconfigured based on the resulting inventory.
 
 In this way it is not possible to delete some property,
 allowing the corresponding Kubernetes component to fall back to the default behaviour.
 This can be worked around by manual changing of the `cluster.yaml`
 and running the `reconfigure` procedure with **empty** necessary section.
-For example, you can delete `services.kubeadm.etcd.local.extraArgs.election-timeout` from `cluster.yaml`
+For example, you can delete `services.kubeadm.etcd.local.extraArgs.election-timeout` from **cluster.yaml**
 and then run the procedure with the following procedure inventory:
 
 ```yaml
@@ -1198,9 +1198,9 @@ services:
 To make sure that the new settings are preserved after reboot, perform the reboot using [Reboot Procedure](#reboot-procedure),
 and run PaaS check, namely [232 Kernel Parameters Configuration](Kubecheck.md#232-kernel-parameters-configuration).
 
-### Append patches
+### Append Patches
 
-It is possible to **append** new [patches](Installation.md#patches) to the main `cluster.yaml`, and trigger reconfiguring of the corresponding services.
+It is possible to **append** new [patches](Installation.md#patches) to the main **cluster.yaml**, and trigger reconfiguring of the corresponding services.
 
 The following sections are supported in the new patches:
 - `services.sysctl`
@@ -1229,9 +1229,9 @@ Manage PSP procedure works as follows:
 1. During this procedure the custom policies specified for deletion are deleted.
    Then the custom policies specified for addition are added.
 2. If OOB policies are reconfigured or admission controller is reconfigured, then all OOB policies are recreated
-   as configured in the `cluster.yaml` and `procedure.yaml`. The values from `procedure.yaml` take precedence.
+   as configured in the **cluster.yaml** and **procedure.yaml**. The values from **procedure.yaml** take precedence.
    If admission controller is disabled, then all OOB policies are deleted without recreation.
-3. If the admission controller is reconfigured in `procedure.yaml`, then `kubeadm` configmap and `kube-apiserver` manifest is updated accordingly. 
+3. If the admission controller is reconfigured in **procedure.yaml**, then `kubeadm` configmap and `kube-apiserver` manifest is updated accordingly. 
 4. All Kubernetes nodes are `drain-uncordon`ed one-by-one and all daemon-sets are restarted to restart all pods (except system) in order to re-validate pods specifications.
 
 ### Configuring Manage PSP Procedure
@@ -1262,7 +1262,7 @@ psp:
 ```
 
 For example, if admission controller is disabled on existing cluster and you want to enable it, without enabling
-`host-network` OOB policy, you should specify the following in the `procedure.yaml` file:
+`host-network` OOB policy, you should specify the following in the **procedure.yaml** file:
 
 ```yaml
 psp:
@@ -1300,7 +1300,7 @@ The procedure accepts required positional argument with the path to the procedur
 The JSON schema for procedure inventory is available by [URL](../kubemarine/resources/schemas/manage_pss.json?raw=1).
 For more information, see [Validation by JSON Schemas](Installation.md#inventory-validation).
 
-To manage PSS on existing cluster one should configure `procedure.yaml` similar the following:
+To manage PSS on existing cluster one should configure the **procedure.yaml** file similar the following:
 
 ```yaml
 pss:
@@ -1894,10 +1894,12 @@ data:
 
 # Common Practice
 
+The common practice information is given below.
+
 ## Security Hardening Guide
 
-For more information, refer to [Security Hardening Guide](./internal/Hardening.md).
+For more information, refer to the [Security Hardening Guide](./internal/Hardening.md).
 
 ## Worker Nodes Should be Managed by Kubelet
 
-You should not run any containers on worker nodes that are not managed by `kubelet` so as not to break the `kube-scheduler` precision.
+You should not run any containers on worker nodes that are not managed by `kubelet` to avoid breaking the `kube-scheduler` precision.

--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -310,10 +310,24 @@ class KubernetesCluster(Environment):
         return self._products.inventory
 
     @property
+    def previous_nodes_inventory(self) -> Dict[str, dict]:
+        """
+        The previous resulting inventory describing specific nodes before procedure inventory is applied.
+        For `install` and some other procedures this equals to the resulting `KubernetesCluster.nodes_inventory`.
+
+        The inventory can be derived from the `KubernetesCluster.previous_inventory` only,
+        and should not depend on other sources of information.
+
+        The property should be read only, and should be examined primarily at PROCEDURE stage or inside the flow.
+        """
+        return self._previous_products.nodes_inventory
+
+    @property
     def nodes_inventory(self) -> Dict[str, dict]:
         """
         The resulting inventory describing specific nodes.
-        The inventory can be derived from the main `inventory` only,
+
+        The inventory can be derived from the main `KubernetesCluster.inventory` only,
         and should not depend on other sources of information.
 
         Should be changed only during the enrichment.

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -35,7 +35,7 @@ NodeConfig = Dict[str, Any]
 GroupFilter = Union[Callable[[NodeConfig], bool], NodeConfig]
 
 _RESULT = TypeVar('_RESULT', bound=GenericResult, covariant=True)
-_T = TypeVar('_T')
+_T = TypeVar('_T', bound=Union['RunnersGroupResult', bool, None])
 
 
 class GenericGroupResult(Mapping[str, _RESULT]):
@@ -452,7 +452,7 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
         callable_path = "%s.%s" % (func.__module__, func.__name__)
         self.cluster.log.debug("Running %s: " % callable_path)
         result = action(self, **kwargs)
-        if result is not None:
+        if isinstance(result, RunnersGroupResult):
             self.cluster.log.debug(result)
 
         return result

--- a/kubemarine/core/inventory.py
+++ b/kubemarine/core/inventory.py
@@ -19,6 +19,16 @@ from kubemarine.core.cluster import EnrichmentStage, enrichment, KubernetesClust
 from kubemarine.core.yaml_merger import default_merger
 
 
+@enrichment(EnrichmentStage.PROCEDURE, procedures=['reconfigure'])
+def enrich_reconfigure_inventory(cluster: KubernetesCluster) -> None:
+    # Do not apply usual merging strategy, always merge and never override.
+    # This is because `reconfigure` might support to change only subset of sections allowed during installation.
+    # Append reconfiguring patches to the end for them to have priority.
+    procedure_patches = cluster.procedure_inventory.get('patches', [])
+    if procedure_patches:
+        cluster.inventory.setdefault('patches', []).extend(procedure_patches)
+
+
 @enrichment(EnrichmentStage.FULL)
 def verify_inventory_patches(cluster: KubernetesCluster) -> None:
     for i, patch in enumerate(cluster.inventory['patches']):

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -408,6 +408,8 @@ class DynamicResources:
             kubemarine.cri.enrich_upgrade_inventory,
             kubemarine.cri.containerd.enrich_migrate_cri_inventory,
             kubemarine.plugins.nginx_ingress.cert_renew_enrichment,
+            kubemarine.sysctl.enrich_reconfigure_inventory,
+            kubemarine.core.inventory.enrich_reconfigure_inventory,
             # Enrichment of procedure inventory should be finished at this step.
 
             # Convert formatted inventory to native python objects, and merge defaults.

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -21,6 +21,7 @@ from typing import List, Dict, Iterator, Any, Optional
 
 import yaml
 from jinja2 import Template
+from ordered_set import OrderedSet
 
 from kubemarine import system, admission, etcd, packages, jinja, sysctl
 from kubemarine.core import utils, static, summary, log, errors
@@ -194,12 +195,14 @@ def enrich_kube_proxy(cluster: KubernetesCluster) -> None:
     # override kubeadm_kube-proxy.conntrack.min with sysctl.net.netfilter.nf_conntrack_max
     # since they define the same kernel variable
     kubernetes_nodes = cluster.make_group_from_roles(['control-plane', 'worker'])
-    conntrack_max_values = {
+    conntrack_max_values = OrderedSet(
         sysctl.get_parameter(cluster, node, 'net.netfilter.nf_conntrack_max')
-        for node in kubernetes_nodes.get_ordered_members_list()}
+        for node in kubernetes_nodes.get_ordered_members_list()
+    )
 
     if len(conntrack_max_values) > 1:
-        raise Exception(ERROR_AMBIGUOUS_CONNTRACK_MAX.format(values=conntrack_max_values))
+        raise Exception(ERROR_AMBIGUOUS_CONNTRACK_MAX.format(
+            values='{' + ', '.join(map(repr, conntrack_max_values)) + '}'))
 
     conntrack_max = next(iter(conntrack_max_values), None)
     if components.kube_proxy_overwrites_higher_system_values(cluster) and conntrack_max is not None:

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -85,6 +85,9 @@ services:
         profiling: "false"
         terminated-pod-gc-threshold: "1000"
       extraVolumes: []
+    etcd:
+      local:
+        extraArgs: {}
   kubeadm_patches:
     # bind-address flag for apiServer is set in the code
     apiServer: []

--- a/kubemarine/resources/schemas/definitions/patch.json
+++ b/kubemarine/resources/schemas/definitions/patch.json
@@ -8,15 +8,8 @@
     "Patch": {
       "type": "object",
       "properties": {
-        "groups": {
-          "$ref": "common/node_ref.json#/definitions/Roles",
-          "default": ["worker", "control-plane", "balancer"],
-          "description": "The list of group names to apply the patch to"
-        },
-        "nodes": {
-          "$ref": "common/node_ref.json#/definitions/Names",
-          "description": "The list of node names to apply the patch to"
-        },
+        "groups": {"$ref": "#/definitions/PatchGroups"},
+        "nodes": {"$ref": "#/definitions/PatchNodes"},
         "services": {
           "type": "object",
           "description": "Configure settings of different services",
@@ -30,6 +23,15 @@
         }
       },
       "additionalProperties": false
+    },
+    "PatchGroups": {
+      "allOf": [{"$ref": "common/node_ref.json#/definitions/Roles"}],
+      "default": ["worker", "control-plane", "balancer"],
+      "description": "The list of group names to apply the patch to"
+    },
+    "PatchNodes": {
+      "allOf": [{"$ref": "common/node_ref.json#/definitions/Names"}],
+      "description": "The list of node names to apply the patch to"
     }
   }
 }

--- a/kubemarine/resources/schemas/definitions/services/kubeadm_patches.json
+++ b/kubemarine/resources/schemas/definitions/services/kubeadm_patches.json
@@ -5,96 +5,104 @@
   "additionalProperties": false,
   "properties": {
     "apiServer": {
-      "$ref": "#/definitions/control-plane-pod-patch"
+      "$ref": "#/definitions/ControlPlanePodPatches"
     },
     "etcd": {
-      "$ref": "#/definitions/control-plane-pod-patch"
+      "$ref": "#/definitions/ControlPlanePodPatches"
     },
     "controllerManager": {
-      "$ref": "#/definitions/control-plane-pod-patch"
+      "$ref": "#/definitions/ControlPlanePodPatches"
     },
     "scheduler": {
-      "$ref": "#/definitions/control-plane-pod-patch"
+      "$ref": "#/definitions/ControlPlanePodPatches"
     },
     "kubelet": {
-      "$ref": "#/definitions/kubelet-patch"
+      "$ref": "#/definitions/KubeletPatches"
     }
   },
   "definitions": {
-    "control-plane-pod-patch": {
+    "ControlPlanePodPatches": {
       "type": "array",
       "description": "Patches for control-plane pods",
       "minItems": 0,
       "items": {
         "oneOf": [
-          {
-            "allOf": [
-              {
-                "$ref": "../common/node_ref.json#/definitions/OneOfNodesGroupsSpec"
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "patch": {
-                    "$ref": "#/definitions/patch"
-                  },
-                  "groups": {
-                    "$ref": "../common/node_ref.json#/definitions/ControlPlanes"
-                  },
-                  "nodes": {
-                    "$ref": "../common/node_ref.json#/definitions/Names"
-                  }
-                },
-                "required": ["patch"],
-                "additionalProperties": false
-              }
-            ]
-          },
+          {"$ref": "#/definitions/ControlPlanePodPatch"},
           {"$ref": "../common/utils.json#/definitions/ListMergingSymbol"}
         ]
       }
     },
-    "kubelet-patch": {
+    "KubeletPatches": {
       "type": "array",
       "description": "Patches for kubelet",
       "minItems": 0,
       "items": {
         "oneOf": [
-          {
-            "allOf": [
-              {
-                "$ref": "../common/node_ref.json#/definitions/OneOfNodesGroupsSpec"
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "patch": {
-                    "allOf": [{"$ref": "#/definitions/patch"}],
-                    "properties": {
-                      "podPidsLimit": {"$ref": "kubeadm_kubelet.json#/definitions/PodPidsLimit"},
-                      "maxPods": {"$ref": "kubeadm_kubelet.json#/definitions/MaxPods"}
-                    }
-                  },
-                  "groups": {
-                    "$ref": "../common/node_ref.json#/definitions/KubernetesRoles"
-                  },
-                  "nodes": {
-                    "$ref": "../common/node_ref.json#/definitions/Names"
-                  }
-                },
-                "required": ["patch"],
-                "additionalProperties": false
-              }
-            ]
-          },
+          {"$ref": "#/definitions/KubeletPatch"},
           {"$ref": "../common/utils.json#/definitions/ListMergingSymbol"}
         ]
       }
     },
-    "patch": {
+    "ControlPlanePodPatch": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "../common/node_ref.json#/definitions/OneOfNodesGroupsSpec"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "patch": {
+              "$ref": "#/definitions/Flags"
+            },
+            "groups": {
+              "$ref": "../common/node_ref.json#/definitions/ControlPlanes"
+            },
+            "nodes": {
+              "$ref": "../common/node_ref.json#/definitions/Names"
+            }
+          },
+          "required": ["patch"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "KubeletPatch": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "../common/node_ref.json#/definitions/OneOfNodesGroupsSpec"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "patch": {
+              "$ref": "#/definitions/KubeletProperties"
+            },
+            "groups": {
+              "$ref": "../common/node_ref.json#/definitions/KubernetesRoles"
+            },
+            "nodes": {
+              "$ref": "../common/node_ref.json#/definitions/Names"
+            }
+          },
+          "required": ["patch"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Flags": {
       "type": "object",
       "additionalProperties": {
         "type": ["string", "boolean", "integer"]
+      }
+    },
+    "KubeletProperties": {
+      "type": "object",
+      "allOf": [{"$ref": "#/definitions/Flags"}],
+      "properties": {
+        "podPidsLimit": {"$ref": "kubeadm_kubelet.json#/definitions/PodPidsLimit"},
+        "maxPods": {"$ref": "kubeadm_kubelet.json#/definitions/MaxPods"}
       }
     }
   }

--- a/kubemarine/resources/schemas/reconfigure.json
+++ b/kubemarine/resources/schemas/reconfigure.json
@@ -77,9 +77,22 @@
             }
           },
           "additionalProperties": false
+        },
+        "sysctl": {
+          "$ref": "definitions/services/sysctl.json"
         }
       },
       "additionalProperties": false
+    },
+    "patches": {
+      "type": "array",
+      "description": "Override the resulting configuration for specific nodes. The list of patches is appended to the main list of patches in the inventory. Thus, the same settings have precedence in the last patch of the procedure inventory if overridden few times for the same node.",
+      "items": {
+        "allOf": [
+          {"$ref": "definitions/common/node_ref.json#/definitions/AnyOfNodesGroupsSpec"},
+          {"$ref": "#/definitions/PatchReconfigureSupported"}
+        ]
+      }
     }
   },
   "additionalProperties": false,
@@ -88,7 +101,28 @@
       "type": "object",
       "properties": {
         "protectKernelDefaults": {"$ref": "definitions/services/kubeadm_kubelet.json#/definitions/ProtectKernelDefaults"},
+        "podPidsLimit": {"$ref": "definitions/services/kubeadm_kubelet.json#/definitions/PodPidsLimit"},
+        "maxPods": {"$ref": "definitions/services/kubeadm_kubelet.json#/definitions/MaxPods"},
         "serializeImagePulls": {"$ref": "definitions/services/kubeadm_kubelet.json#/definitions/SerializeImagePulls"}
+      },
+      "additionalProperties": false
+    },
+    "PatchReconfigureSupported": {
+      "type": "object",
+      "properties": {
+        "groups": {"$ref": "definitions/patch.json#/definitions/PatchGroups"},
+        "nodes": {"$ref": "definitions/patch.json#/definitions/PatchNodes"},
+        "services": {
+          "type": "object",
+          "description": "Configure settings of different services",
+          "properties": {
+            "sysctl": {
+              "$ref": "definitions/services/sysctl.json",
+              "description": "Manage the Linux Kernel parameters for the specified nodes in a patch"
+            }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     }

--- a/kubemarine/resources/schemas/reconfigure.json
+++ b/kubemarine/resources/schemas/reconfigure.json
@@ -9,11 +9,7 @@
         "kubeadm_kubelet": {
           "type": "object",
           "description": "Override the original settings for the kubelet",
-          "properties": {
-            "protectKernelDefaults": {"$ref": "definitions/services/kubeadm_kubelet.json#/definitions/ProtectKernelDefaults"},
-            "serializeImagePulls": {"$ref": "definitions/services/kubeadm_kubelet.json#/definitions/SerializeImagePulls"}
-          },
-          "additionalProperties": false
+          "allOf": [{"$ref": "#/definitions/KubeletReconfigureSupported"}]
         },
         "kubeadm_kube-proxy": {
           "type": "object",
@@ -24,7 +20,32 @@
           }
         },
         "kubeadm_patches": {
-          "$ref": "definitions/services/kubeadm_patches.json"
+          "type": "object",
+          "allOf": [{"$ref": "definitions/services/kubeadm_patches.json"}],
+          "properties": {
+            "kubelet": {
+              "type": "array",
+              "allOf": [{"$ref": "definitions/services/kubeadm_patches.json#/definitions/KubeletPatches"}],
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "allOf": [{"$ref": "definitions/services/kubeadm_patches.json#/definitions/KubeletPatch"}],
+                    "properties": {
+                      "patch": {
+                        "type": "object",
+                        "allOf": [
+                          {"$ref": "#/definitions/KubeletReconfigureSupported"},
+                          {"$ref": "definitions/services/kubeadm_patches.json#/definitions/KubeletProperties"}
+                        ]
+                      }
+                    }
+                  },
+                  {"$ref": "definitions/common/utils.json#/definitions/ListMergingSymbol"}
+                ]
+              }
+            }
+          }
         },
         "kubeadm": {
           "type": "object",
@@ -61,5 +82,15 @@
       "additionalProperties": false
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "definitions": {
+    "KubeletReconfigureSupported": {
+      "type": "object",
+      "properties": {
+        "protectKernelDefaults": {"$ref": "definitions/services/kubeadm_kubelet.json#/definitions/ProtectKernelDefaults"},
+        "serializeImagePulls": {"$ref": "definitions/services/kubeadm_kubelet.json#/definitions/SerializeImagePulls"}
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/test/unit/test_reconfigure.py
+++ b/test/unit/test_reconfigure.py
@@ -100,7 +100,7 @@ class ReconfigureKubeadmEnrichment(unittest.TestCase):
                 {'<<': 'merge'}
             ],
             'kubelet': [
-                {'groups': ['worker'], 'patch': {'kubelet_kp1': 'kubelet_vp1_new'}}
+                {'groups': ['worker'], 'patch': {'maxPods': 111}}
             ]
         }
 
@@ -164,7 +164,7 @@ class ReconfigureKubeadmEnrichment(unittest.TestCase):
             {'groups': ['control-plane'], 'patch': {'api_kp1': 'api_vp1'}}
         ], kubeadm_patches['apiServer'])
 
-        self.assertEqual([{'groups': ['worker'], 'patch': {'kubelet_kp1': 'kubelet_vp1_new'}}], kubeadm_patches['kubelet'])
+        self.assertEqual([{'groups': ['worker'], 'patch': {'maxPods': 111}}], kubeadm_patches['kubelet'])
 
     def test_change_apiserver_args_check_jinja_dependent_parameters(self):
         self.reconfigure['services']['kubeadm'] = {
@@ -211,7 +211,7 @@ class ReconfigureKubeadmEnrichment(unittest.TestCase):
         self.inventory['services'].setdefault('kubeadm', {})['kubernetesVersion'] = 'v1.25.7'
         self.reconfigure['services']['kubeadm_patches'] = {
             'kubelet': [
-                {'nodes': ['balancer-1'], 'patch': {'key': 'value'}},
+                {'nodes': ['balancer-1'], 'patch': {'maxPods': 111}},
             ]
         }
         with self.assertRaisesRegex(
@@ -237,7 +237,7 @@ class ReconfigureKubeadmEnrichment(unittest.TestCase):
         self.inventory['services'].setdefault('kubeadm', {})['kubernetesVersion'] = kubernetes_version
         self.reconfigure['services']['kubeadm_patches'] = {
             'kubelet': [
-                {'nodes': ['master-1'], 'patch': {'key': 'value'}},
+                {'nodes': ['master-1'], 'patch': {'maxPods': 111}},
             ]
         }
         with self.assertRaisesRegex(


### PR DESCRIPTION
### Description
* If maxPods or podPidsLimit are reconfigured in `services.kubeadm_patches.kubelet`,
  the related kernel parameter kernel.pid_max is not reconfigured.
* PaaS check fails because the parameter value is unexpected.
* The problem appeared after #639 after which calculated kernel.pid_max started to take into account kubeadm patches.

### Solution
* Support to reconfigure `services.sysctl` and `patches` using `reconfigure` procedure.
    * Added task `prepare.system.sysctl`.
    * In comparison to the installation procedure, the task does not trigger reboot.
    * `services.sysctl` is merged with the main inventory, and `patches` can only be appended.
* Implemented detecting of changes in the inventory in `prepare.system.sysctl` and `deploy.kubernetes.reconfigure` tasks.
    * If maxPods or podPidsLimit are changed for kubelet, the dependent kernel.pid_max parameter is reconfigured.
    * If net.netfilter.nf_conntrack_max parameter is changed, the dependent kube-proxy settings are reconfigured.
* Restrict the set of parameters to support reconfiguring in `services.kubeadm_patches.kubelet` to the same as for `services.kubeadm_kubelet`.
    * Support to reconfigure maxPods and podPidsLimit in both sections.

### Test Cases

**TestCase 1**

Basic kernel parameters reconfiguring scenario.

Steps:

1. Run `reconfigure` procedure providing new kernel parameters, or changing the already configured ones using `services.sysctl`, and `patches` in the procedure inventory.

ER: The parameters are reconfigured.

2. Run `check_paas`.

ER: check is successful.

**TestCase 2**

Run procedure with empty `services.sysctl` section.

Steps:

1. Change `services.sysctl` in `cluster.yaml` manually, and configure empty `services: {sysctl: {}}` section in the procedure inventory.
2. Run `reconfigure` procedure.

ER: The parameters are reconfigured.

**TestCase 3**

Change of maxPods or podPidsLimit triggers reconfiguring of sysctl.

Steps:

1. Configure new maxPods or podPidsLimit using `services.kubeadm_patches.kubelet`, or `services.kubeadm_kubelet` in the procedure inventory.
2. Run `reconfigure` procedure.

ER: Both kubelet and sysctl are reconfigured.

3. Run `check_paas`.

ER: check is successful.

**TestCase 4**

Change of net.netfilter.nf_conntrack_max triggers reconfiguring of kube-proxy.

Steps:

1. Install cluster v1.29.1.
2. Configure new `"net.netfilter.nf_conntrack_max".value` using `services.sysctl`, or `patches` in the procedure inventory.
3. Run `reconfigure` procedure.

ER: Both kube-proxy and sysctl are reconfigured.

4. Run `check_paas`.

ER: check is successful.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_reconfigure.py - cover new cases.
