### PR TITLE
[CPDEV-102270] OpenSSH server issue WA has been added to TG.

### DIFF
--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -42,6 +42,7 @@ This section provides troubleshooting information for Kubemarine and Kubernetes 
   - [Troubleshooting an Installation That Ended Incorrectly](#troubleshooting-an-installation-that-ended-incorrectly)
   - [Upgrade Procedure to v1.28.3 Fails on ETCD Step](#upgrade-procedure-to-v1283-fails-on-etcd-step)
   - [kubectl logs and kubectl exec fail](#kubectl-logs-and-kubectl-exec-fail)
+  - [OpenSSH server becomes unavailable during cluster installation on Centos9](#openssh-server-becomes-unavailable-during-cluster-installation-on-centos9)
 
 # Kubemarine Errors
 
@@ -1404,3 +1405,27 @@ Error from server: error dialing backend: remote error: tls: internal error
 **Root cause**: The `kubelet` server certificate is not approved, whereas the cluster has been configured not to use self-signed certificates for the `kubelet` server.
 
 **Solution**: Perform CSR approval steps from the maintenance guide. Refer to the [Kubelet Server Certificate Approval](https://github.com/Netcracker/KubeMarine/blob/main/documentation/internal/Hardening.md#kubelet-server-certificate-approval) section for details.
+
+## OpenSSH server becomes unavailable during cluster installation on Centos9
+
+**Sympthoms**: Installation fails on `kubemarine.system.reboot_nodes`, OpenSSH server becomes unavailable due to OpenSSL version missmatch error.
+
+The following lines can be found in OpenSSH server logs:
+```
+OpenSSL version mismatch. Built against 30000070, you have 30200010
+sshd.service: Main process exited, code=exited, status=255/EXEPTION
+sshd.service: Failed with result 'exit-code'.
+Failed to start OpenSSH server daemon.
+```
+
+**Root cause**: Since OpenSSL is updated by default when deploying a cluster with KubeMarine, a version incompatibility problem arises. OpenSSH was compiled with OpenSSL version 3.0.0 (30000070), and after the update version 3.2.0 (30200010) is installed.
+Probably, OpenSSL does not provide backward compatibility.
+
+**Solution**: Add upgrade section for OpenSSH server in `cluster.yaml`
+
+```yaml
+services:
+  packages:
+    upgrade:
+      - openssh-server
+```

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -1418,7 +1418,7 @@ sshd.service: Failed with result 'exit-code'.
 Failed to start OpenSSH server daemon.
 ```
 
-**Root cause**: Since OpenSSL is updated by default when deploying a cluster with KubeMarine, the version incompatibility problem arises. OpenSSH was compiled with OpenSSL version 3.0.0 (30000070) and the update version 3.2.0 (30200010) is installed after that.
+**Root cause**: Since OpenSSL is updated by default when deploying a cluster with KubeMarine, the version incompatibility problem arises. OpenSSH was compiled with OpenSSL version 3.0.0 (30000070) and after the update, version 3.2.0 (30200010) is installed.
 Probably, OpenSSL does not provide backward compatibility.
 
 **Solution**: Add the upgrade section for OpenSSH server in the **cluster.yaml** file.

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -1410,7 +1410,7 @@ Error from server: error dialing backend: remote error: tls: internal error
 
 **Sympthoms**: Installation fails on `kubemarine.system.reboot_nodes`, OpenSSH server becomes unavailable due to OpenSSL version missmatch error.
 
-The following lines can be found in OpenSSH server logs:
+The following lines can be found in the OpenSSH server logs:
 ```
 OpenSSL version mismatch. Built against 30000070, you have 30200010
 sshd.service: Main process exited, code=exited, status=255/EXEPTION
@@ -1418,10 +1418,10 @@ sshd.service: Failed with result 'exit-code'.
 Failed to start OpenSSH server daemon.
 ```
 
-**Root cause**: Since OpenSSL is updated by default when deploying a cluster with KubeMarine, a version incompatibility problem arises. OpenSSH was compiled with OpenSSL version 3.0.0 (30000070), and after the update version 3.2.0 (30200010) is installed.
+**Root cause**: Since OpenSSL is updated by default when deploying a cluster with KubeMarine, the version incompatibility problem arises. OpenSSH was compiled with OpenSSL version 3.0.0 (30000070) and the update version 3.2.0 (30200010) is installed after that.
 Probably, OpenSSL does not provide backward compatibility.
 
-**Solution**: Add upgrade section for OpenSSH server in `cluster.yaml`
+**Solution**: Add the upgrade section for OpenSSH server in the **cluster.yaml** file.
 
 ```yaml
 services:


### PR DESCRIPTION
### Description
Since we update OpenSSL by default when deploying a cluster with KubeMarine, a version incompatibility problem arises. OpenSSH was compiled with OpenSSL version 3.0.0 (30000070), and after the update we have version 3.2.0 (30200010) installed.

### Solution
WA has been added to TG.


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


