### PR TITLE
[CPDEV-98973] Scale Typha replicas to 1 in All-in-One

### DIFF
--- a/ci/extended_cluster.yaml
+++ b/ci/extended_cluster.yaml
@@ -43,6 +43,8 @@ plugins:
     install: true
     apiserver:
       enabled: true
+    typha:
+      enabled: true
 
 rbac:
   accounts:

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -22,8 +22,10 @@ The whole directory is automatically cleared and reset after new version of Kube
 from typing import List
 
 from kubemarine.core.patch import Patch
+from kubemarine.patches.p1_calico_typha_schedule_control_planes import CalicoTyphaScheduleControlPlane
 
 patches: List[Patch] = [
+    CalicoTyphaScheduleControlPlane(),
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/p1_calico_typha_schedule_control_planes.py
+++ b/kubemarine/patches/p1_calico_typha_schedule_control_planes.py
@@ -1,0 +1,66 @@
+from textwrap import dedent
+from typing import cast, Optional
+
+from kubemarine import plugins
+from kubemarine.core import utils
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine.kubernetes import deployment
+from kubemarine.plugins import builtin, manifest, calico
+
+
+class TheAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Schedule Calico Typha on control-planes")
+
+    def run(self, res: DynamicResources) -> None:
+        cluster = res.cluster()
+        logger = cluster.log
+
+        calico_version = cluster.inventory['plugins']['calico']['version']
+        if utils.version_key(calico_version)[0:2] >= utils.minor_version_key("v3.27"):
+            return logger.info("The patch is not relevant for Calico >= v3.27.x.")
+
+        if not calico.is_typha_enabled(cluster.inventory):
+            return logger.info("The patch is skipped as Calico Typha is not enabled.")
+
+        processor = cast(Optional[calico.CalicoLess_3_27_ManifestProcessor],
+                         builtin.get_manifest_processor(cluster, manifest.Identity('calico')))
+        if processor is None:
+            return logger.warning("Calico manifest is not installed using default procedure. The patch is skipped.")
+
+        original_manifest = processor.original_manifest()
+        if not processor.get_typha_schedule_control_plane_extra_tolerations(original_manifest):
+            return logger.info("Necessary tolerations already exist in the original manifest. The patch is skipped.")
+
+        manifest_ = processor.enrich()
+        key = "Deployment_calico-typha"
+        typha_deployment_yaml = manifest_.get_obj(key, patch=False)
+
+        typha_deployment = deployment.Deployment(cluster, 'calico-typha', 'kube-system', typha_deployment_yaml)
+        logger.debug("Apply patched 'calico-typha' deployment")
+        typha_deployment.apply(cluster.nodes['control-plane'].get_first_member())
+
+        logger.debug("Expect 'calico-typha' deployment and pods")
+        plugins.expect_deployment(cluster, [{'name': 'calico-typha', 'namespace': 'kube-system'}])
+        plugins.expect_pods(cluster, ['calico-typha'], namespace='kube-system')
+
+
+class CalicoTyphaScheduleControlPlane(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("calico_typha_schedule_control_planes")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            Allow to schedule Calico Typha pods on control-planes.
+            
+            This effectively resolves https://github.com/projectcalico/calico/pull/7979 in older versions.
+            """.rstrip()
+        )

--- a/kubemarine/plugins/builtin.py
+++ b/kubemarine/plugins/builtin.py
@@ -17,14 +17,14 @@ from typing import Dict, Optional
 from kubemarine.core import log
 from kubemarine.core.cluster import KubernetesCluster, EnrichmentStage, enrichment
 from kubemarine.plugins import calico, manifest
-from kubemarine.plugins.calico import CalicoManifestProcessor, CalicoApiServerManifestProcessor
+from kubemarine.plugins.calico import get_calico_manifest_processor, CalicoApiServerManifestProcessor
 from kubemarine.plugins.kubernetes_dashboard import get_dashboard_manifest_processor
 from kubemarine.plugins.local_path_provisioner import LocalPathProvisionerManifestProcessor
 from kubemarine.plugins.manifest import Identity
 from kubemarine.plugins.nginx_ingress import get_ingress_nginx_manifest_processor
 
 MANIFEST_PROCESSOR_PROVIDERS: Dict[Identity, manifest.PROCESSOR_PROVIDER] = {
-    Identity("calico"): CalicoManifestProcessor,
+    Identity("calico"): get_calico_manifest_processor,
     Identity("calico", "apiserver"): CalicoApiServerManifestProcessor,
     Identity("nginx-ingress-controller"): get_ingress_nginx_manifest_processor,
     Identity("kubernetes-dashboard"): get_dashboard_manifest_processor,

--- a/kubemarine/plugins/manifest.py
+++ b/kubemarine/plugins/manifest.py
@@ -238,19 +238,23 @@ class Processor(ABC):
                 self.log.verbose(f"The current version of original yaml does not include "
                                  f"the following object: {key}")
 
+    def original_manifest(self) -> Manifest:
+        """
+        get original YAML and parse it into list of objects
+        """
+        try:
+            with utils.open_utf8(self.manifest_path, 'r') as stream:
+                return Manifest(self.manifest_identity, stream)
+        except Exception as exc:
+            raise Exception(f"Failed to load {self.manifest_identity.repr_id()} from {self.manifest_path} "
+                            f"for {self.plugin_name!r} plugin") from exc
+
     def enrich(self) -> Manifest:
         """
         The method implements full processing for the plugin main manifest.
         """
 
-        # get original YAML and parse it into list of objects
-        try:
-            with utils.open_utf8(self.manifest_path, 'r') as stream:
-                manifest = Manifest(self.manifest_identity, stream)
-        except Exception as exc:
-            raise Exception(f"Failed to load {self.manifest_identity.repr_id()} from {self.manifest_path} "
-                            f"for {self.plugin_name!r} plugin") from exc
-
+        manifest = self.original_manifest()
         self.validate_original(manifest)
 
         # call enrichment functions one by one

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -617,8 +617,18 @@ plugins:
     typha:
       # enabled by default for envs with nodes > 3
       enabled: '{% if (nodes | select("has_roles", ["control-plane", "worker"]) | list | length) < 4 %}false{% else %}true{% endif %}'
-      # let's start from 2 replicas and increment it every 50 nodes
-      replicas: '{{ (((nodes | select("has_roles", ["control-plane", "worker"]) | list | length) / 50) + 2) | round(0, "floor") | int }}'
+      # If Typha is disabled, set 0 replicas to avoid sudden configuration changes during add/remove nodes.
+      # If enabled, Let's start from 2 replicas and increment it every 50 nodes.
+      # In special case of 1 node, scale to 1 replica.
+      # In some calico versions Typha could not be deployed on control-planes
+      # https://github.com/projectcalico/calico/pull/7979
+      # This is considered a bug, so instead of introducing a dependency on calico version,
+      # it is potentially better to patch tolerations ourselves in the manifests during enrichment.
+      replicas: "\
+        {% if plugins.calico.typha.enabled | is_true %}\
+        {% set kubernetes_nodes = nodes | select('has_roles', ['control-plane', 'worker']) | list | length %}\
+        {{ (1 + ([kubernetes_nodes - 1, 1] | min) + kubernetes_nodes / 50) | round(0, 'floor') | int }}\
+        {% else %}0{% endif %}"
       image: 'calico/typha:{{ plugins.calico.version }}'
       nodeSelector:
         kubernetes.io/os: linux

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -620,10 +620,6 @@ plugins:
       # If Typha is disabled, set 0 replicas to avoid sudden configuration changes during add/remove nodes.
       # If enabled, Let's start from 2 replicas and increment it every 50 nodes.
       # In special case of 1 node, scale to 1 replica.
-      # In some calico versions Typha could not be deployed on control-planes
-      # https://github.com/projectcalico/calico/pull/7979
-      # This is considered a bug, so instead of introducing a dependency on calico version,
-      # it is potentially better to patch tolerations ourselves in the manifests during enrichment.
       replicas: "\
         {% if plugins.calico.typha.enabled | is_true %}\
         {% set kubernetes_nodes = nodes | select('has_roles', ['control-plane', 'worker']) | list | length %}\

--- a/test/unit/plugins/test_calico.py
+++ b/test/unit/plugins/test_calico.py
@@ -241,12 +241,17 @@ class ManifestEnrichment(_AbstractManifestEnrichmentTest):
                 self.assertEqual(expected_image, container['image'], "Unexpected calico-typha image")
                 self.assertEqual({"kubernetes.io/os": "something"}, template_spec['nodeSelector'],
                                  "Unexpected calico-typha nodeSelector")
-                self.assertIn({'key': 'node.kubernetes.io/network-unavailable', 'effect': 'NoSchedule'},
-                              template_spec['tolerations'],
-                              "Default calico-typha toleration is not present")
-                self.assertIn({'key': 'node.kubernetes.io/network-unavailable', 'effect': 'NoExecute'},
-                              template_spec['tolerations'],
-                              "Default calico-typha toleration is not present")
+
+                default_tolerations = [
+                    {'key': 'node.kubernetes.io/network-unavailable', 'effect': 'NoSchedule'},
+                    {'key': 'node.kubernetes.io/network-unavailable', 'effect': 'NoExecute'},
+                    {'effect': 'NoExecute', 'operator': 'Exists'},
+                    {'effect': 'NoSchedule', 'operator': 'Exists'},
+                ]
+                for toleration in default_tolerations:
+                    self.assertEqual(1, sum(1 for t in template_spec['tolerations'] if t == toleration),
+                                  "Default calico-typha toleration is not present")
+
                 self.assertIn({"key": 'something', "effect": "NoSchedule"}, template_spec['tolerations'],
                               "Custom calico-typha toleration is not present")
 

--- a/test/unit/test_defaults.py
+++ b/test/unit/test_defaults.py
@@ -256,10 +256,6 @@ class PrimitiveValuesAsString(unittest.TestCase):
                          ['plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options']['SystemdCgroup'])
         self.assertNotIn('min', inventory['services']['kubeadm_kube-proxy']['conntrack'])
 
-        typha = inventory['plugins']['calico']['typha']
-        self.assertEqual(False, typha['enabled'])
-        self.assertEqual(2, typha['replicas'])
-
         nginx_ingress_ports = inventory['plugins']['nginx-ingress-controller']['ports']
         self.assertEqual(20080, [port for port in nginx_ingress_ports if port['name'] == 'http'][0]['hostPort'])
         self.assertEqual(20443, [port for port in nginx_ingress_ports if port['name'] == 'https'][0]['hostPort'])


### PR DESCRIPTION
### Description
* If Calico Typha is enabled in All-in-One, installation fails.
    * This is caused by #618 after which we started to expect Typha deployment.
* Calico Typha is not scheduled on control-planes for old Kubernetes versions.

### Solution
* Scale Typha replicas to 1 if it is enabled in schemes with 1 Kubernetes node.
* If 2nd Kubernetes node is added, scale replicas to 2 and redeploy `calico` plugin.
* Add default tolerations to schedule Calico Typha on all nodes for old Kubernetes versions.

### How to apply
Run `kubemarine migrate_kubemarine --force-apply calico_typha_schedule_control_planes`

### Test Cases

**TestCase 1**

Enable Calico Typha in All-in-One.

Steps:

1. Set `plugins.calico.typha.enabled` to True in All-in-One and install the cluster.

Results:

| Before | After |
| ------ | ------ |
| Installation fails | Installation succeeds with 1 deployed Typha replica |

**TestCase 2**

Add 2nd Kubernetes node to All-in-One with Calico Typha enabled.

Steps:

1. Set `plugins.calico.typha.enabled` to True in All-in-One and install the cluster.
2. Add 2nd Kubernetes node.

ER: `calico` plugin is redeployed and Calico Typha is scaled to 2 replicas.

**TestCase 3**

Schedule Calico Typha on control-planes.

Steps:

1. Install cluster of version < v1.26.7 with 3 control planes, and 1 worker.

| Before | After |
| ------ | ------ |
| Installation fails with 1 Calico Typha pod being Pending | Installation succeeds with 2 deployed Typha replica |

**TestCase 4**

Migrate Kubemarine.

Steps:

1. Install cluster of version < v1.26.7 with 2 control planes, and 2 workers.

ER: Calico Typha is scheduled on 2 workers.

2. Run `kubemarine migrate_kubemarine --force-apply calico_typha_schedule_control_planes`
3. Remove 1 worker.

ER: At least 1 Calico Typha pod is scheduled on control plane.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_calico.py - cover new enrichment, and redeploy cases.
