### PR TITLE
[CPDEV-106078] - Control plane kubelet local mode kuber 1.31

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -1092,25 +1092,26 @@ In the `services.kubeadm` section, you can override the original settings for ku
 For more information about these settings, refer to the official Kubernetes documentation at [https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file).
 By default, the installer uses the following parameters:
 
-| Parameter                                             | Default Value                                            | Description                                                                                      |
-|-------------------------------------------------------|----------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-|kubernetesVersion                                      | `v1.28.12`                                               |                                                                                                  |
-|controlPlaneEndpoint                                   | `{{ cluster_name }}:6443`                                |                                                                                                  |
-|networking.podSubnet                                   | `10.128.0.0/14` for IPv4 or `fd02::/48` for IPv6         |                                                                                                  |
-|networking.serviceSubnet                               | `172.30.0.0/16` for IPv4 or `fd03::/112` for IPv6        |                                                                                                  |
-|apiServer.certSANs                                     | List with all nodes internal IPs, external IPs and names | Custom SANs are only appended to, but do not override the default list                           |
-|apiServer.extraArgs.enable-admission-plugins           | `NodeRestriction`                                        |                                                                                                  |
-|apiServer.extraArgs.feature-gates                      |                                                          | `PodSecurity=true` is added for Kubernetes < v1.28 if [RBAC pss](#rbac-pss) is enabled           |
-|apiServer.extraArgs.admission-control-config-file      | `/etc/kubernetes/pki/admission.yaml`                     | Provided default value **overrides** custom value if [RBAC pss](#rbac-pss) is enabled.           |
-|apiServer.extraArgs.profiling                          | `false`                                                  |                                                                                                  |
-|apiServer.extraArgs.audit-log-path                     | `/var/log/kubernetes/audit/audit.log`                    |                                                                                                  |
-|apiServer.extraArgs.audit-policy-file                  | `/etc/kubernetes/audit-policy.yaml`                      |                                                                                                  |
-|apiServer.extraArgs.audit-log-maxage                   | `30`                                                     |                                                                                                  |
-|apiServer.extraArgs.audit-log-maxbackup                | `10`                                                     |                                                                                                  |
-|apiServer.extraArgs.audit-log-maxsize                  | `100`                                                    |                                                                                                  |
-|scheduler.extraArgs.profiling                          | `false`                                                  |                                                                                                  |
-|controllerManager.extraArgs.profiling                  | `false`                                                  |                                                                                                  |
-|controllerManager.extraArgs.terminated-pod-gc-threshold| `1000`                                                   |                                                                                                  |
+| Parameter                                               | Default Value                                            | Description                                                                            |
+|---------------------------------------------------------|----------------------------------------------------------|----------------------------------------------------------------------------------------|
+| kubernetesVersion                                       | `v1.28.12`                                               |                                                                                        |
+| controlPlaneEndpoint                                    | `{{ cluster_name }}:6443`                                |                                                                                        |
+| networking.podSubnet                                    | `10.128.0.0/14` for IPv4 or `fd02::/48` for IPv6         |                                                                                        |
+| networking.serviceSubnet                                | `172.30.0.0/16` for IPv4 or `fd03::/112` for IPv6        |                                                                                        |
+| apiServer.certSANs                                      | List with all nodes internal IPs, external IPs and names | Custom SANs are only appended to, but do not override the default list                 |
+| apiServer.extraArgs.enable-admission-plugins            | `NodeRestriction`                                        |                                                                                        |
+| apiServer.extraArgs.feature-gates                       |                                                          | `PodSecurity=true` is added for Kubernetes < v1.28 if [RBAC pss](#rbac-pss) is enabled |
+| apiServer.extraArgs.admission-control-config-file       | `/etc/kubernetes/pki/admission.yaml`                     | Provided default value **overrides** custom value if [RBAC pss](#rbac-pss) is enabled. |
+| apiServer.extraArgs.profiling                           | `false`                                                  |                                                                                        |
+| apiServer.extraArgs.audit-log-path                      | `/var/log/kubernetes/audit/audit.log`                    |                                                                                        |
+| apiServer.extraArgs.audit-policy-file                   | `/etc/kubernetes/audit-policy.yaml`                      |                                                                                        |
+| apiServer.extraArgs.audit-log-maxage                    | `30`                                                     |                                                                                        |
+| apiServer.extraArgs.audit-log-maxbackup                 | `10`                                                     |                                                                                        |
+| apiServer.extraArgs.audit-log-maxsize                   | `100`                                                    |                                                                                        |
+| scheduler.extraArgs.profiling                           | `false`                                                  |                                                                                        |
+| controllerManager.extraArgs.profiling                   | `false`                                                  |                                                                                        |
+| controllerManager.extraArgs.terminated-pod-gc-threshold | `1000`                                                   |                                                                                        |
+| featureGates.ControlPlaneKubeletLocalMode               | `true`                                                   | Provided for Kubernetes version >= 1.31                                                |
 
 The following is an example of kubeadm defaults override:
 

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -462,6 +462,7 @@ class DynamicResources:
             # * kubemarine.sysctl.enrich_inventory
             kubemarine.kubernetes.enrich_inventory,
             kubemarine.admission.enrich_inventory,
+            kubemarine.kubernetes.enrich_control_plane_kubelet_local_mode,
             # Depends on kubemarine.core.defaults.apply_defaults
             kubemarine.kubernetes_accounts.enrich_inventory,
             # Depends on kubemarine.kubernetes.enrich_inventory

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -23,7 +23,7 @@ import yaml
 from jinja2 import Template
 from ordered_set import OrderedSet
 
-from kubemarine import system, admission, etcd, packages, jinja, sysctl, kubernetes
+from kubemarine import system, admission, etcd, packages, jinja, sysctl
 from kubemarine.core import utils, static, summary, log, errors
 from kubemarine.core.cluster import KubernetesCluster, EnrichmentStage, enrichment
 from kubemarine.core.executor import Token
@@ -193,7 +193,7 @@ def enrich_control_plane_kubelet_local_mode(cluster: KubernetesCluster) -> None:
     inventory = cluster.inventory
 
     kubeadm = inventory["services"]["kubeadm"]
-    if kubernetes.components.control_plane_kubelet_local_mode(cluster):
+    if components.control_plane_kubelet_local_mode(cluster):
         feature_gates = kubeadm.get("featureGates", {})
         if 'ControlPlaneKubeletLocalMode' not in feature_gates:
             feature_gates['ControlPlaneKubeletLocalMode'] = True

--- a/kubemarine/kubernetes/components.py
+++ b/kubemarine/kubernetes/components.py
@@ -208,6 +208,10 @@ def kube_proxy_overwrites_higher_system_values(cluster: KubernetesCluster) -> bo
     return kubernetes_minor_release_at_least(cluster.inventory, "v1.29")
 
 
+def control_plane_kubelet_local_mode(cluster: KubernetesCluster) -> bool:
+    return kubernetes_minor_release_at_least(cluster.inventory, "v1.31")
+
+
 def kubernetes_minor_release_at_least(inventory: dict, minor_version: str) -> bool:
     kubernetes_version = inventory["services"]["kubeadm"]["kubernetesVersion"]
     return utils.version_key(kubernetes_version)[0:2] >= utils.minor_version_key(minor_version)

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -17,7 +17,6 @@ import itertools
 from collections import OrderedDict
 from typing import List, Callable, Dict
 import uuid
-import yaml
 from kubemarine import kubernetes, plugins, admission, jinja
 from kubemarine.core import flow, log, resources as res
 from kubemarine.core import utils

--- a/kubemarine/resources/schemas/definitions/services/kubeadm.json
+++ b/kubemarine/resources/schemas/definitions/services/kubeadm.json
@@ -48,7 +48,10 @@
       "$ref": "#/definitions/Etcd"
     },
     "apiVersion": {"type": ["string"], "default": "kubeadm.k8s.io/v1beta2"},
-    "kind": {"enum": ["ClusterConfiguration"], "default": "ClusterConfiguration"}
+    "kind": {"enum": ["ClusterConfiguration"], "default": "ClusterConfiguration"},
+    "featureGates": {
+      "$ref": "#/definitions/FeatureGates"
+    }
   },
   "definitions": {
     "ApiServer": {
@@ -172,6 +175,15 @@
       },
       "required": ["name", "hostPath", "mountPath"],
       "additionalProperties": false
+    },
+    "FeatureGates": {
+      "type": "object",
+      "properties": {
+        "ControlPlaneKubeletLocalMode": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
     }
   }
 }


### PR DESCRIPTION
### Description

Kubernetes version 1.31 provides kubelet local mode feature, that is needed for kubelet to do requests to local api-server ip instead of vrrp. ip. It helps to resolve the floating issue with kubernetes upgrade to 1.30 version. It's enabled in kubeadm config using `featureGates.ControlPlaneKubeletLocalMode=true` in `ClusterConfiguration`.

Fixes # (issue)


### Solution
* Add `featureGates.ControlPlaneKubeletLocalMode=true` for install procedure with kubernetes version v1.31+. This feature can be turned off by user in cluster.yaml configuration;
* Set `featureGates.ControlPlaneKubeletLocalMode=true` for upgrade procedure to kubernetes version v1.31+ before the upgrade.
* Include `featureGates` section to claster.yaml lson schema;
* Add unittests for `featureGates` enrichment;
* Add doc mention about `featureGates.ControlPlaneKubeletLocalMode`;

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 1.31.0 kubernetes version

Steps:

1. Run `kubemarine install` procedure;
2. Check `kubeadm-config` in cluster;
3. Check kubelet configuration in `/etc/kubernetes/kubelet.conf`;

Results:

| Before | After |
| ------ | ------ |
| No `featureGates` field in kubeadm-config | `featureGates.ControlPlaneKubeletLocalMode=true` in kubeadm-config |
| cluster name is specisied as `server` in kubelet config | local kubeapi-server endpoint is used in kubelet config |

**TestCase 2**

Test Configuration:

- Hardware: 
- OS: 
- Inventory: 2 control plane nodes + 1 balancer node and  1.30.3 kubernetes version

Steps:

1. Run `kubemarine install` procedure;
2. Remove first control plane node IP from control plane haproxy configuration on balancer node (all kubeapi requests should go to second control-plane node) and restart haproxy;
3. Run kubemarine upgrade` procedure to 1.31 version;
4. Check `kubeadm-config` in cluster;
5. Check kubelet configuration in `/etc/kubernetes/kubelet.conf`;

Results:

| Before | After |
| ------ | ------ |
| Upgrade procedure fails on first control-plane, because some pods have `CreateContainerConfigError` status | Successful upgrade to 1.31 version |
| No `featureGates` field in kubeadm-config | `featureGates.ControlPlaneKubeletLocalMode=true` in kubeadm-config |
| cluster name is specisied as `server` in kubelet config | local kubeapi-server endpoint is used in kubelet config |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


