### PR TITLE
Mypy fixes

### DIFF
--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -23,7 +23,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from types import TracebackType
 from typing import (
-    Tuple, List, Dict, Callable, Any, Optional, Union, OrderedDict, TypeVar, Type, Mapping, Iterable,
+    Tuple, List, Dict, Callable, Any, Optional, Union, OrderedDict, TypeVar, Type, Mapping,
     Sequence, Generic, Generator
 )
 

--- a/kubemarine/core/executor.py
+++ b/kubemarine/core/executor.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from types import TracebackType
 from typing import (
     Tuple, List, Dict, Callable, Any, Optional, Union, OrderedDict, TypeVar, Type, Mapping, Iterable,
-    Sequence, Generic
+    Sequence, Generic, Generator
 )
 
 import fabric  # type: ignore[import-untyped]
@@ -791,7 +791,7 @@ class RawExecutor:
             def __init__(self) -> None:
                 super().__init__(re.escape(prompt), "")
 
-            def submit(self, stream: str) -> Iterable[str]:
+            def submit(self, stream: str) -> Generator[str, None, None]:
                 if self.pattern_matches(stream, self.pattern, "index"):
                     # If user appears to be not a NOPASSWD sudoer, "sudo" suggests to write password.
                     # This is a W/A to handle the situation in a docker container without pseudo-TTY (no -t option)
@@ -799,7 +799,7 @@ class RawExecutor:
                     raise invoke.exceptions.ResponseNotAccepted("The user should be a NOPASSWD sudoer")
 
                 # The only acceptable situation, responder does nothing.
-                return []
+                yield from []
 
         # Currently only NOPASSWD sudoers are supported.
         # Thus, running of connection.sudo("something") should be equal to connection.run("sudo something")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,11 @@ requires-python = ">=3.8"
 ansible = ["ansible==7.7.*"]
 mypy = [
     "mypy==1.10.*",
-    "types-PyYAML==6.*",
-    "types-invoke==2.*",
-    "types-toml==0.*",
-    "types-python-dateutil==2.*",
-    "types-paramiko==3.*",
-    "types-jsonschema==4.*",
+    "types-PyYAML==6.0.*",
+    "types-toml==0.10.*",
+    "types-python-dateutil==2.9.*",
+    "types-paramiko==3.4.*",
+    "types-jsonschema==4.22.*",
     "types-pyinstaller==6.6.0.*",
 ]
 pylint = [


### PR DESCRIPTION
### Description
We have differences between types packages versions for mypy and real packages, that can follow issues like recently found one:  
We have `jsonschema=4.22.*` requirement and  `types-jsonschema==4.*` one for mypy. It worked normally, until `jsonschema=4.23.0` was released. This version contains more strict changes in data types. So we still install `jsonschema=4.22.*` as before, but when we run mypy check in CI, `types-jsonschema==4.23.0` is installed and check fails because of differences in between  types in our code and expected ones.

### Solution
* Fixed types package versions to be compatible with real packages versions;
* Removed `types-invoke` package, because we use `invoke-2.2.*` that contains types information itself. From [official package description](https://pypi.org/project/types-invoke/): `Note: The invoke package includes type annotations or type stubs since version 2.1.2. Please uninstall the types-invoke package if you use this or a newer version.`;
* Fixed types and imports to be compatible with types described in `invoke-2.2.*`; 


### Test Cases

**TestCase 1**

Test Configuration:

Steps:

1. Install/update requirements for mypy with command: `python3 -m pip install -e .[mypy]`;
2. Run mypy check for kubemarine: `python3 -m mypy`

Results:

| Before | After |
| ------ | ------ |
| Check fails with issues in `schema.py` script | No errors |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


