### PR TITLE
[CPDEV-110904] Deprecated version (v3) of the artifact actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           docker cp "${CONTAINER_ID}:/opt/kubemarine/dist" dist
           docker rm -v "${CONTAINER_ID}"
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: ./dist
@@ -59,7 +59,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Download Package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: package
           path: ./dist
@@ -69,7 +69,7 @@ jobs:
         run: ${{ matrix.executable_path }} selftest
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kubemarine-${{ matrix.target.arch }}
           path: ${{ matrix.executable_path }}
@@ -81,7 +81,7 @@ jobs:
     needs: build-binary
     steps:
       - name: Download Executable
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kubemarine-macos14-arm64
       - name: Run Selftest
@@ -121,7 +121,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Download Package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: package
           path: ./dist
@@ -163,7 +163,7 @@ jobs:
           echo "target_commitish=$BRANCH_OWNERS" >> $GITHUB_OUTPUT
 
       - name: Download Package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: package
           path: ./dist
@@ -195,7 +195,7 @@ jobs:
             ext: '.exe'
     steps:
       - name: Download Executable
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kubemarine-${{ matrix.arch }}
 

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -86,7 +86,7 @@ jobs:
         run: rename 's/[:]/_/g' ./results/*/dump/*
       - name: Collect dump artifacts
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: default_cluster_procedure_dumps-${{ matrix.kubernetes-version }}
           path: ./results/
@@ -148,7 +148,7 @@ jobs:
         run: rename 's/[:]/_/g' ./results/*/dump/*
       - name: Collect dump artifacts
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: extended_cluster_procedure_dumps
           path: ./results/

--- a/kubemarine/kubernetes/components.py
+++ b/kubemarine/kubernetes/components.py
@@ -895,7 +895,7 @@ def compare_kubelet_config(cluster: KubernetesCluster, *, with_inventory: bool) 
 def compare_configmap(cluster: KubernetesCluster, configmap: str) -> Optional[str]:
     control_plane = cluster.nodes['control-plane'].get_first_member()
     kubeadm_config = KubeadmConfig(cluster)
-    
+
     if configmap == 'kubelet-config':
         # Do not check kubelet-config ConfigMap, because some properties may be deleted from KubeletConfiguration
         # if set to default, for example readOnlyPort: 0, protectKernelDefaults: false

--- a/kubemarine/kubernetes/components.py
+++ b/kubemarine/kubernetes/components.py
@@ -895,7 +895,7 @@ def compare_kubelet_config(cluster: KubernetesCluster, *, with_inventory: bool) 
 def compare_configmap(cluster: KubernetesCluster, configmap: str) -> Optional[str]:
     control_plane = cluster.nodes['control-plane'].get_first_member()
     kubeadm_config = KubeadmConfig(cluster)
-
+    
     if configmap == 'kubelet-config':
         # Do not check kubelet-config ConfigMap, because some properties may be deleted from KubeletConfiguration
         # if set to default, for example readOnlyPort: 0, protectKernelDefaults: false


### PR DESCRIPTION
### Description
* Gitlab actions are failing due Deprecated version (v3) of the artifact actions as starting for **30th January 2025**, v3 version of artifact actions has been deprecated.

Fixes # (issue)
* [CPDEV-110904]

### Solution
* Updated version of artifact actions to **v4**


### How to apply
Provide steps how to apply on top previous Kubemarine version to execute on existing clusters
* [Install task/s](documentation/Installation.md#installation-tasks-description)
* Manual step 
* [Upgrade procedure](documentation/Maintenance.md#upgrade-procedure)


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no breaking changes, or migration patch is provided
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts
