### PR TITLE
[CPDEV-103189] Different improvements in SSH connections usage

### DIFF
--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -640,8 +640,10 @@ class RawExecutor:
             left_nodes = [host for host, result in results.items()
                           if (isinstance(result, Exception)
                               # Something is wrong with sudo access. Node is active.
-                              and not self.is_require_nopasswd_exception(result))
-                          or (not isinstance(result, Exception)
+                              and not self.is_require_nopasswd_exception(result)
+                              # If not a connection-related exception, do not try to connect further
+                              and self._is_allowed_connection_exception(str(result)))
+                          or (isinstance(result, RunnersResult)
                               and result == initial_boot_history.get(host))]
 
             waited = (datetime.now() - time_start).total_seconds()

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -343,7 +343,7 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
             # if text contains non-ASCII characters.
             # Use the same encoding as paramiko uses, see paramiko/file.py/BufferedFile.write()
 
-            local_stream: Union[io.BytesIO, str] = io.BytesIO(local_file.getvalue().encode('utf-8'))
+            local_stream: Union[bytes, str] = local_file.getvalue().encode('utf-8')
             group_to_upload = self
         else:
             if not os.path.isfile(local_file):
@@ -376,7 +376,7 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
         group_to_upload._put_with_mv(local_stream, remote_file,
                                      backup=backup, sudo=sudo, mkdir=mkdir, immutable=immutable)
 
-    def _put_with_mv(self, local_stream: Union[io.BytesIO, str], remote_file: str,
+    def _put_with_mv(self, local_stream: Union[bytes, str], remote_file: str,
                      backup: bool, sudo: bool, mkdir: bool, immutable: bool) -> None:
 
         if sudo:
@@ -440,7 +440,7 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
         self.sudo(mv_command)
 
     @abstractmethod
-    def _put(self, local_stream: Union[io.BytesIO, str], remote_file: str) -> None:
+    def _put(self, local_stream: Union[bytes, str], remote_file: str) -> None:
         pass
 
     def _unsafe_make_runners_result(self, host_results: HostToResult) -> RunnersGroupResult:
@@ -660,7 +660,7 @@ class NodeGroup(AbstractGroup[RunnersGroupResult]):
     def get(self, remote_file: str, local_file: str) -> None:
         self._do_exec("get", remote_file, local_file)
 
-    def _put(self, local_stream: Union[io.BytesIO, str], remote_file: str) -> None:
+    def _put(self, local_stream: Union[bytes, str], remote_file: str) -> None:
         self._do_exec("put", local_stream, remote_file)
 
     def _run(self, do_type: str, command: str, caller: Optional[Dict[str, object]],
@@ -804,7 +804,7 @@ class DeferredGroup(AbstractGroup[Token]):
             raise ValueError("Streaming of output is currently not supported in deferred mode")
         return self._do_queue(do_type, command, **kwargs)
 
-    def _put(self, local_stream: Union[io.BytesIO, str], remote_file: str) -> None:
+    def _put(self, local_stream: Union[bytes, str], remote_file: str) -> None:
         self._do_queue("put", local_stream, remote_file)
 
     def _do_queue(self, do_type: str, *args: object, **kwargs: Any) -> Token:

--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -303,6 +303,7 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
         return not self == other
 
     def run(self, command: str,
+            *,
             warn: bool = False, hide: bool = True,
             env: Dict[str, str] = None, timeout: int = None,
             callback: Callback = None) -> GROUP_RUN_TYPE:
@@ -314,6 +315,7 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
                          warn=warn, hide=hide, env=env, timeout=timeout, callback=callback)
 
     def sudo(self, command: str,
+             *,
              warn: bool = False, hide: bool = True,
              env: Dict[str, str] = None, timeout: int = None,
              callback: Callback = None) -> GROUP_RUN_TYPE:
@@ -334,8 +336,20 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
         pass
 
     def put(self, local_file: Union[io.StringIO, str], remote_file: str,
+            *,
             backup: bool = False, sudo: bool = False,
-            mkdir: bool = False, immutable: bool = False) -> None:
+            mkdir: bool = False, immutable: bool = False,
+            compare_hashes: bool = False) -> None:
+        local_stream = self._prepare_local(local_file, remote_file)
+        group_to_upload = self._group_to_upload(local_stream, remote_file, compare_hashes)
+        if group_to_upload.is_empty():
+            return
+
+        # pylint: disable-next=protected-access
+        group_to_upload._put_with_mv(local_stream, remote_file,
+                                     backup=backup, sudo=sudo, mkdir=mkdir, immutable=immutable)
+
+    def _prepare_local(self, local_file: Union[io.StringIO, str], remote_file: str) -> Union[bytes, str]:
         if isinstance(local_file, io.StringIO):
             self.cluster.log.verbose("Text is being transferred to remote file \"%s\" on nodes %s"
                                      % (remote_file, list(self.nodes)))
@@ -343,8 +357,7 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
             # if text contains non-ASCII characters.
             # Use the same encoding as paramiko uses, see paramiko/file.py/BufferedFile.write()
 
-            local_stream: Union[bytes, str] = local_file.getvalue().encode('utf-8')
-            group_to_upload = self
+            return local_file.getvalue().encode('utf-8')
         else:
             if not os.path.isfile(local_file):
                 raise Exception(f"File {local_file} does not exist")
@@ -352,29 +365,38 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
             self.cluster.log.verbose("Local file \"%s\" is being transferred to remote file \"%s\" on nodes %s"
                                      % (local_file, remote_file, list(self.nodes)))
 
-            self.cluster.log.verbose('File size: %s' % os.path.getsize(local_file))
-            eager_group = self.cluster.make_group(self.nodes)
-            local_file_hash = eager_group.get_local_file_sha1(local_file)
-            self.cluster.log.verbose('Local file hash: %s' % local_file_hash)
-            remote_file_hashes = eager_group.get_remote_file_sha1(remote_file)
-            self.cluster.log.verbose('Remote file hashes: %s' % remote_file_hashes)
+            return local_file
 
-            hosts_to_upload = []
-            for remote_ip, remote_file_hash in remote_file_hashes.items():
-                if remote_file_hash != local_file_hash:
-                    self.cluster.log.verbose('Local and remote hashes does not match on node \'%s\' %s %s'
-                                             % (remote_ip, local_file_hash, remote_file_hash))
-                    hosts_to_upload.append(remote_ip)
-            if not hosts_to_upload:
-                self.cluster.log.verbose('Local and remote hashes are equal on all nodes, no transmission required')
-                return
+    def _group_to_upload(self: GROUP_SELF, local_file: Union[bytes, str], remote_file: str,
+                         compare_hashes: bool) -> GROUP_SELF:
+        if self.is_empty():
+            repr_local = '<text>' if isinstance(local_file, bytes) else local_file
+            self.cluster.log.verbose(f'No nodes to transfer {repr_local} to remote file {remote_file}')
+            return self
 
-            local_stream = local_file
-            group_to_upload = self._make_group(hosts_to_upload)
+        if not compare_hashes:
+            return self
 
-        # pylint: disable-next=protected-access
-        group_to_upload._put_with_mv(local_stream, remote_file,
-                                     backup=backup, sudo=sudo, mkdir=mkdir, immutable=immutable)
+        file_size = len(local_file) if isinstance(local_file, bytes) else os.path.getsize(local_file)
+        self.cluster.log.verbose(f'File size: %s' % file_size)
+        eager_group = self.cluster.make_group(self.nodes)
+        local_file_hash = eager_group.get_local_file_sha1(local_file)
+        self.cluster.log.verbose('Local file hash: %s' % local_file_hash)
+        remote_file_hashes = eager_group.get_remote_file_sha1(remote_file)
+        self.cluster.log.verbose('Remote file hashes: %s' % remote_file_hashes)
+
+        hosts_to_upload = []
+        for remote_ip, remote_file_hash in remote_file_hashes.items():
+            if remote_file_hash != local_file_hash:
+                self.cluster.log.verbose('Local and remote hashes does not match on node \'%s\' %s %s'
+                                         % (remote_ip, local_file_hash, remote_file_hash))
+                hosts_to_upload.append(remote_ip)
+
+        group_to_upload = self._make_group(hosts_to_upload)
+        if group_to_upload.is_empty():
+            self.cluster.log.verbose('Local and remote hashes are equal on all nodes, no transmission required')
+
+        return group_to_upload
 
     def _put_with_mv(self, local_stream: Union[bytes, str], remote_file: str,
                      backup: bool, sudo: bool, mkdir: bool, immutable: bool) -> None:
@@ -768,8 +790,11 @@ class NodeGroup(AbstractGroup[RunnersGroupResult]):
 
         utils.wait_command_successful(logger, attempt, retries, timeout)
 
-    def get_local_file_sha1(self, filename: str) -> str:
-        return utils.get_local_file_sha1(filename)
+    def get_local_file_sha1(self, local_file: Union[bytes, str]) -> str:
+        if isinstance(local_file, str):
+            return utils.get_local_file_sha1(local_file)
+        else:
+            return utils.get_stream_sha1(io.BytesIO(local_file))
 
     def get_remote_file_sha1(self, filename: str) -> Dict[str, Optional[str]]:
         results = self.sudo("openssl sha1 %s" % filename, warn=True)

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -435,7 +435,7 @@ class FakeNodeGroup(NodeGroup, FakeAbstractGroup[RunnersGroupResult]):
     def _make_defer(self, executor: RemoteExecutor) -> FakeDeferredGroup:
         return FakeDeferredGroup(self.nodes, self.cluster, executor)
 
-    def get_local_file_sha1(self, filename: str) -> str:
+    def get_local_file_sha1(self, local_file: Union[bytes, str]) -> str:
         return '0'
 
     def get_remote_file_sha1(self, filename: str) -> Dict[str, Optional[str]]:

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -423,7 +423,7 @@ class FakeConnection(fabric.connection.Connection):  # type: ignore[misc]
 
 
 class FakeAbstractGroup(AbstractGroup[GROUP_RUN_TYPE], ABC):
-    def _put_with_mv(self, local_stream: Union[io.BytesIO, str], remote_file: str,
+    def _put_with_mv(self, local_stream: Union[bytes, str], remote_file: str,
                      backup: bool, sudo: bool, mkdir: bool, immutable: bool) -> None:
         super()._put_with_mv(local_stream, remote_file, backup=False, sudo=False, mkdir=False, immutable=False)
 

--- a/kubemarine/kubernetes/secrets.py
+++ b/kubemarine/kubernetes/secrets.py
@@ -51,8 +51,8 @@ def put_certificate(control_plane: NodeGroup, cert: io.StringIO, key: io.StringI
     :param cert: data with certificate
     :param key: data with private key
     """
-    control_plane.put(cert, _certificate_path, sudo=True)
-    control_plane.put(key, _private_key_path, sudo=True)
+    control_plane.put(cert, _certificate_path, sudo=True, compare_hashes=False)
+    control_plane.put(key, _private_key_path, sudo=True, compare_hashes=False)
 
 
 def create_certificate(control_plane: NodeGroup, config: str, customization_flags: str) -> None:

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -1064,7 +1064,7 @@ def apply_source(cluster: KubernetesCluster, config: dict) -> None:
     else:
         apply_common_group = cluster.create_group_from_groups_nodes_names(apply_groups, apply_nodes)
 
-    destination_common_group.put(source, destination_path, backup=True, mkdir=True, sudo=use_sudo)
+    destination_common_group.put(source, destination_path, backup=True, mkdir=True, sudo=use_sudo, compare_hashes=True)
 
     if apply_required:
         cluster.log.debug("Applying yaml...")

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -443,13 +443,16 @@ def thirdparties_hashes(cluster: KubernetesCluster) -> None:
                 # Remove temporary dir in any case
                 cluster.log.verbose(f"Remove temporary dir {random_dir}...")
                 first_control_plane.sudo(final_commands, warn=True)
+            else:
+                script = utils.read_internal(config['source'])
+                expected_sha = utils.get_stream_sha1(io.BytesIO(script.encode('utf-8')))
 
             recommended_sha = thirdparties.get_thirdparty_recommended_sha(path, cluster)
             if recommended_sha is not None and recommended_sha != expected_sha:
                 warnings.append(f"{path} source contains not recommended thirdparty version for used kubernetes version")
 
             if config.get("sha1", expected_sha) != expected_sha and expected_sha is not None:
-                broken .append("Given sha is not equal with actual sha from source for %s" % path)
+                broken.append("Given sha is not equal with actual sha from source for %s" % path)
 
             expected_sha = config.get("sha1", expected_sha)
 

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -114,7 +114,7 @@ def import_nodes_data(cluster: KubernetesCluster) -> None:
             node_name = node.get_node_name()
             cluster.log.debug('Uploading backup for \'%s\'' % node_name)
             node.put(os.path.join(cluster.context['backup_tmpdir'], 'nodes_data', '%s.tar.gz' % node_name),
-                     '/tmp/kubemarine-backup.tar.gz')
+                     '/tmp/kubemarine-backup.tar.gz', compare_hashes=True)
 
 
 def restore_dns_resolv_conf(cluster: KubernetesCluster) -> None:
@@ -164,7 +164,8 @@ def import_etcd(cluster: KubernetesCluster) -> None:
 
     cluster.log.debug('Uploading ETCD snapshot...')
     snap_name = '/var/lib/etcd/etcd-snapshot%s.db' % int(round(time.time() * 1000))
-    cluster.nodes['control-plane'].put(os.path.join(cluster.context['backup_tmpdir'], 'etcd.db'), snap_name, sudo=True)
+    cluster.nodes['control-plane'].put(os.path.join(cluster.context['backup_tmpdir'], 'etcd.db'), snap_name,
+                                       sudo=True, compare_hashes=True)
 
     initial_cluster_list = []
     initial_cluster_list_without_names = []

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -14,6 +14,7 @@ connection:
     - encountered RSA key
     - Socket is closed
     - WinError 10060
+    - Timeout opening channel
 etcd:
   default_arguments:
     cert: /etc/kubernetes/pki/etcd/server.crt


### PR DESCRIPTION
### Description
* Support calculating of sha1 for `Connection.put()` of in memory StringIO buffer.
* Added option `NodeGroup.put(compare_hashes=True)` to specify if sha1 of remote and local files should be compared.
    * The option is set to `False` in all cases when we do not expect existence of remote file, or expect its sha1 being always different.
* Added check of sha1 for thirdparties provided as scripts (etcdctl.sh).
* `check_iaas --tasks network.ipip_connectivity` now copies ipip_check binary only if is not copied yet or not actual.
* Fail connect attempts early in case of not a connection-related exceptions.
* fabric's Connection is now instantiated with channel_timeout=10 (default) to recover from problems with SSH (like in comment https://github.com/Netcracker/KubeMarine/pull/463#discussion_r1245053066).
* Other minor fixes in installation of thirdparties.

### Test Cases

**TestCase 1**

Check if etcdctl is actual.

Steps:

1. Install cluster and manually change /usr/bin/etcdctl
2. Run `check_paas --tasks thirdparties.hashes`

Results:

| Before | After |
| ------ | ------ |
| Check is successful | Check fails |

**TestCase 2**

Fail early during instantiating of SSH connections.

Steps:

1. Specify incorrect path to RSA key file and run any procedure.

Results:

| Before | After |
| ------ | ------ |
| Procedure fails after 30 seconds | Procedure fails immediately |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
