### PR TITLE
[CPDEV-103323] No initial timeout for etcd check

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1071,13 +1071,12 @@ def etcd_health_status(cluster: KubernetesCluster) -> None:
     """
     with TestCase(cluster, '219', "ETCD", "Health status ETCD") as tc:
         try:
-            etcd_health_status = etcd.wait_for_health(cluster, cluster.nodes['control-plane'].get_any_member())
+            etcd.wait_for_health(cluster, cluster.nodes['control-plane'].get_any_member())
         except Exception as e:
             cluster.log.verbose('Failed to load and parse ETCD status')
             raise TestFailure('invalid',
                               hint=f"ETCD not ready, please check"
                                    f" because of {e} ") from None
-        cluster.log.debug(etcd_health_status)
         tc.success(results='healthy')
 
 

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -26,7 +26,6 @@ etcd:
     - "etcdserver: leader changed"
     - "etcdserver: request timed out"
   health:
-    init_timeout: 30
     timeout: 2
     retries: 20
 kubernetes:


### PR DESCRIPTION
### Description
* `check_paas --tasks etcd.health_status` works long due to sleep for 30 seconds.

### Solution
* Remove sleep. Use warn=True to handle potential errors.

### Test Cases

**TestCase 1**

Steps:

1. Run `check_paas --tasks etcd.health_status`.

Results:

| Before | After |
| ------ | ------ |
| Works more than 30 seconds | Works 30 seconds less |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
