### PR TITLE
[CPDEV-110491] - Add new Kubernetes version v1.32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ ca-key.pem
 kubernetes.csr
 kubernetes.pem
 kubernetes-key.pem
-/cluster.yaml
+/cluster*.yaml
 /additional.yaml
 /procedure.yaml
 venv/

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -19,7 +19,7 @@ import time
 import re
 import json
 from contextlib import contextmanager
-from typing import List, Dict, Iterator, Any, Optional, Union
+from typing import List, Dict, Iterator, Any, Optional
 
 import yaml
 from jinja2 import Template
@@ -399,8 +399,6 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
     node.sudo("mkdir -p /etc/kubernetes")
     node.put(io.StringIO(config), '/etc/kubernetes/join-config.yaml', sudo=True)
 
-
-
     # put control-plane patches
     components.create_kubeadm_patches_for_node(cluster, node)
 
@@ -508,6 +506,7 @@ def init_first_control_plane(group: NodeGroup) -> None:
     log.debug("Uploading init config to initial control_plane...")
     first_control_plane.sudo("mkdir -p /etc/kubernetes")
     first_control_plane.put(io.StringIO(config), '/etc/kubernetes/init-config.yaml', sudo=True)
+
     # put control-plane patches
     components.create_kubeadm_patches_for_node(cluster, first_control_plane)
 
@@ -516,6 +515,7 @@ def init_first_control_plane(group: NodeGroup) -> None:
 
     # put audit-policy.yaml
     prepare_audit_policy(first_control_plane)
+
     log.debug("Initializing first control_plane...")
     result = first_control_plane.sudo(
         "kubeadm init"
@@ -1161,6 +1161,7 @@ def images_prepull(group: DeferredGroup, collector: CollectorCallback) -> Token:
     config = components.get_kubeadm_config(cluster, kubeadm_init)
 
     group.put(io.StringIO(config), '/etc/kubernetes/prepull-config.yaml', sudo=True)
+
     return group.sudo("kubeadm config images pull --config=/etc/kubernetes/prepull-config.yaml",
                       pty=True, callback=collector)
 
@@ -1290,4 +1291,3 @@ def prepare_audit_policy(group: NodeGroup) -> None:
     utils.dump_file(cluster, policy_config_file, 'audit-policy.yaml')
     # upload rules on cluster
     group.put(io.StringIO(policy_config_file), audit_file_name, sudo=True, backup=True)
-

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -535,7 +535,10 @@ def init_first_control_plane(group: NodeGroup) -> None:
     stdout_output = list(result.values())[0].stdout
 
     # regex patterns for variations in msg for kubeadm init command
-    control_plane_pattern = r"You can now join any number of (?:the )?control-plane node[s]?.*?(\n\s+kubeadm join[^\n]+(?:\n\s+--[^\n]+)*)"
+    control_plane_pattern = (
+    r"You can now join any number of (?:the )?control-plane node[s]?.*?"
+    r"(\n\s+kubeadm join[^\n]+(?:\n\s+--[^\n]+)*)"
+    )
     worker_pattern = r"Then you can join any number of worker nodes.*?(\n\s+kubeadm join[^\n]+(?:\n\s+--[^\n]+)*)"
 
     control_plane_match = re.search(control_plane_pattern, stdout_output, re.DOTALL)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -533,9 +533,9 @@ def init_first_control_plane(group: NodeGroup) -> None:
 
     # Preparing join_dict to init other nodes
     control_plane_lines = list(result.values())[0].stdout. \
-                       split("You can now join any number of the control-plane")[1].splitlines()[2:5]
+                       split("You can now join any number of the control-plane")[0].splitlines()[2:5]
     worker_lines = list(result.values())[0].stdout. \
-                       split("Then you can join any number of worker")[1].splitlines()[2:4]
+                       split("Then you can join any number of worker")[0].splitlines()[2:4]
     control_plane_join_command = " ".join([x.replace("\\", "").strip() for x in control_plane_lines])
     worker_join_command = " ".join([x.replace("\\", "").strip() for x in worker_lines])
 

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -509,7 +509,7 @@ def init_first_control_plane(group: NodeGroup) -> None:
     first_control_plane.sudo("mkdir -p /etc/kubernetes")
     first_control_plane.put(io.StringIO(config), '/etc/kubernetes/init-config.yaml', sudo=True)
 
-    migrate_kubeadm_config(first_control_plane, "/etc/kubernetes/init-config.yaml")
+    # migrate_kubeadm_config(first_control_plane, "/etc/kubernetes/init-config.yaml")
     # put control-plane patches
     components.create_kubeadm_patches_for_node(cluster, first_control_plane)
 
@@ -1164,7 +1164,7 @@ def images_prepull(group: DeferredGroup, collector: CollectorCallback) -> Token:
 
     group.put(io.StringIO(config), '/etc/kubernetes/prepull-config.yaml', sudo=True)
 
-    migrate_kubeadm_config(group, "/etc/kubernetes/prepull-config.yaml")
+    # migrate_kubeadm_config(group, "/etc/kubernetes/prepull-config.yaml")
 
     return group.sudo("kubeadm config images pull --config=/etc/kubernetes/prepull-config.yaml",
                       pty=True, callback=collector)
@@ -1296,27 +1296,27 @@ def prepare_audit_policy(group: NodeGroup) -> None:
     # upload rules on cluster
     group.put(io.StringIO(policy_config_file), audit_file_name, sudo=True, backup=True)
 
-def migrate_kubeadm_config(group: Union[NodeGroup, DeferredGroup], config_file: str) -> None:
-    """
-    Check if migration is needed based on Kubernetes minor version and perform the migration.
+# def migrate_kubeadm_config(group: Union[NodeGroup, DeferredGroup], config_file: str) -> None:
+#     """
+#     Check if migration is needed based on Kubernetes minor version and perform the migration.
     
-    :param group: Node group where the migration is performed.
-    :param config_file: The path to the configuration file.
-    """
-    cluster: KubernetesCluster = group.cluster
-    log = cluster.log
+#     :param group: Node group where the migration is performed.
+#     :param config_file: The path to the configuration file.
+#     """
+#     cluster: KubernetesCluster = group.cluster
+#     log = cluster.log
 
-    # Retrieve Kubernetes version from inventory and parse the minor version
-    k8s_version = cluster.inventory['services']['kubeadm']['kubernetesVersion']
-    log.debug(f"Cluster Kubernetes version: {k8s_version}")
-    minor_version = int(k8s_version.lstrip('v').split('.')[1])
+#     # Retrieve Kubernetes version from inventory and parse the minor version
+#     k8s_version = cluster.inventory['services']['kubeadm']['kubernetesVersion']
+#     log.debug(f"Cluster Kubernetes version: {k8s_version}")
+#     minor_version = int(k8s_version.lstrip('v').split('.')[1])
    
-    # If minor version > 31, proceed with migration
-    if minor_version > 31:
-        config = config_file
-        # Perform migration
-        group.sudo(f"kubeadm config migrate --old-config {config} --new-config {config}-migrated", hide=True) 
-        log.debug(f"Kubeadm config migration successful: {config}-migrated")
-        group.sudo(f"cp {config}-migrated {config}")
-    else:
-        log.debug(f"No migration needed for Kubernetes version: {k8s_version}")
+#     # If minor version > 31, proceed with migration
+#     if minor_version > 31:
+#         config = config_file
+#         # Perform migration
+#         group.sudo(f"kubeadm config migrate --old-config {config} --new-config {config}-migrated", hide=True) 
+#         log.debug(f"Kubeadm config migration successful: {config}-migrated")
+#         group.sudo(f"cp {config}-migrated {config}")
+#     else:
+#         log.debug(f"No migration needed for Kubernetes version: {k8s_version}")

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -508,8 +508,6 @@ def init_first_control_plane(group: NodeGroup) -> None:
     log.debug("Uploading init config to initial control_plane...")
     first_control_plane.sudo("mkdir -p /etc/kubernetes")
     first_control_plane.put(io.StringIO(config), '/etc/kubernetes/init-config.yaml', sudo=True)
-
-    migrate_kubeadm_config(first_control_plane, "/etc/kubernetes/init-config.yaml")
     # put control-plane patches
     components.create_kubeadm_patches_for_node(cluster, first_control_plane)
 
@@ -1163,9 +1161,6 @@ def images_prepull(group: DeferredGroup, collector: CollectorCallback) -> Token:
     config = components.get_kubeadm_config(cluster, kubeadm_init)
 
     group.put(io.StringIO(config), '/etc/kubernetes/prepull-config.yaml', sudo=True)
-
-    migrate_kubeadm_config(group, "/etc/kubernetes/prepull-config.yaml")
-
     return group.sudo("kubeadm config images pull --config=/etc/kubernetes/prepull-config.yaml",
                       pty=True, callback=collector)
 
@@ -1296,27 +1291,3 @@ def prepare_audit_policy(group: NodeGroup) -> None:
     # upload rules on cluster
     group.put(io.StringIO(policy_config_file), audit_file_name, sudo=True, backup=True)
 
-def migrate_kubeadm_config(group: Union[NodeGroup, DeferredGroup], config_file: str) -> None:
-    """
-    Check if migration is needed based on Kubernetes minor version and perform the migration.
-    
-    :param group: Node group where the migration is performed.
-    :param config_file: The path to the configuration file.
-    """
-    cluster: KubernetesCluster = group.cluster
-    log = cluster.log
-
-    # Retrieve Kubernetes version from inventory and parse the minor version
-    k8s_version = cluster.inventory['services']['kubeadm']['kubernetesVersion']
-    log.debug(f"Cluster Kubernetes version: {k8s_version}")
-    minor_version = int(k8s_version.lstrip('v').split('.')[1])
-   
-    # If minor version > 31, proceed with migration
-    if minor_version > 31:
-        config = config_file
-        # Perform migration
-        group.sudo(f"kubeadm config migrate --old-config {config} --new-config {config}-migrated", hide=True) 
-        log.debug(f"Kubeadm config migration successful: {config}-migrated")
-        group.sudo(f"cp {config}-migrated {config}")
-    else:
-        log.debug(f"No migration needed for Kubernetes version: {k8s_version}")

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -533,9 +533,9 @@ def init_first_control_plane(group: NodeGroup) -> None:
 
     # Preparing join_dict to init other nodes
     control_plane_lines = list(result.values())[0].stdout. \
-                       split("You can now join any number of the control-plane")[0].splitlines()[2:5]
+                       split("You can now join any number of control-plane")[1].splitlines()[2:5]
     worker_lines = list(result.values())[0].stdout. \
-                       split("Then you can join any number of worker")[0].splitlines()[2:4]
+                       split("Then you can join any number of worker")[1].splitlines()[2:4]
     control_plane_join_command = " ".join([x.replace("\\", "").strip() for x in control_plane_lines])
     worker_join_command = " ".join([x.replace("\\", "").strip() for x in worker_lines])
 

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -19,7 +19,7 @@ import time
 import re
 import json
 from contextlib import contextmanager
-from typing import List, Dict, Iterator, Any, Optional
+from typing import List, Dict, Iterator, Any, Optional, Union
 
 import yaml
 from jinja2 import Template
@@ -1296,7 +1296,7 @@ def prepare_audit_policy(group: NodeGroup) -> None:
     # upload rules on cluster
     group.put(io.StringIO(policy_config_file), audit_file_name, sudo=True, backup=True)
 
-def migrate_kubeadm_config(group: NodeGroup, config_file: str) -> None:
+def migrate_kubeadm_config(group: Union[NodeGroup, DeferredGroup], config_file: str) -> None:
     """
     Check if migration is needed based on Kubernetes minor version and perform the migration.
     

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -399,6 +399,8 @@ def join_control_plane(cluster: KubernetesCluster, node: NodeGroup, join_dict: d
     node.sudo("mkdir -p /etc/kubernetes")
     node.put(io.StringIO(config), '/etc/kubernetes/join-config.yaml', sudo=True)
 
+
+
     # put control-plane patches
     components.create_kubeadm_patches_for_node(cluster, node)
 
@@ -1313,7 +1315,8 @@ def migrate_kubeadm_config(group: NodeGroup, config_file: str) -> None:
     if minor_version > 31:
         config = config_file
         # Perform migration
-        group.sudo(f"kubeadm config migrate --old-config {config} --new-config {config}", hide=True) 
-        log.debug(f"Kubeadm config migration successful: {config}")
+        group.sudo(f"kubeadm config migrate --old-config {config} --new-config {config}-migrated", hide=True) 
+        log.debug(f"Kubeadm config migration successful: {config}-migrated")
+        group.sudo(f"cp {config}-migrated {config}")
     else:
         log.debug(f"No migration needed for Kubernetes version: {k8s_version}")

--- a/kubemarine/kubernetes/components.py
+++ b/kubemarine/kubernetes/components.py
@@ -895,7 +895,7 @@ def compare_kubelet_config(cluster: KubernetesCluster, *, with_inventory: bool) 
 def compare_configmap(cluster: KubernetesCluster, configmap: str) -> Optional[str]:
     control_plane = cluster.nodes['control-plane'].get_first_member()
     kubeadm_config = KubeadmConfig(cluster)
-    
+
     if configmap == 'kubelet-config':
         # Do not check kubelet-config ConfigMap, because some properties may be deleted from KubeletConfiguration
         # if set to default, for example readOnlyPort: 0, protectKernelDefaults: false

--- a/kubemarine/kubernetes/components.py
+++ b/kubemarine/kubernetes/components.py
@@ -517,6 +517,7 @@ def _upload_config(cluster: KubernetesCluster, control_plane: AbstractGroup[RunR
 
     control_plane.put(io.StringIO(config), remote_path, sudo=True)
 
+
 def _update_configmap(cluster: KubernetesCluster, control_plane: NodeGroup, configmap: str,
                       uploader: Callable[[DeferredGroup], None], backup_dir: str) -> bool:
     logger = cluster.log
@@ -894,6 +895,7 @@ def compare_kubelet_config(cluster: KubernetesCluster, *, with_inventory: bool) 
 def compare_configmap(cluster: KubernetesCluster, configmap: str) -> Optional[str]:
     control_plane = cluster.nodes['control-plane'].get_first_member()
     kubeadm_config = KubeadmConfig(cluster)
+    
     if configmap == 'kubelet-config':
         # Do not check kubelet-config ConfigMap, because some properties may be deleted from KubeletConfiguration
         # if set to default, for example readOnlyPort: 0, protectKernelDefaults: false
@@ -958,6 +960,7 @@ def compare_configmap(cluster: KubernetesCluster, configmap: str) -> Optional[st
         return utils.get_unified_diff(yaml.dump(stored_config), yaml.dump(generated_config),
                                       fromfile=f'{configmap} ConfigMap',
                                       tofile=f"{configmap} ConfigMap merged 'services.{section}' section")
+
 
 def _detect_changes(logger: log.EnhancedLogger, old: str, new: str, fromfile: str, tofile: str) -> bool:
     diff = utils.get_yaml_diff(old, new, fromfile, tofile)

--- a/kubemarine/kubernetes/components.py
+++ b/kubemarine/kubernetes/components.py
@@ -517,17 +517,17 @@ def _upload_config(cluster: KubernetesCluster, control_plane: AbstractGroup[RunR
 
     control_plane.put(io.StringIO(config), remote_path, sudo=True)
     
-    log = cluster.log
-    k8s_version = cluster.inventory['services']['kubeadm']['kubernetesVersion']
-    log.debug(f"Cluster Kubernetes version: {k8s_version}")
-    minor_version = int(k8s_version.lstrip('v').split('.')[1])
-    # If minor version > 31, proceed with migration
-    if minor_version > 31:
-        control_plane.sudo(f"kubeadm config migrate --old-config {remote_path} --new-config {remote_path}-migrated") 
-        log.debug(f"Kubeadm config migration successful: {remote_path}-migrated")
-        control_plane.sudo(f"cp {remote_path}-migrated {remote_path}")
-    else:
-        log.debug(f"No migration needed for Kubernetes version: {k8s_version}")
+    # log = cluster.log
+    # k8s_version = cluster.inventory['services']['kubeadm']['kubernetesVersion']
+    # log.debug(f"Cluster Kubernetes version: {k8s_version}")
+    # minor_version = int(k8s_version.lstrip('v').split('.')[1])
+    # # If minor version > 31, proceed with migration
+    # if minor_version > 31:
+    #     control_plane.sudo(f"kubeadm config migrate --old-config {remote_path} --new-config {remote_path}-migrated") 
+    #     log.debug(f"Kubeadm config migration successful: {remote_path}-migrated")
+    #     control_plane.sudo(f"cp {remote_path}-migrated {remote_path}")
+    # else:
+    #     log.debug(f"No migration needed for Kubernetes version: {k8s_version}")
 
 
 def _update_configmap(cluster: KubernetesCluster, control_plane: NodeGroup, configmap: str,

--- a/kubemarine/kubernetes/components.py
+++ b/kubemarine/kubernetes/components.py
@@ -516,19 +516,6 @@ def _upload_config(cluster: KubernetesCluster, control_plane: AbstractGroup[RunR
     utils.dump_file(cluster, config, f"{name}_{control_plane.get_node_name()}.yaml")
 
     control_plane.put(io.StringIO(config), remote_path, sudo=True)
-    
-    # log = cluster.log
-    # k8s_version = cluster.inventory['services']['kubeadm']['kubernetesVersion']
-    # log.debug(f"Cluster Kubernetes version: {k8s_version}")
-    # minor_version = int(k8s_version.lstrip('v').split('.')[1])
-    # # If minor version > 31, proceed with migration
-    # if minor_version > 31:
-    #     control_plane.sudo(f"kubeadm config migrate --old-config {remote_path} --new-config {remote_path}-migrated") 
-    #     log.debug(f"Kubeadm config migration successful: {remote_path}-migrated")
-    #     control_plane.sudo(f"cp {remote_path}-migrated {remote_path}")
-    # else:
-    #     log.debug(f"No migration needed for Kubernetes version: {k8s_version}")
-
 
 def _update_configmap(cluster: KubernetesCluster, control_plane: NodeGroup, configmap: str,
                       uploader: Callable[[DeferredGroup], None], backup_dir: str) -> bool:

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -331,8 +331,9 @@ def kubelet_config(cluster: KubernetesCluster) -> None:
                 cluster.log.debug(msg)
                 cluster.log.debug(diff + '\n')
         else:
-            cluster.log.debug("Checking kubelet-config ConfigMap consistency with services.kubeadm_kubelet "\
-                              "section in skipped as kubernetes version is >= v1.32.0")
+            raise TestWarn("Skipping kubelet-config ConfigMap consistency check",
+                           hint="Kubernetes version is >= v1.32.0. The consistency check is no longer performed as the "\
+                                "kubelet configuration is managed differently in newer versions. Verify manually if required.")
 
         if not messages:
             tc.success(results='valid')

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -322,7 +322,7 @@ def kubelet_config(cluster: KubernetesCluster) -> None:
         k8s_version = cluster.inventory['services']['kubeadm']['kubernetesVersion']
         minor_version = int(k8s_version.lstrip('v').split('.')[1])
         # If minor version > 31, skip checking kubelet-config ConfigMap consistency with services.kubeadm_kubelet section 
-        if minor_version < 31:
+        if minor_version < 32:
             cluster.log.debug("Checking kubelet-config ConfigMap consistency with services.kubeadm_kubelet section")
             diff = components.compare_configmap(cluster, 'kubelet-config')
             if diff is not None:
@@ -330,6 +330,8 @@ def kubelet_config(cluster: KubernetesCluster) -> None:
                 messages.append(msg)
                 cluster.log.debug(msg)
                 cluster.log.debug(diff + '\n')
+        else:
+            cluster.log.debug("Checking kubelet-config ConfigMap consistency with services.kubeadm_kubelet section in skipped as kubernetes version is >= v1.32.0")
 
         if not messages:
             tc.success(results='valid')

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -331,7 +331,8 @@ def kubelet_config(cluster: KubernetesCluster) -> None:
                 cluster.log.debug(msg)
                 cluster.log.debug(diff + '\n')
         else:
-            cluster.log.debug("Checking kubelet-config ConfigMap consistency with services.kubeadm_kubelet section in skipped as kubernetes version is >= v1.32.0")
+            cluster.log.debug("Checking kubelet-config ConfigMap consistency with services.kubeadm_kubelet "\
+                              "section in skipped as kubernetes version is >= v1.32.0")
 
         if not messages:
             tc.success(results='valid')

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -318,14 +318,18 @@ def kubelet_config(cluster: KubernetesCluster) -> None:
         if failed_nodes:
             messages.append(f"/var/lib/kubelet/config.yaml is not consistent with patches from inventory "
                             f"on nodes {', '.join(failed_nodes)}")
-
-        cluster.log.debug("Checking kubelet-config ConfigMap consistency with services.kubeadm_kubelet section")
-        diff = components.compare_configmap(cluster, 'kubelet-config')
-        if diff is not None:
-            msg = "kubelet-config ConfigMap is not consistent with services.kubeadm_kubelet section"
-            messages.append(msg)
-            cluster.log.debug(msg)
-            cluster.log.debug(diff + '\n')
+            
+        k8s_version = cluster.inventory['services']['kubeadm']['kubernetesVersion']
+        minor_version = int(k8s_version.lstrip('v').split('.')[1])
+        # If minor version > 31, skip checking kubelet-config ConfigMap consistency with services.kubeadm_kubelet section 
+        if minor_version < 31:
+            cluster.log.debug("Checking kubelet-config ConfigMap consistency with services.kubeadm_kubelet section")
+            diff = components.compare_configmap(cluster, 'kubelet-config')
+            if diff is not None:
+                msg = "kubelet-config ConfigMap is not consistent with services.kubeadm_kubelet section"
+                messages.append(msg)
+                cluster.log.debug(msg)
+                cluster.log.debug(diff + '\n')
 
         if not messages:
             tc.success(results='valid')

--- a/kubemarine/resources/configurations/compatibility/internal/kubernetes_images.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/kubernetes_images.yaml
@@ -35,6 +35,8 @@ kube-apiserver:
     version: v1.30.3
   v1.31.1:
     version: v1.31.1
+  v1.32.0:
+    version: v1.32.0
 kube-controller-manager:
   v1.27.1:
     version: v1.27.1
@@ -70,6 +72,8 @@ kube-controller-manager:
     version: v1.30.3
   v1.31.1:
     version: v1.31.1
+  v1.32.0:
+    version: v1.32.0
 kube-scheduler:
   v1.27.1:
     version: v1.27.1
@@ -105,6 +109,8 @@ kube-scheduler:
     version: v1.30.3
   v1.31.1:
     version: v1.31.1
+  v1.32.0:
+    version: v1.32.0
 kube-proxy:
   v1.27.1:
     version: v1.27.1
@@ -140,6 +146,8 @@ kube-proxy:
     version: v1.30.3
   v1.31.1:
     version: v1.31.1
+  v1.32.0:
+    version: v1.32.0
 pause:
   v1.27.1:
     version: '3.9'
@@ -174,6 +182,8 @@ pause:
   v1.30.3:
     version: '3.9'
   v1.31.1:
+    version: '3.10'
+  v1.32.0:
     version: '3.10'
 etcd:
   v1.27.1:
@@ -210,6 +220,8 @@ etcd:
     version: 3.5.12-0
   v1.31.1:
     version: 3.5.15-0
+  v1.32.0:
+    version: 3.5.16-0
 coredns/coredns:
   v1.27.1:
     version: v1.10.1
@@ -244,4 +256,6 @@ coredns/coredns:
   v1.30.3:
     version: v1.11.1
   v1.31.1:
+    version: v1.11.3
+  v1.32.0:
     version: v1.11.3

--- a/kubemarine/resources/configurations/compatibility/internal/packages.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/packages.yaml
@@ -39,6 +39,8 @@ containerd:
     version_debian: 1.7.*
   v1.31.1:
     version_debian: 1.7.*
+  v1.32.0:
+    version_debian: 1.7.*
 containerdio:
   v1.27.1:
     version_rhel: 1.6*
@@ -105,6 +107,10 @@ containerdio:
     version_rhel8: 1.6*
     version_rhel9: 1.6*
   v1.31.1:
+    version_rhel: 1.6*
+    version_rhel8: 1.6*
+    version_rhel9: 1.6*
+  v1.32.0:
     version_rhel: 1.6*
     version_rhel8: 1.6*
     version_rhel9: 1.6*

--- a/kubemarine/resources/configurations/compatibility/internal/plugins.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/plugins.yaml
@@ -39,6 +39,8 @@ calico:
     version: v3.29.1
   v1.31.1:
     version: v3.29.1
+  v1.32.0:
+    version: v3.29.1
 nginx-ingress-controller:
   v1.27.1:
     version: v1.8.4
@@ -89,6 +91,9 @@ nginx-ingress-controller:
     version: v1.11.1
     webhook-version: v1.4.1
   v1.31.1:
+    version: v1.11.1
+    webhook-version: v1.4.1
+  v1.32.0:
     version: v1.11.1
     webhook-version: v1.4.1
 kubernetes-dashboard:
@@ -143,6 +148,9 @@ kubernetes-dashboard:
   v1.31.1:
     version: v2.7.0
     metrics-scraper-version: v1.0.8
+  v1.32.0:
+    version: v2.7.0
+    metrics-scraper-version: v1.0.8
 local-path-provisioner:
   v1.27.1:
     version: v0.0.25
@@ -193,5 +201,8 @@ local-path-provisioner:
     version: v0.0.27
     busybox-version: 1.34.1
   v1.31.1:
+    version: v0.0.27
+    busybox-version: 1.34.1
+  v1.32.0:
     version: v0.0.27
     busybox-version: 1.34.1

--- a/kubemarine/resources/configurations/compatibility/internal/thirdparties.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/thirdparties.yaml
@@ -36,6 +36,8 @@ kubeadm:
     sha1: f840e75f5dc1001ebdd7e286c0e87e1090df011b
   v1.31.1:
     sha1: 0a682af6436ce4e7188f93ddeebff5c2f3be1592
+  v1.32.0:
+    sha1: 981cdd31d4072fe65fb251c1158090f511d34610
 kubelet:
   v1.27.1:
     sha1: 43cb7231a889c01cfd88bd3f27441134e3d1cbff
@@ -71,6 +73,8 @@ kubelet:
     sha1: fbae53efc43ec715a45b05415294ab991ea087a2
   v1.31.1:
     sha1: fc7d0a9859c97ec2a2a4ac9ec1814b131e8d875f
+  v1.32.0:
+    sha1: e81e622c57721ddb31b92e09e2f2f0fc9f58562b
 kubectl:
   v1.27.1:
     sha1: 0c3f1e262a6c37719ba4d66885df6715f58b60e5
@@ -106,6 +110,8 @@ kubectl:
     sha1: 097d6b02fabb284418a9c95ea81fa86fc3c85bb7
   v1.31.1:
     sha1: a0fd9dc942f533e2bdeaa4b2691fc408e334f922
+  v1.32.0:
+    sha1: 0bc860f7bc83b991ee3b099e21504a60c515cfd7
 calicoctl:
 # calicoctl version is duplicated from kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
 # It also corresponds to the plugin version in kubemarine/resources/configurations/compatibility/internal/plugins.yaml
@@ -158,6 +164,9 @@ calicoctl:
     version: v3.29.1
     sha1: 00be749d257eee5035d3ba408aca15fcaf8be7c2
   v1.31.1:
+    version: v3.29.1
+    sha1: 00be749d257eee5035d3ba408aca15fcaf8be7c2
+  v1.32.0:
     version: v3.29.1
     sha1: 00be749d257eee5035d3ba408aca15fcaf8be7c2
 crictl:
@@ -214,3 +223,6 @@ crictl:
   v1.31.1:
     version: v1.30.0
     sha1: c81e76d5d4bf64d6b513485490722d2fc0a9a83b
+  v1.32.0:
+    version: v1.32.0
+    sha1: c503051cf6e809a691f776ddf544abfc2a15e790

--- a/kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
+++ b/kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
@@ -10,6 +10,8 @@ kubernetes_versions:
     supported: true
   v1.31:
     supported: true
+  v1.32:
+    supported: true
 compatibility_map:
 # This section should be changed manually.
   v1.27.1:
@@ -114,6 +116,12 @@ compatibility_map:
     kubernetes-dashboard: v2.7.0
     local-path-provisioner: v0.0.27
     crictl: v1.30.0
+  v1.32.0:
+    calico: v3.29.1
+    nginx-ingress-controller: v1.11.1
+    kubernetes-dashboard: v2.7.0
+    local-path-provisioner: v0.0.27
+    crictl: v1.32.0
 # After any change, please run scripts/thirdparties/sync.py
 
 # The following optional keys are supported in addition to the 5 required software keys:


### PR DESCRIPTION
### Description
* New Kubernetes version v1.32.0 is available and we are going to add support for it in kubemarine

Fixes # (issue)
[CPDEV-110491](https://tms.netcracker.com/browse/CPDEV-110491)

### Solution
*  Add support for v1.32.0




### Test Cases
**TestCase 1**
* Run `kubemarine install` procedure for k8s version **v1.32.0**


Test Configuration:

- Hardware: Openshift
- OS: Ubuntu 22.04 LTS
- Inventory: MiniHA/FullHA/All-in-One


Results:

| Before | After |
| ------ | ------ |
|  Failed to proceed inventory file.  KME0008: Specified Kubernetes version 'v1.32.0' - cannot be used!   | Successful installation of cluster with kubernetes version v1.32.0 |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no breaking changes, or migration patch is provided
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


