### PR TITLE
[CPDEV-101898] - do not create empty /etc/kubernetes/nodes-k8s-versions.txt file

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -1036,7 +1036,7 @@ def autodetect_non_upgraded_nodes(cluster: KubernetesCluster, future_version: st
         # comes from nodes-k8s-versions.txt content as a comment symbol
         if line[0] == '#':
             continue
-        version, node_name, status = list(filter(lambda val: val, line.split(' ')))
+        version, node_name, status = list(filter(len, line.split(' ')))
         if version != future_version:
             cluster.log.verbose("Node \"%s\" has version \"%s\" and scheduled for upgrade." % (node_name, version))
             upgrade_list.append(node_name)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -1002,19 +1002,22 @@ def exclude_node_from_upgrade_list(first_control_plane: NodeGroup, node_name: st
 def autodetect_non_upgraded_nodes(cluster: KubernetesCluster, future_version: str) -> List[str]:
     first_control_plane = cluster.nodes['control-plane'].get_first_member()
     try:
-        nodes_list_result = first_control_plane.sudo('[ ! -f /etc/kubernetes/nodes-k8s-versions.txt ] && '
-                                              'sudo kubectl get nodes -o custom-columns=\''
+        nodes_list_result = (first_control_plane.sudo('[ ! -f /etc/kubernetes/nodes-k8s-versions.txt ] || '
+                                                     'sudo cat /etc/kubernetes/nodes-k8s-versions.txt')
+                                .get_simple_out())
+        if not nodes_list_result:
+            cluster.log.debug('Cluster status file /etc/kubernetes/nodes-k8s-versions.txt unexist or empty, '
+                              'the new file will be created.')
+            nodes_list_result = first_control_plane.sudo('sudo kubectl get nodes --no-headers -o custom-columns=\''
                                               'VERSION:.status.nodeInfo.kubeletVersion,'
                                               'NAME:.metadata.name,'
-                                              'STATUS:.status.conditions[-1].type\' '
-                                              '| sed -n \'1!p\' | tr -s \' \' '
-                                              '| sed \'1 i\\# This file contains a cached list of nodes and versions '
-                                              'required to continue the Kubernetes upgrade procedure if it fails. '
-                                              'If all the nodes are completely updated or you manually fixed the '
-                                              'problem that occurred during the upgrade, you can delete it.\' '
-                                              '| sudo tee /etc/kubernetes/nodes-k8s-versions.txt; '
-                                              'sudo cat /etc/kubernetes/nodes-k8s-versions.txt') \
-            .get_simple_out()
+                                              'STATUS:.status.conditions[-1].type\'').get_simple_result().stdout
+            nodes_list_result = (f'# This file contains a cached list of nodes and versions '
+                                   'required to continue the Kubernetes upgrade procedure if it fails. '
+                                   'If all the nodes are completely updated or you manually fixed the '
+                                   f'problem that occurred during the upgrade, you can delete it.\n{nodes_list_result}')
+            first_control_plane.put(io.StringIO(nodes_list_result), '/etc/kubernetes/nodes-k8s-versions.txt',
+                                    backup=False, sudo=True)
         cluster.log.verbose("Remote response with nodes description:\n%s" % nodes_list_result)
     except Exception as e:
         cluster.log.warning("Failed to detect cluster status before upgrade. All nodes will be scheduled for upgrade.")
@@ -1033,7 +1036,7 @@ def autodetect_non_upgraded_nodes(cluster: KubernetesCluster, future_version: st
         # comes from nodes-k8s-versions.txt content as a comment symbol
         if line[0] == '#':
             continue
-        version, node_name, status = line.split(' ')
+        version, node_name, status = list(filter(lambda val: val, line.split(' ')))
         if version != future_version:
             cluster.log.verbose("Node \"%s\" has version \"%s\" and scheduled for upgrade." % (node_name, version))
             upgrade_list.append(node_name)


### PR DESCRIPTION
### Description
During upgrade procedure we create special temporary file with node versions: `/etc/kubernetes/nodes-k8s-versions.txt`.
This file is needed to continue from the same step after failed upgrade: https://github.com/Netcracker/KubeMarine/blob/main/documentation/Maintenance.md#nodes-saved-versions-before-upgrade
This file is created with such complex command: https://github.com/Netcracker/KubeMarine/blob/v0.30.0/kubemarine/kubernetes/__init__.py#L1002
But if something went wrong, when kubemarine calls `kubectl get nodes` command (e.g. etcd restarts for some reason), no exceptions will be called and empty `/etc/kubernetes/nodes-k8s-versions.txt` will be created.
After that the exception appears in the next parsing of this file:
```
2024-05-16 15:44:30.854 +0300 INFO *** TASK prepull_images ***
2024-05-16 15:44:30.854 +0300 DEBUG Prepulling Kubernetes images...
2024-05-16 15:44:32.460 +0300 CRITICAL FAILURE!
2024-05-16 15:44:32.460 +0300 CRITICAL TASK FAILED prepull_images
2024-05-16 15:44:32.464 +0300 CRITICAL KME0001: Unexpected exception
2024-05-16 15:44:32.464 +0300 Traceback (most recent call last):
2024-05-16 15:44:32.464 +0300   File "/usr/local/lib/python3.12/site-packages/kubemarine/core/flow.py", line 381, in run_tasks_recursive
2024-05-16 15:44:32.464 +0300     task(cluster)
2024-05-16 15:44:32.464 +0300   File "/usr/local/lib/python3.12/site-packages/kubemarine/procedures/upgrade.py", line 44, in prepull_images
2024-05-16 15:44:32.464 +0300     fix_cri_socket(cluster)
2024-05-16 15:44:32.464 +0300   File "/usr/local/lib/python3.12/site-packages/kubemarine/procedures/upgrade.py", line 286, in fix_cri_socket
2024-05-16 15:44:32.464 +0300     upgrade_group = kubernetes.get_group_for_upgrade(cluster)
2024-05-16 15:44:32.464 +0300                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-16 15:44:32.464 +0300   File "/usr/local/lib/python3.12/site-packages/kubemarine/kubernetes/__init__.py", line 1052, in get_group_for_upgrade
2024-05-16 15:44:32.464 +0300     nodes_for_upgrade = autodetect_non_upgraded_nodes(cluster, version)
2024-05-16 15:44:32.464 +0300                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-16 15:44:32.464 +0300   File "/usr/local/lib/python3.12/site-packages/kubemarine/kubernetes/__init__.py", line 1013, in autodetect_non_upgraded_nodes
2024-05-16 15:44:32.464 +0300     raise Exception('Remote result did not returned any lines containing node info')
2024-05-16 15:44:32.464 +0300 Exception: Remote result did not returned any lines containing node info 
```
The problem is complicated by the fact that as a result of such a shutdown, this file **is not deleted**, so if the upgrade procedure is restarted when the cluster will be OK, it'll continue failing because of empty `/etc/kubernetes/nodes-k8s-versions.txt`. 
To resolve this issue, this file should be removed manually, but it's not obvious for user: in fact, this file is absolutely empty without the first line comment about its purpose.

### Solution
* The complex command is spited to several commands, that are called separately, so if `kubectl get nodes` command fails, kubemarine throws the exception, that is handled and empty file is not created;
* Parsing `kubectl get nodes` result is moved to the kubemarine code instead of using `sed` command;


### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: any;
- Inventory: any; 

Steps:

1. Run `kubemarine install` and wait the successful installation;
2. Run `kubemarine upgrade`;
3. Restart etcd when kubemarine runs `prepull_images` (the best way is using breakpoints to fail etcd right before [autodetect_non_upgraded_nodes function](https://github.com/Netcracker/KubeMarine/blob/v0.30.0/kubemarine/kubernetes/__init__.py#L999);
4. Wait, when `kubemarine upgrade` finishes (successfully or not);
5. Rerun `kubemarine upgrade` when the etcd will be restarted;

Results:

| Before | After |
| ------ | ------ |
| The empty `/etc/kubernetes/nodes-k8s-versions.txt` is created on the first control-plane after step 4  | No `etc/kubernetes/nodes-k8s-versions.txt` after step 4 |
| `kubemarine upgrade` on step 5 fails | `kubemarine upgrade` on step 5 is successful |
| `kubemarine upgrade` on step 2-4 always fails | `kubemarine upgrade` on step 2-4 can be finished successful if failed etcd restarts quickly and does not affect other commands |



### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


