### PR TITLE
[CPDEV-107325] - add KME error if unexpected content is returned for helm chart

### DIFF
--- a/kubemarine/core/errors.py
+++ b/kubemarine/core/errors.py
@@ -89,6 +89,10 @@ def get_kme_dictionary() -> dict:
                     "in cluster.yaml{previous_version_spec}, "
                     "but not present in procedure inventory{next_version_spec}. "
                     "Please, specify required 'sandbox_image' explicitly in procedure inventory."
+        },
+        'KME0014': {
+            "name": "Provided helm chart url {url} returns not a {type} content. Please check, that is returned in "
+                    "{destination} file"
         }
     }
 

--- a/kubemarine/core/errors.py
+++ b/kubemarine/core/errors.py
@@ -92,7 +92,7 @@ def get_kme_dictionary() -> dict:
         },
         'KME0014': {
             "name": "The provided Helm chart URL {url} does not return {type} content in the {destination} file. "
-                    "Please validate the URL. If this is a private repository, ensure the correct authentication is provided."
+                    "Please validate the URL. If this is a private repository, ensure that the correct authentication is provided."
         }
     }
 

--- a/kubemarine/core/errors.py
+++ b/kubemarine/core/errors.py
@@ -91,7 +91,8 @@ def get_kme_dictionary() -> dict:
                     "Please, specify required 'sandbox_image' explicitly in procedure inventory."
         },
         'KME0014': {
-            "name": "The provided Helm chart URL {url} does not return {type} content in the {destination} file. Please validate the URL. If this is a private repository, ensure the correct authentication is provided."
+            "name": "The provided Helm chart URL {url} does not return {type} content in the {destination} file. "
+                    "Please validate the URL. If this is a private repository, ensure the correct authentication is provided."
         }
     }
 

--- a/kubemarine/core/errors.py
+++ b/kubemarine/core/errors.py
@@ -92,7 +92,8 @@ def get_kme_dictionary() -> dict:
         },
         'KME0014': {
             "name": "The provided Helm chart URL {url} does not return {type} content in the {destination} file. "
-                    "Please validate the URL. If this is a private repository, ensure that the correct authentication is provided."
+                    "Please validate the URL. If this is a private repository, "
+                    "ensure that the correct authentication is provided."
         }
     }
 

--- a/kubemarine/core/errors.py
+++ b/kubemarine/core/errors.py
@@ -91,8 +91,7 @@ def get_kme_dictionary() -> dict:
                     "Please, specify required 'sandbox_image' explicitly in procedure inventory."
         },
         'KME0014': {
-            "name": "Provided helm chart url {url} returns not a {type} content. Please check, that is returned in "
-                    "{destination} file"
+            "name": "The provided Helm chart URL {url} does not return {type} content in the {destination} file. Please validate the URL. If this is a private repository, ensure the correct authentication is provided."
         }
     }
 

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -920,15 +920,15 @@ def get_local_chart_path(logger: log.EnhancedLogger, config: dict) -> str:
             try:
                 with zipfile.ZipFile(destination, 'r') as zf:
                     zf.extractall(local_chart_folder)
-            except zipfile.BadZipFile:
-                raise KME(code="KME0014", url=chart_path, type=extension, destination=destination)
+            except zipfile.BadZipFile as e:
+                raise KME(code="KME0014", url=chart_path, type=extension, destination=destination) from e
         else:
             logger.verbose('Tar will be used for unpacking')
             try:
                 with tarfile.open(destination, "r:gz") as tf:
                     tf.extractall(local_chart_folder)
-            except tarfile.ReadError:
-                raise KME(code="KME0014", url=chart_path, type="tar:gz", destination=destination)
+            except tarfile.ReadError as e:
+                raise KME(code="KME0014", url=chart_path, type="tar:gz", destination=destination) from e
     else:
         logger.debug("Create copy of chart to work with")
         shutil.copytree(chart_path, local_chart_folder, dirs_exist_ok=True)

--- a/kubemarine/plugins/__init__.py
+++ b/kubemarine/plugins/__init__.py
@@ -36,6 +36,7 @@ import yaml
 from kubemarine.core.cluster import KubernetesCluster, EnrichmentStage, enrichment
 from kubemarine import jinja, thirdparties
 from kubemarine.core import utils, static, errors, os as kos, log
+from kubemarine.core.errors import FailException, KME
 from kubemarine.core.yaml_merger import default_merger
 from kubemarine.core.group import NodeGroup
 from kubemarine.kubernetes.daemonset import DaemonSet
@@ -916,12 +917,18 @@ def get_local_chart_path(logger: log.EnhancedLogger, config: dict) -> str:
         extension = destination.split('.')[-1]
         if extension == 'zip':
             logger.verbose('Unzip will be used for unpacking')
-            with zipfile.ZipFile(destination, 'r') as zf:
-                zf.extractall(local_chart_folder)
+            try:
+                with zipfile.ZipFile(destination, 'r') as zf:
+                    zf.extractall(local_chart_folder)
+            except zipfile.BadZipFile:
+                raise KME(code="KME0014", url=chart_path, type=extension, destination=destination)
         else:
             logger.verbose('Tar will be used for unpacking')
-            with tarfile.open(destination, "r:gz") as tf:
-                tf.extractall(local_chart_folder)
+            try:
+                with tarfile.open(destination, "r:gz") as tf:
+                    tf.extractall(local_chart_folder)
+            except tarfile.ReadError:
+                raise KME(code="KME0014", url=chart_path, type="tar:gz", destination=destination)
     else:
         logger.debug("Create copy of chart to work with")
         shutil.copytree(chart_path, local_chart_folder, dirs_exist_ok=True)


### PR DESCRIPTION
### Description
If user uses remote url to install helm chart plugin, for some reasons unexpected content may return instead of zip/targz file.  
 For example it can happens, if helm chart archive is stored in privated gitlab instance, that requires authorization. Without it gitlab redirects the request to sign-in page, so html content with 200 status code is returned.  
Now we fail with unexpected expression in kubemarine:
```
2024-10-31 08:32:57,855 CRITICAL FAILURE!
2024-10-31 08:32:57,855 CRITICAL TASK FAILED deploy.plugins
2024-10-31 08:32:57,855 CRITICAL KME0001: Unexpected exception
Traceback (most recent call last):
  File "C:\Users\mame0719\Desktop\PaaS\github\KubeMarine\kubemarine\core\flow.py", line 382, in run_tasks_recursive
    task(cluster)
  File "C:\Users\mame0719\Desktop\PaaS\github\KubeMarine\kubemarine\procedures\install.py", line 471, in deploy_plugins
    plugins.install(cluster)
  File "C:\Users\mame0719\Desktop\PaaS\github\KubeMarine\kubemarine\plugins\__init__.py", line 203, in install
    install_plugin(cluster, plugin_name, plugins[plugin_name]["installation"]['procedures'])
  File "C:\Users\mame0719\Desktop\PaaS\github\KubeMarine\kubemarine\plugins\__init__.py", line 211, in install_plugin
    procedure_types()[apply_type]['apply'](cluster, configs)
  File "C:\Users\mame0719\Desktop\PaaS\github\KubeMarine\kubemarine\plugins\__init__.py", line 802, in apply_helm
    chart_path = get_local_chart_path(cluster.log, config)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\mame0719\Desktop\PaaS\github\KubeMarine\kubemarine\plugins\__init__.py", line 919, in get_local_chart_path
    with zipfile.ZipFile(destination, 'r') as zf:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\mame0719\AppData\Local\Programs\Python\Python312\Lib\zipfile\__init__.py", line 1349, in __init__
    self._RealGetContents()
  File "C:\Users\mame0719\AppData\Local\Programs\Python\Python312\Lib\zipfile\__init__.py", line 1416, in _RealGetContents
    raise BadZipFile("File is not a zip file")
zipfile.BadZipFile: File is not a zip file

An unexpected error occurred. It is failed to solve the problem automatically. Follow the instructions from the Troubleshooting Guide available to you. If it is impossible to solve the problem, provide the dump and the technical information above to the support team. You can restart the procedure from the last task with the following command: C:\Users\mame0719\Desktop\PaaS\github\KubeMarine\kubemarine\__main__.py --tasks="deploy.plugins"
```

### Solution
* Created new KME error for unexpected content, returned for remote helm charts urls;
* Catched wrong content exceptions for zip and tar gz cases and returned new KME error in that case.
As result kubemarine fails with following error:
```
2024-10-31 08:37:32,483 CRITICAL FAILURE!
2024-10-31 08:37:32,483 CRITICAL TASK FAILED deploy.plugins
2024-10-31 08:37:32,483 CRITICAL KME0014: Provided helm chart url http://localhost:8000/helm/postgres/charts.zip returns not a zip content. Please check, that is returned in charts.zip file

An unexpected error occurred. It is failed to solve the problem automatically. Follow the instructions from the Troubleshooting Guide available to you. If it is impossible to solve the problem, provide the dump and the technical information above to the support team. You can restart the procedure from the last task with the following command: C:\Users\mame0719\Desktop\PaaS\github\KubeMarine\kubemarine\__main__.py --tasks="deploy.plugins"
```

### Test Cases

**TestCase 1**: unexpected zip content

Test Configuration:

- Hardware: 
- OS: 
- Inventory: some plugin with zip remote  helm chart (url should end on `.zip`)  Provided helm chart url should return something else instead of zip content.

Steps:

1. Run `kubemarine install`;

Results:

| Before | After |
| ------ | ------ |
| Installation fails with `zipfile.BadZipFile` exception | Kubemarine fails with `KME0014` error |

**TestCase 2**: unexpected tar gz content

Test Configuration:

- Hardware: 
- OS: 
- Inventory: some plugin with tar gzremote  helm chart (url should not end on `.zip`)  Provided helm chart url should return something else instead of tar gz content.

Steps:

1. Run `kubemarine install`;

Results:

| Before | After |
| ------ | ------ |
| Installation fails with `tarfile.ReadError` exception | Kubemarine fails with `KME0014` error |

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


