### PR TITLE
[CPDEV-93296]PAAS_check_failed_after_procedure_Kubernetes_upgrade

### DIFF
--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import itertools
 from collections import OrderedDict
 from typing import List, Callable, Dict
@@ -161,17 +162,15 @@ def upgrade_plugins(cluster: KubernetesCluster) -> None:
 
     plugins.install(cluster, upgrade_candidates)
 
+
 def release_calico_leaked_ips(cluster: KubernetesCluster) -> None:
     """
-    During drain command we ignore daemon sets, as result this such pods as ingress-nginx-controller arent't deleted before migration.
-    For this reason their ips can stay in calico ipam despite they aren't used. You can check this, if you run "calicoctl ipam check --show-problem-ips" right after apply_new_cri task.
-    Those ips are cleaned by calico garbage collector, but it can take about 20 minutes.
-    This task releases problem ips with force.
+    Releases leaked IPs with force to handle IPAM issues caused by leftover IPs from pods not properly cleaned up.
     """
     first_control_plane = cluster.nodes['control-plane'].get_first_member()
     cluster.log.debug("Getting leaked ips...")
     random_report_name = "/tmp/%s.json" % uuid.uuid4().hex
-    result = first_control_plane.sudo(f"calicoctl ipam check --show-problem-ips -o {random_report_name} | grep 'leaked' || true", is_async=False, hide=False)
+    result = first_control_plane.sudo(f"calicoctl ipam check --show-problem-ips -o {random_report_name} | grep 'leaked' || true", hide=False)
     leaked_ips = result.get_simple_out()
     leaked_ips_count = leaked_ips.count('leaked')
     cluster.log.debug(f"Found {leaked_ips_count} leaked ips")
@@ -188,27 +187,29 @@ def release_calico_leaked_ips(cluster: KubernetesCluster) -> None:
                     continue
                 elif 'IPAM handles with no matching IPs' in line:
                     break
-                elif 'affinity' in line:
-                    ip_address = line.split()[2]
-                    ips_with_missing_handles.append(ip_address)
-                elif 'affinity=host' in line:
-                    handle = line.split()[3][:-1]  # Remove trailing colon
-                    handles_with_no_matching_ips.append(handle)
+                else:
+                    ip = line.split()[0]
+                    ips_with_missing_handles.append(ip)
+
+            for line in report_file:
+                handle = line.split()[3][:-1]  # Remove trailing colon
+                handles_with_no_matching_ips.append(handle)
 
         # Release IPs with missing handles
         if ips_with_missing_handles:
             cluster.log.debug("Releasing IPs with missing handles...")
             for ip in ips_with_missing_handles:
-                first_control_plane.sudo(f"calicoctl ipam release --ip={ip} --force", is_async=False, hide=False)
+                first_control_plane.sudo(f"calicoctl ipam release --ip={ip} --force", hide=False)
 
         # Release handles with no matching IPs
         if handles_with_no_matching_ips:
             cluster.log.debug("Releasing handles with no matching IPs...")
             for handle in handles_with_no_matching_ips:
-                first_control_plane.sudo(f"calicoctl ipam release --handle={handle} --force", is_async=False, hide=False)
+                first_control_plane.sudo(f"calicoctl ipam release --handle={handle} --force", hide=False)
 
     # Clean up the temporary report file
-    first_control_plane.sudo(f"rm {random_report_name}", is_async=False, hide=False)
+    first_control_plane.sudo(f"rm {random_report_name}", hide=False)
+
 
 tasks = OrderedDict({
     "cleanup_tmp_dir": cleanup_tmp_dir,

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -161,7 +161,7 @@ def upgrade_plugins(cluster: KubernetesCluster) -> None:
 
     plugins.install(cluster, upgrade_candidates)
 
-def release_calico_leaked_ips(cluster):
+def release_calico_leaked_ips(cluster) -> None:
     """
     During drain command we ignore daemon sets, as result this such pods as ingress-nginx-controller arent't deleted before migration.
     For this reason their ips can stay in calico ipam despite they aren't used. You can check this, if you run "calicoctl ipam check --show-problem-ips" right after apply_new_cri task.

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -161,7 +161,7 @@ def upgrade_plugins(cluster: KubernetesCluster) -> None:
 
     plugins.install(cluster, upgrade_candidates)
 
-def release_calico_leaked_ips(cluster) -> None:
+def release_calico_leaked_ips(cluster: KubernetesCluster) -> None:
     """
     During drain command we ignore daemon sets, as result this such pods as ingress-nginx-controller arent't deleted before migration.
     For this reason their ips can stay in calico ipam despite they aren't used. You can check this, if you run "calicoctl ipam check --show-problem-ips" right after apply_new_cri task.

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -162,7 +162,7 @@ def upgrade_plugins(cluster: KubernetesCluster) -> None:
     plugins.install(cluster, upgrade_candidates)
 
 
-def release_calico_leaked_ips(cluster):
+def release_calico_leaked_ips(cluster: KubernetesCluster) -> None:
     """
     Sometimes ips can stay in calico ipam despite they aren't used. You can check this, if you run "calicoctl ipam check --show-problem-ips".
     Those ips are cleaned by calico garbage collector, but it can take about 20 minutes.


### PR DESCRIPTION
### Description
After Kubernetes Upgrade procedure check_paas indicates inconsistencies in the IP address management (IPAM) system used by Calico in Kubernetes cluster. Specifically, it identifies the following problems:
1. IPs with missing handles: These are IP addresses that are allocated but do not have corresponding handles in the IPAM system.
2. Handles with no matching IPs: These are handles in the IPAM system that do not have corresponding IP addresses allocated to them. 
* 


### Solution
Added a function(release_calico_leaked_ips) in the upgrade procedure. This function should parse the output of the calicoctl ipam check --show-problem-ips command, identify the problematic IPs and handles, and release them automatically.
* 


### Test Cases

**TestCase 1**

Steps:

1. Run kubemarine upgrade
2. Run kubemarine check_paas

Results:

| Before | After |
| ------ | ------ |
| ipam check indicates some problems, for more info you can use `calicoctl ipam check --show-problem-ips` | pass_check for Calico will be successful |


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


