### PR TITLE
[CPDEV-102476] Implement patch that reconfigures Kubernetes audit

### DIFF
--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -24,10 +24,12 @@ from typing import List
 from kubemarine.core.patch import Patch
 from kubemarine.patches.p1_calico_typha_schedule_control_planes import CalicoTyphaScheduleControlPlane
 from kubemarine.patches.p2_reinstall_etcdctl_thirdparty import ReinstallEtcdctl
+from kubemarine.patches.p3_reconfigure_audit import ReconfigureAudit
 
 patches: List[Patch] = [
     CalicoTyphaScheduleControlPlane(),
     ReinstallEtcdctl(),
+    ReconfigureAudit(),
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/p3_reconfigure_audit.py
+++ b/kubemarine/patches/p3_reconfigure_audit.py
@@ -1,0 +1,42 @@
+from textwrap import dedent
+
+from kubemarine.core import yaml_merger
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine.procedures import install
+
+
+class TheAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Reconfigure Kubernetes auditing")
+
+    def run(self, res: DynamicResources) -> None:
+        logger = res.logger()
+        raw_cluster_policy = res.inventory().get('services', {}).get('audit', {}).get('cluster_policy', {})
+
+        if ('rules' not in raw_cluster_policy
+                or yaml_merger.is_list_extends(raw_cluster_policy['rules'],
+                                               ['services', 'audit', 'cluster_policy', 'rules'])):
+            install.run_tasks(res, ['deploy.kubernetes.audit'])
+        else:
+            return logger.info("Audit policy is redefined in the inventory file. Nothing to change.")
+
+
+class ReconfigureAudit(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("reconfigure_audit")
+
+    @property
+    def action(self) -> Action:
+        return TheAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            Reconfigure Kubernetes auditing. Remove auditing of no longer supported podsecuritypolicies.
+            
+            The patch is equivalent to `kubemarine install --tasks deploy.kubernetes.audit`.
+            """.rstrip()
+        )


### PR DESCRIPTION
### Description
* In #665 default audit policy configuration has changed, but patch was not written.

### Solution
* Implemented patch the similar way as in #516

### How to apply
Run `kubemarine migrate_kubemarine --force-apply reconfigure_audit`.

### Test Cases

**TestCase 1**

Steps:

1. Install cluster using **old** Kubemarine version.

Next steps should be performed using **new** Kubemarine version.

2. Run `check_paas`.

ER: kubernetes.audit.policy should fail.

3. Run `kubemarine migrate_kubemarine --force-apply reconfigure_audit`.
4. Run `check_paas`.

ER: kubernetes.audit.policy should succeed.

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
