### PR TITLE
[CPDEV-103936] Fix prepare_dns_etc_hosts for work with unavailable nodes

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -548,6 +548,7 @@ The following parameters are supported:
 | `expect.pods.plugins.retries`    | int  | no        | 150           | `300`   | Number of retires to check pods readiness in `plugins`                                                             |
 | `nodes.ready.timeout`            | int  | no        | 5             | `10`    | Timeout between `nodes.ready.retries` for cluster node readiness waiting                                           |
 | `nodes.ready.retries`            | int  | no        | 15            | `60`    | Number of retries to check a cluster node readiness                                                                |
+| `ignore_unavailable_nodes_for_etchosts_update` | boolean  | no        | false            | false    | Allow to run `prepare.dns.etc_hosts, `update.etc_hosts` tasks when some nodes are unavailable. **Do not change the default value unless you know what for!**                    |
 
 
 ### node_defaults

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -548,7 +548,7 @@ The following parameters are supported:
 | `expect.pods.plugins.retries`    | int  | no        | 150           | `300`   | Number of retires to check pods readiness in `plugins`                                                             |
 | `nodes.ready.timeout`            | int  | no        | 5             | `10`    | Timeout between `nodes.ready.retries` for cluster node readiness waiting                                           |
 | `nodes.ready.retries`            | int  | no        | 15            | `60`    | Number of retries to check a cluster node readiness                                                                |
-| `ignore_unavailable_nodes_for_etchosts_update` | boolean  | no        | false            | false    | Allow to run `prepare.dns.etc_hosts, `update.etc_hosts` tasks when some nodes are unavailable. **Do not change the default value unless you know what for!**                    |
+| `ignore_unavailable_nodes_for_etchosts_update` | boolean  | no        | false            | false    | Allow to run `prepare.dns.etc_hosts`, `update.etc_hosts` tasks when some nodes are unavailable. **Do not change the default value unless you know what for!**                    |
 
 
 ### node_defaults

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -208,7 +208,7 @@ def system_prepare_dns_resolv_conf(group: NodeGroup) -> None:
 def system_prepare_dns_etc_hosts(cluster: KubernetesCluster) -> None:
     remained_offline = cluster.nodes['all'].get_online_nodes(False)
     if not remained_offline.is_empty():
-        raise Exception("Nodes %s are not reachable" % remained_offline.get_hosts())
+        cluster.log.warning("Nodes %s are not reachable. You can update their /etc/hosts by running install job with the task prepare.dns.etc_hosts only when these nodes become available." % remained_offline.get_hosts())
 
     config = system.generate_etc_hosts_config(cluster.inventory, 'etc_hosts')
     config += system.generate_etc_hosts_config(cluster.inventory, 'etc_hosts_generated')
@@ -216,7 +216,7 @@ def system_prepare_dns_etc_hosts(cluster: KubernetesCluster) -> None:
     utils.dump_file(cluster, config, 'etc_hosts')
     cluster.log.debug("\nUploading...")
 
-    group = cluster.nodes['all']
+    group = cluster.nodes['all'].get_online_nodes(True)
 
     system.update_etc_hosts(group, config=config)
     cluster.log.debug(group.sudo("ls -la /etc/hosts"))

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -208,7 +208,8 @@ def system_prepare_dns_resolv_conf(group: NodeGroup) -> None:
 def system_prepare_dns_etc_hosts(cluster: KubernetesCluster) -> None:
     remained_offline = cluster.nodes['all'].get_online_nodes(False)
     if not remained_offline.is_empty():
-        cluster.log.warning("Nodes %s are not reachable. You can update their /etc/hosts by running install job with the task prepare.dns.etc_hosts only when these nodes become available." % remained_offline.get_hosts())
+        cluster.log.warning("Nodes %s are not reachable. You can update their /etc/hosts by running install job "
+                "with the task prepare.dns.etc_hosts only when these nodes become available." % remained_offline.get_hosts())
 
     config = system.generate_etc_hosts_config(cluster.inventory, 'etc_hosts')
     config += system.generate_etc_hosts_config(cluster.inventory, 'etc_hosts_generated')

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -207,7 +207,11 @@ def system_prepare_dns_resolv_conf(group: NodeGroup) -> None:
 
 def system_prepare_dns_etc_hosts(cluster: KubernetesCluster) -> None:
     remained_offline = cluster.nodes['all'].get_online_nodes(False)
-    if not remained_offline.is_empty():
+    if not cluster.inventory['globals']['ignore_unavailable_nodes_for_etchosts_update']:
+        # generally all the nodes must be available during this task running
+        raise Exception("Nodes %s are not reachable" % remained_offline.get_hosts())
+    else:
+        # in some cases we allow to update /etc/hosts only at the available nodes
         cluster.log.warning("Nodes %s are not reachable. You can update their /etc/hosts by running install job "
                 "with the task prepare.dns.etc_hosts only when these nodes become available." % remained_offline.get_hosts())
 
@@ -217,7 +221,12 @@ def system_prepare_dns_etc_hosts(cluster: KubernetesCluster) -> None:
     utils.dump_file(cluster, config, 'etc_hosts')
     cluster.log.debug("\nUploading...")
 
-    group = cluster.nodes['all'].get_online_nodes(True)
+    if not cluster.inventory['globals']['ignore_unavailable_nodes_for_etchosts_update']:
+        # generally we update /etc/hosts at all the nodes
+        group = cluster.nodes['all']
+    else:
+        # update /etc/hosts only at the available nodes
+        group = cluster.nodes['all'].get_online_nodes(True)
 
     system.update_etc_hosts(group, config=config)
     cluster.log.debug(group.sudo("ls -la /etc/hosts"))

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -207,12 +207,13 @@ def system_prepare_dns_resolv_conf(group: NodeGroup) -> None:
 
 def system_prepare_dns_etc_hosts(cluster: KubernetesCluster) -> None:
     remained_offline = cluster.nodes['all'].get_online_nodes(False)
-    if not cluster.inventory['globals']['ignore_unavailable_nodes_for_etchosts_update']:
-        # generally all the nodes must be available during this task running
-        raise Exception("Nodes %s are not reachable" % remained_offline.get_hosts())
-    else:
-        # in some cases we allow to update /etc/hosts only at the available nodes
-        cluster.log.warning("Nodes %s are not reachable. You can update their /etc/hosts by running install job "
+    if not remained_offline.is_empty():
+        if not cluster.inventory['globals']['ignore_unavailable_nodes_for_etchosts_update']:
+            # generally all the nodes must be available during this task running
+            raise Exception("Nodes %s are not reachable" % remained_offline.get_hosts())
+        else:
+            # in some cases we allow to update /etc/hosts only at the available nodes
+            cluster.log.warning("Nodes %s are not reachable. You can update their /etc/hosts by running install job "
                 "with the task prepare.dns.etc_hosts only when these nodes become available." % remained_offline.get_hosts())
 
     config = system.generate_etc_hosts_config(cluster.inventory, 'etc_hosts')

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -18,6 +18,7 @@ globals:
       retries: 15
   timeout_download:
     60
+  ignore_unavailable_nodes_for_etchosts_update: false
 
 node_defaults:
   boot:

--- a/kubemarine/resources/schemas/definitions/globals.json
+++ b/kubemarine/resources/schemas/definitions/globals.json
@@ -111,5 +111,10 @@
          }
       }
     }
+  },
+  "ignore_unavailable_nodes_for_etchosts_update": {
+    "type": "boolean",
+    "default": false,
+    "description": "Switcher to allow /etc/hosts update at the cluster nodes when there are unavailable nodes"
   }
 }

--- a/kubemarine/resources/schemas/definitions/globals.json
+++ b/kubemarine/resources/schemas/definitions/globals.json
@@ -82,6 +82,11 @@
       "type": "integer",
       "default": 60,
       "description": "Timeout for the thirdparties download on nodes."
+    },
+    "ignore_unavailable_nodes_for_etchosts_update": {
+      "type": "boolean",
+      "default": false,
+      "description": "Switcher to allow /etc/hosts update at the cluster nodes when there are unavailable nodes"
     }
   },
   "definitions": {
@@ -111,10 +116,5 @@
          }
       }
     }
-  },
-  "ignore_unavailable_nodes_for_etchosts_update": {
-    "type": "boolean",
-    "default": false,
-    "description": "Switcher to allow /etc/hosts update at the cluster nodes when there are unavailable nodes"
   }
 }


### PR DESCRIPTION
### Description
When one or more nodes are unavailable, `add_node`, `remove_node` procedures have to be run with `prepare.dns.etc_hosts` or `update.etc_hosts` task skipped (see [PR](https://github.com/Netcracker/KubeMarine/pull/628)).
If after that you try to add another node, `add_node` fails with error like 
```
Temporary failure in name resolution': ['some_node_fqdn']}
```

Fixes # (issue)
CPDEV-103936

### Solution
1. New boolean parameter `globals.ignore_unavailable_nodes_for_etchosts_update` is added to cluster.yaml with default value False.
`system_prepare_dns_etc_hosts` is adjusted to work as previously if `globals.ignore_unavailable_nodes_for_etchosts_update= false` and update /etc/hosts only at the available nodes if it's set to True.

2. IN is updated with description of new variable.
### How to apply


### Test Cases
**TestCase 1**
step 1) Set `globals.ignore_unavailable_nodes_for_etchosts_update` to `true` in the cluster.yaml, disable one of the nodes in a cluster and try to add a new node with `add_node` procedure.
**ER**: The new node is added successfully
step 2) With the node still disabled and `globals.ignore_unavailable_nodes_for_etchosts_update` set to `true`, try to add another new node with `add_node` procedure.
**ER**: The new node is added successfully

**TestCase 2**
When a node is disabled in cluster and `globals.ignore_unavailable_nodes_for_etchosts_update` is set to `true`, remove another node with `remove_node` procedure.
**ER**: The node is removed successfully.

**TestCase 3**
Remove `globals.ignore_unavailable_nodes_for_etchosts_update` variable from cluster.yaml and try to add a node when there is at least one unavailable node.
**ER**: `add_node` fails because not all the nodes are available.

**TestCase 4**
Remove `globals.ignore_unavailable_nodes_for_etchosts_update` variable from cluster.yaml and try to add a node when all the nodes are available.
**ER**: `add_node` finishes successfully.

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


