### PR TITLE
[CPDEV-101420] Fix failure of second backup after restore

### DIFF
--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -138,6 +138,7 @@ def export_nodes(cluster: KubernetesCluster) -> None:
     cluster.log.debug('Backing up the following files: \n' + '  - ' + '\n  - '.join(backup_list))
 
     backup_command = 'cd /tmp && ' \
+                     'sudo rm -f /tmp/kubemarine-backup.tar.gz && ' \
                      'sudo tar -czvf /tmp/kubemarine-backup.tar.gz -P $(sudo readlink -e %s) && ' \
                      'sudo ls -la /tmp/kubemarine-backup.tar.gz && ' \
                      'sudo du -hs /tmp/kubemarine-backup.tar.gz' % (' '.join(backup_list))


### PR DESCRIPTION
### Description
When doing the following sequence of action:
- backup
- restore
- backup
the last backup fails at RHEL hosts.

#### RC
Out of the box RHEL has fs.protected_regular kernel variable set to 1 which means prohibiting O_CREAT open on regular files that we don’t own in world writable sticky directories (which the /tmp folder is), unless they are owned by the owner of the directory.

After the restore procedure the /tmp/kubemarine-backup.tar.gz file is left in /tmp folder, so the second backup procedure tries to update an existing file and fails.

Actually, Ubuntu 20.04 and 22.04 have fs.protected_regular=2 which means the same as 1, but also applies to group writable sticky directories, so the issue must be reproduced there too. Centos 7 doesn't have this variable and doesn't have such an issue.
### Solution
`Restore` procedure leaves `/tmp/kubemarine-backup.tar.gz` file after itself. This file also can be left after previously failed backup procedures, etc.
So it's better to delete this file anyway before creating new one in the `backup` procedure.

### How to apply
-

### Test Cases

**TestCase 1**

Deploy a cluster at RHEL nodes and run maintenance procedures:
- backup
- restore
- backup
**ER**: All the procedures finish successfully.

**TestCase 2**

Deploy a cluster at Ubuntu nodes and run maintenance procedures:
- backup
- restore
- backup
**ER**: All the procedures finish successfully.


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


