### PR TITLE
Update version for gh-action-pypi-publish

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -15,6 +15,6 @@ jobs:
       - name: Unpack Package
         run: unzip package.zip
       - name: Publish Package
-        uses: pypa/gh-action-pypi-publish@v1.12.0
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### Description
* Deprecated version of `gh-action-pypi-publish` is causing failure for pypi package publishing 

### Solution
* Update version for `gh-action-pypi-publish` to **v1.12.4**