### PR TITLE
build process macos11 to macos12 migration due to macos11 deprecation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,8 @@ jobs:
       matrix:
         target:
           - {os: windows-2022, arch: 'win64'}
-          - {os: macos-11, arch: 'macos11-x86_64'}
-          - {os: macos-11, arch: 'macos11-arm64'}
+          - {os: macos-12, arch: 'macos12-x86_64'}
+          - {os: macos-12, arch: 'macos12-arm64'}
           - {os: ubuntu-latest, arch: 'linux-x86_64'}
         include:
           - executable_path: './dist/kubemarine'
@@ -47,9 +47,9 @@ jobs:
               'python scripts/ci/build_binary.py'
           - target: {os: windows-2022, arch: 'win64'}
             build_cmd: python scripts/ci/build_binary.py
-          - target: {os: macos-11, arch: 'macos11-x86_64'}
+          - target: {os: macos-12, arch: 'macos12-x86_64'}
             build_cmd: python scripts/ci/build_binary.py x86_64
-          - target: {os: macos-11, arch: 'macos11-arm64'}
+          - target: {os: macos-12, arch: 'macos12-arm64'}
             build_cmd: python scripts/ci/build_binary.py arm64
     steps:
       - name: Checkout Repo
@@ -66,7 +66,7 @@ jobs:
 
       # Remove the step after https://github.com/actions/setup-python/issues/713 is solved
       - name: Fix broken pip installation
-        if: ${{ matrix.target.os == 'macos-11' }}
+        if: ${{ matrix.target.os == 'macos-12' }}
         run: |
           SITE_PACKAGES="/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages"
           PIP_VERSION=$(cat $SITE_PACKAGES/pip/__init__.py | grep __version__ | sed 's/["=]//g' | awk '{print $2}')
@@ -79,7 +79,7 @@ jobs:
       - name: Build
         run: ${{ matrix.build_cmd }}
       - name: Run Selftest
-        if: ${{ matrix.target.arch != 'macos11-arm64' }}
+        if: ${{ matrix.target.arch != 'macos12-arm64' }}
         run: ${{ matrix.executable_path }} selftest
 
       - name: Upload Artifact
@@ -90,14 +90,14 @@ jobs:
           retention-days: 1
 
   test-binary:
-    # Currently macos-latest is macos-14-arm64, and thus binary build for macos11-arm64 can be tested on it.
+    # Currently macos-latest is macos-14-arm64, and thus binary build for macos12-arm64 can be tested on it.
     runs-on: macos-latest
     needs: build-binary
     steps:
       - name: Download Executable
         uses: actions/download-artifact@v3
         with:
-          name: kubemarine-macos11-arm64
+          name: kubemarine-macos12-arm64
       - name: Run Selftest
         run: |
           chmod +x kubemarine
@@ -202,7 +202,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     strategy:
       matrix:
-        arch: [ 'win64', 'macos11-x86_64', 'macos11-arm64', 'linux-x86_64' ]
+        arch: [ 'win64', 'macos12-x86_64', 'macos12-arm64', 'linux-x86_64' ]
         include:
           - ext: ''
           - arch: 'win64'


### PR DESCRIPTION
### Description
macos11 github runners stuck because of https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/


### Solution
* move build process to macos12

### How to apply

### Test Cases


**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 

Steps:

1. 

Results:

| Before | After |
| ------ | ------ |
|  |  |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


