### PR TITLE
[CPDEV-106079] add containerd health check after restart

### DIFF
--- a/kubemarine/cri/containerd.py
+++ b/kubemarine/cri/containerd.py
@@ -304,7 +304,7 @@ def configure_containerd(group: NodeGroup) -> RunnersGroupResult:
                 f"chmod 600 {os_specific_associations['config_location']} && "
                 f"sudo systemctl restart {os_specific_associations['service_name']} && "
                 f"systemctl status {os_specific_associations['service_name']} && "
-                f"timeout 10 sh -c 'until sudo crictl info 2>&1; do sleep 1; done' ", callback=collector) 
+                f"timeout 10 sh -c 'until sudo ctr version 2>&1; do sleep 1; done' ", callback=collector) 
     return collector.result
 
 

--- a/kubemarine/cri/containerd.py
+++ b/kubemarine/cri/containerd.py
@@ -299,7 +299,7 @@ def configure_containerd(group: NodeGroup) -> RunnersGroupResult:
                              backup=True, sudo=True, mkdir=True)
 
             log.debug("Restarting Containerd on %s node..." % node.get_node_name())
-            # to restart and wait untill containerd is up2running
+            # to restart and wait untill containerd is up&running
             node.sudo(
                 f"chmod 600 {os_specific_associations['config_location']} && "
                 f"sudo systemctl restart {os_specific_associations['service_name']} && "

--- a/kubemarine/cri/containerd.py
+++ b/kubemarine/cri/containerd.py
@@ -299,10 +299,12 @@ def configure_containerd(group: NodeGroup) -> RunnersGroupResult:
                              backup=True, sudo=True, mkdir=True)
 
             log.debug("Restarting Containerd on %s node..." % node.get_node_name())
+            # to restart and wait untill containerd is up2running
             node.sudo(
                 f"chmod 600 {os_specific_associations['config_location']} && "
                 f"sudo systemctl restart {os_specific_associations['service_name']} && "
-                f"systemctl status {os_specific_associations['service_name']}", callback=collector)
+                f"systemctl status {os_specific_associations['service_name']} && "
+                f"timeout 10 sh -c 'until sudo crictl info 2>&1; do sleep 1; done' ", callback=collector) 
     return collector.result
 
 


### PR DESCRIPTION
### Description
*   _containerd_ configuration procedure  doesn't wait that _containred_ daemon is healthy after restart. This may cause to issue when _containerd_ daemon is not ready yet and cri request fails.

Fixes # (issue)
Possible way to reproduce:
```
# systemctl stop containerd; systemctl start containerd && systemctl status --no-pager containerd ; crictl info
...
FATA[0000] validate service connection: validate CRI v1 runtime API for endpoint "unix:///run/containerd/containerd.sock": rpc error: code = Unknown desc = server is not initialized yet
```

### Solution
* To add _containerd_ health check in _containerd_ configuration procedure using active polling with 10 sec timout


### How to apply


### Test Cases


**TestCase 1**

Steps:

1. 

Results:

| Before | After |
| ------ | ------ |
|  |  |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


