### PR TITLE
[CPDEV-101682] Support single control plane cluster

### DIFF
--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -4,7 +4,7 @@ This section provides troubleshooting information for Kubemarine and Kubernetes 
   - [KME0001: Unexpected exception](#kme0001-unexpected-exception)
   - [KME0002: Remote group exception](#kme0002-remote-group-exception)
     - [Command did not complete within a number of seconds](#command-did-not-complete-within-a-number-of-seconds)
-  - [KME0004: There are no workers defined in the cluster scheme](#kme0004-there-are-no-workers-defined-in-the-cluster-scheme)
+  - [KME0004: There are no control planes defined in the cluster scheme](#kme0004-there-are-no-control-planes-defined-in-the-cluster-scheme)
   - [KME0005: {hostnames} are not sudoers](#kme0005-hostnames-are-not-sudoers)
 - [Troubleshooting Tools](#troubleshooting-tools)
   - [etcdctl Script](#etcdctl-script)
@@ -167,18 +167,18 @@ frozen stage of the procedure. It will be useful to check the cluster with
 [IAAS checker](Kubecheck.md#iaas-procedure) to detect problems with network connectivity.
 
 
-## KME0004: There are no workers defined in the cluster scheme
+## KME0004: There are no control planes defined in the cluster scheme
 
 ```
 FAILURE!
-KME0004: There are no workers defined in the cluster scheme
+KME0004: There are no control planes defined in the cluster scheme
 ```
 
-An error related with the absence of any worker role in the inventory file. The error occurs before
+An error related with the absence of any control plane role in the inventory file. The error occurs before
 the payload is executed on the cluster.
 
-To fix it, you need to either specify new nodes with the `worker` role, or add the `worker` role to 
-the existing control-planes nodes.
+To fix it, you need to either specify new nodes with the `control-plane` role, or add the `control-plane` role to 
+the existing worker nodes.
 
 An example of specifying different nodes with separate `control-plane` and `worker` roles is as follows.
 

--- a/kubemarine/core/errors.py
+++ b/kubemarine/core/errors.py
@@ -33,7 +33,7 @@ def get_kme_dictionary() -> dict:
             "name": "Remote group exception\n{reason}"
         },
         "KME0004": {
-            "name": "There are no workers defined in the cluster scheme"
+            "name": "There are no control planes defined in the cluster scheme"
         },
         "KME0005": {
             "name": "{hostnames} are not sudoers"

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -430,6 +430,7 @@ class DynamicResources:
             kubemarine.core.defaults.apply_connection_defaults,
             kubemarine.core.defaults.calculate_nodegroups,
             kubemarine.core.defaults.remove_service_roles,
+            kubemarine.kubernetes.verify_roles,
             # Enrichment of inventory for LIGHT stage should be finished at this step.
 
             # Validation of procedure inventory enrichment after compilation

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -108,7 +108,11 @@ def enrich_reconfigure_inventory(cluster: KubernetesCluster) -> None:
 
 @enrichment(EnrichmentStage.ALL)
 def verify_roles(cluster: KubernetesCluster) -> None:
-    if cluster.make_group_from_roles(['control-plane']).is_empty():
+    control_plane_roles = ['control-plane']
+    if cluster.context['initial_procedure'] == 'do':
+        control_plane_roles = ['control-plane', 'master']
+
+    if cluster.make_group_from_roles(control_plane_roles).is_empty():
         raise KME("KME0004")
 
 

--- a/test/unit/core/test_cluster.py
+++ b/test/unit/core/test_cluster.py
@@ -246,17 +246,6 @@ class LightClusterTest(unittest.TestCase):
         host = cluster.nodes['all'].get_host()
         self.assertEqual('10.101.1.100', cluster.connection_pool.get_connection(host).gateway.host)
 
-    def test_legacy_role(self):
-        inventory = demo.generate_inventory(**demo.ALLINONE)
-        del inventory['nodes'][0]['name']
-        # pylint: disable-next=implicit-str-concat
-        inventory['nodes'][0]['roles'] = ['balancer', 'm''a''s''t''e''r', 'worker']
-
-        cluster = demo.new_resources(inventory).cluster(EnrichmentStage.LIGHT)
-
-        self.assertIn('master', cluster.inventory['nodes'][0]['roles'])
-        self.assertEqual('control-plane-1', cluster.nodes['master'].get_node_name())
-
     def test_recursive_compile_inventory(self):
         inventory = demo.generate_inventory(**demo.ALLINONE)
         inventory['values'] = {

--- a/test/unit/test_defaults.py
+++ b/test/unit/test_defaults.py
@@ -242,6 +242,22 @@ class DefaultsEnrichmentAppendControlPlain(unittest.TestCase):
         self.assertEqual(inventory['control_plain']['internal'], inventory['vrrp_ips'][1]['ip'])
         self.assertEqual(inventory['control_plain']['external'], inventory['vrrp_ips'][1]['floating_ip'])
 
+    def test_single_control_plane(self):
+        inventory = demo.generate_inventory(master=['node-1'], worker=['node-1'], balancer=0)
+        inventory['nodes'][0]['roles'].remove('worker')
+        cluster = demo.new_cluster(inventory)
+        self.assertTrue(cluster.make_group_from_roles(['worker']).is_empty())
+
+    def test_error_no_control_planes_balancers(self):
+        inventory = demo.generate_inventory(master=0, worker=1, balancer=0)
+        with test_utils.assert_raises_kme(self, 'KME0004'):
+            demo.new_cluster(inventory)
+
+    def test_error_no_control_planes(self):
+        inventory = demo.generate_inventory(master=0, worker=1, balancer=1)
+        with test_utils.assert_raises_kme(self, 'KME0004'):
+            demo.new_cluster(inventory)
+
 
 class PrimitiveValuesAsString(unittest.TestCase):
     def test_default_enrichment(self):

--- a/test/unit/test_defaults.py
+++ b/test/unit/test_defaults.py
@@ -243,18 +243,18 @@ class DefaultsEnrichmentAppendControlPlain(unittest.TestCase):
         self.assertEqual(inventory['control_plain']['external'], inventory['vrrp_ips'][1]['floating_ip'])
 
     def test_single_control_plane(self):
-        inventory = demo.generate_inventory(master=['node-1'], worker=['node-1'], balancer=0)
+        inventory = demo.generate_inventory(control_plane=['node-1'], worker=['node-1'], balancer=0)
         inventory['nodes'][0]['roles'].remove('worker')
         cluster = demo.new_cluster(inventory)
         self.assertTrue(cluster.make_group_from_roles(['worker']).is_empty())
 
     def test_error_no_control_planes_balancers(self):
-        inventory = demo.generate_inventory(master=0, worker=1, balancer=0)
+        inventory = demo.generate_inventory(control_plane=0, worker=1, balancer=0)
         with test_utils.assert_raises_kme(self, 'KME0004'):
             demo.new_cluster(inventory)
 
     def test_error_no_control_planes(self):
-        inventory = demo.generate_inventory(master=0, worker=1, balancer=1)
+        inventory = demo.generate_inventory(control_plane=0, worker=1, balancer=1)
         with test_utils.assert_raises_kme(self, 'KME0004'):
             demo.new_cluster(inventory)
 

--- a/test/unit/test_do.py
+++ b/test/unit/test_do.py
@@ -19,6 +19,7 @@ import unittest
 
 from kubemarine import demo
 from kubemarine.core import flow
+from kubemarine.core.cluster import EnrichmentStage
 from kubemarine.procedures import do
 
 
@@ -44,6 +45,10 @@ class DoTest(unittest.TestCase):
             flow.ActionsFlow([do.CLIAction(context)]).run_flow(resources, print_summary=False)
 
         self.assertEqual('v0.28.0\n', buf.getvalue(), "Unexpected stdout output")
+
+        cluster = resources.cluster(EnrichmentStage.LIGHT)
+        self.assertEqual(['master'], cluster.inventory['nodes'][0]['roles'])
+        self.assertEqual('control-plane-1', cluster.make_group_from_roles(['control-plane', 'master']).get_node_name())
 
     def test_command_run_any_node(self):
         inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)

--- a/test/unit/test_inventory.py
+++ b/test/unit/test_inventory.py
@@ -69,6 +69,13 @@ class TestInventoryValidation(unittest.TestCase):
                                     re.escape("Value should be one of ['worker', 'control-plane', 'master', 'balancer']")):
             demo.new_cluster(inventory)
 
+    def test_not_supported_master_role(self):
+        inventory = demo.generate_inventory(control_plane=2, worker=0, balancer=0)
+        inventory['nodes'][0]['roles'] = ['master']
+        with self.assertRaisesRegex(errors.FailException,
+                                    re.escape("Value should be one of ['worker', 'control-plane', 'balancer']")):
+            demo.new_cluster(inventory)
+
     def test_explicitly_added_service_role(self):
         error_regex = r"Value should be one of \['worker', 'control-plane', 'master', 'balancer']"
         inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)

--- a/test/unit/test_inventory.py
+++ b/test/unit/test_inventory.py
@@ -25,16 +25,20 @@ from kubemarine.core import errors
 class TestInventoryValidation(unittest.TestCase):
 
     def test_labels_check(self):
-        inventory = demo.generate_inventory(control_plane=0, balancer=1, worker=0)
-        inventory["nodes"][0]["labels"] = {"should": "fail"}
+        inventory = demo.generate_inventory(control_plane=1, balancer=1, worker=0)
+        for node in inventory['nodes']:
+            if 'balancer' in node['roles']:
+                node["labels"] = {"should": "fail"}
         with self.assertRaises(Exception) as context:
             demo.new_cluster(inventory)
 
         self.assertIn("Only 'worker' or 'control-plane' nodes can have labels", str(context.exception))
 
     def test_taints_check(self):
-        inventory = demo.generate_inventory(control_plane=0, balancer=1, worker=0)
-        inventory["nodes"][0]["taints"] = ["should fail"]
+        inventory = demo.generate_inventory(control_plane=1, balancer=1, worker=0)
+        for node in inventory['nodes']:
+            if 'balancer' in node['roles']:
+                node["taints"] = ["should fail"]
         with self.assertRaises(Exception) as context:
             demo.new_cluster(inventory)
 


### PR DESCRIPTION
### Description
* If no nodes with `control-plane` role are provided, Kubemarine fails with internal error.
* At least one control-plane node is necessary even for connection-only enrichment
    * choose default node in `do` procedure
    * preserve information about the procedure run.
* In contrast, it is potentially possible to install the cluster with the only `control-plane` node for dev aims.
    * In particular, this allows to rebuild the only worker node using remove & add node while temporarily persisting only control planes.

### Solution
* Raise exception if no control planes are specified in the inventory.
* Allow clusters without workers.

### Test Cases

**TestCase 1**

Rebuild the only worker node using remove & add node.

Steps:

1. Install the cluster with 1 worker and 1 control-plane.
2. Remove the only worker.

Results:

| Before | After |
| ------ | ------ |
| KME0004 | Node is removed successfully |

3. Add the worker.

ER: Node is added successfully.

**TestCase 2**

Install single control plane cluster.

Steps:

1. Configure inventory
   ```yaml
   nodes:
   - name: control-plane
     internal_address: <address>
     roles: [control-plane]
   services:
     coredns:
       deployment:
         spec:
           template:
             spec:
               nodeSelector:
                 node-role.kubernetes.io/worker: null
   plugins:
     nginx-ingress-controller:
       install: false
   ```
2. Install the cluster.

Results:

| Before | After |
| ------ | ------ |
| KME0004 | Cluster is installed successfully |

3. Upgrade the cluster.

ER: Cluster is upgraded successfully.

**TestCase 3**

Try to install cluster without control planes.

Steps:

1. Try to install cluster without control planes.

Results:

| Before | After |
| ------ | ------ |
| Internal error | KME0004  |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
test_defaults.yaml - cover new functionality and validation.
