### PR TITLE
Fix broken default logging format

### DIFF
--- a/kubemarine/core/log.py
+++ b/kubemarine/core/log.py
@@ -196,14 +196,14 @@ class LogHandler:
                  colorize: bool = False,
                  correct_newlines: bool = False,
                  filemode: str = 'a',
-                 format_: str = DEFAULT_FORMAT,
+                 format: str = DEFAULT_FORMAT,  # pylint: disable=redefined-builtin
                  datefmt: str = None,
                  header: str = None,
                  **kwargs: Union[str, bool, int]):
 
         self._colorize = colorize
         self._correct_newlines = correct_newlines
-        self._format = format_
+        self._format = format
         self._datefmt = datefmt
         self._header = header
 


### PR DESCRIPTION
### Description
* After #617 logging format was broken and become `%(asctime)s %(name)s %(levelname)s %(message)s` for any handler.
* This is caused by changed argument name in `kubemarine.core.log.LogHandler` that we initialize using kwargs.

### Solution
* Revert argument name in `kubemarine.core.log.LogHandler`.

### Test Cases

**TestCase 1**

Steps:

1. Run any procedure.
2. Check logging format in stdout and debug.log

ER: there should be no `cluster_name`.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

