### PR TITLE
Support unauthenticated OIDC discovery endpoint

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2,14 +2,12 @@ This section provides information about the inventory, features, and steps for i
 
 - [Prerequisites](#prerequisites)
   - [Prerequisites for Deployment Node](#prerequisites-for-deployment-node)
-    - [Windows Deployer Restrictions](#windows-deployer-restrictions)
   - [Prerequisites for Cluster Nodes](#prerequisites-for-cluster-nodes)
     - [Minimal Hardware Requirements](#minimal-hardware-requirements)
     - [Recommended Hardware Requirements](#recommended-hardware-requirements)
     - [Disk Partitioning Recommendation](#disk-partitioning-recommendation)
-      - [Disk Pressure](#disk-pressure)
     - [ETCD Recommendation](#etcd-recommendation)
-    - [SSH Key Recommendation](#ssh-key-recommendation)
+    - [SSH key Recommendation](#ssh-key-recommendation)
     - [Private Certificate Authority](#private-certificate-authority)
 - [Inventory Preparation](#inventory-preparation)
   - [Deployment Schemes](#deployment-schemes)
@@ -19,85 +17,59 @@ This section provides information about the inventory, features, and steps for i
       - [Mini-HA Scheme](#mini-ha-scheme)
       - [Full-HA Scheme](#full-ha-scheme)
   - [Taints and Toleration](#taints-and-toleration)
-      - [CoreDNS Deployment with Node Taints](#coredns-deployment-with-node-taints)
-      - [Plugins Deployment with Node Taints](#plugins-deployment-with-node-taints)
   - [Configuration](#configuration)
-      - [Inventory validation](#inventory-validation)
     - [globals](#globals)
-    - [node\_defaults](#node_defaults)
+    - [node_defaults](#node_defaults)
     - [nodes](#nodes)
-    - [cluster\_name](#cluster_name)
-    - [control\_plain](#control_plain)
-      - [control\_endpoint](#control_endpoint)
-    - [public\_cluster\_ip](#public_cluster_ip)
+    - [cluster_name](#cluster_name)
+    - [control_plain](#control_plain)
+    - [public_cluster_ip](#public_cluster_ip)
     - [registry](#registry)
-      - [registry (new endpoints format)](#registry-new-endpoints-format)
-      - [registry (old address-port format)](#registry-old-address-port-format)
-    - [gateway\_nodes](#gateway_nodes)
-    - [vrrp\_ips](#vrrp_ips)
-      - [maintenance type](#maintenance-type)
+    - [gateway_nodes](#gateway_nodes)
+    - [vrrp_ips](#vrrp_ips)
     - [services](#services)
       - [kubeadm](#kubeadm)
-      - [Kubernetes version](#kubernetes-version)
-    - [Service Account Issuer](#service-account-issuer)
-      - [kubeadm\_kubelet](#kubeadm_kubelet)
-      - [kubeadm\_kube-proxy](#kubeadm_kube-proxy)
-      - [kubeadm\_patches](#kubeadm_patches)
-      - [kernel\_security](#kernel_security)
+        - [Kubernetes version](#kubernetes-version)
+        - [Service Account Issuer](#service-account-issuer)
+      - [kubeadm_kubelet](#kubeadm_kubelet)
+      - [kubeadm_kube-proxy](#kubeadm_kube-proxy)
+      - [kubeadm_patches](#kubeadm_patches)
+      - [kernel_security](#kernel_security)
         - [selinux](#selinux)
         - [apparmor](#apparmor)
       - [packages](#packages)
-        - [package\_manager](#package_manager)
+        - [package_manager](#package_manager)
         - [management](#management)
-          - [mandatory](#mandatory)
-          - [custom](#custom)
         - [associations](#associations)
-          - [RHEL and Centos](#rhel-and-centos)
-          - [Ubuntu and Debian](#ubuntu-and-debian)
       - [thirdparties](#thirdparties)
-        - [secure registries for thirdparties](#secure-registries-for-thirdparties)
       - [CRI](#cri)
       - [modprobe](#modprobe)
       - [sysctl](#sysctl)
       - [audit](#audit)
-        - [Audit Kubernetes Policy](#audit-kubernetes-policy)
-        - [Audit Daemon](#audit-daemon)
+        - [Kubernetes Policy](#audit-kubernetes-policy)
+        - [Daemon](#audit-daemon)
       - [ntp](#ntp)
         - [chrony](#chrony)
         - [timesyncd](#timesyncd)
       - [resolv.conf](#resolvconf)
-      - [etc\_hosts](#etc_hosts)
+      - [etc_hosts](#etc_hosts)
       - [coredns](#coredns)
-        - [add\_etc\_hosts\_generated](#add_etc_hosts_generated)
-        - [configmap](#configmap)
-        - [deployment](#deployment)
       - [loadbalancer](#loadbalancer)
-          - [target\_ports](#target_ports)
-        - [haproxy](#haproxy)
-        - [keepalived](#keepalived)
-      - [maintenance mode](#maintenance-mode)
     - [patches](#patches)
     - [RBAC pss](#rbac-pss)
       - [Configuring Default Profiles](#configuring-default-profiles)
       - [Configuring Exemptions](#configuring-exemptions)
       - [Application Prerequisites](#application-prerequisites)
     - [RBAC Accounts](#rbac-accounts)
-    - [RBAC account\_defaults](#rbac-account_defaults)
-    - [RBAC Authenticated Issuer Discovery](#rbac-authenticated-issuer-discovery)
+      - [RBAC account_defaults](#rbac-account_defaults)
     - [Plugins](#plugins)
       - [Predefined Plugins](#predefined-plugins)
         - [calico](#calico)
-          - [Calico BGP Configuration](#calico-bgp-configuration)
-          - [Default Typha Tolerations](#default-typha-tolerations)
-          - [Calico Metrics Configuration](#calico-metrics-configuration)
-          - [Calico Environment Properties](#calico-environment-properties)
-          - [Calico API server](#calico-api-server)
         - [nginx-ingress-controller](#nginx-ingress-controller)
-          - [monitoring](#monitoring)
         - [kubernetes-dashboard](#kubernetes-dashboard)
         - [local-path-provisioner](#local-path-provisioner)
       - [Plugins Features](#plugins-features)
-        - [plugin\_defaults](#plugin_defaults)
+        - [plugin_defaults](#plugin_defaults)
         - [Plugins Reinstallation](#plugins-reinstallation)
         - [Plugins Installation Order](#plugins-installation-order)
         - [Node Selector](#node-selector)
@@ -131,20 +103,15 @@ This section provides information about the inventory, features, and steps for i
   - [Tasks List Redefinition](#tasks-list-redefinition)
   - [Logging](#logging)
   - [Dump Files](#dump-files)
-    - [Finalized Dump](#finalized-dump)
   - [Configurations Backup](#configurations-backup)
   - [Ansible Inventory](#ansible-inventory)
     - [Contents](#contents)
-      - [\[all\]](#all)
-      - [\[cluster:children\]](#clusterchildren)
-      - [\[balancer\], \[control-plane\], \[worker\]](#balancer-control-plane-worker)
-      - [\[cluster:vars\]](#clustervars)
+      - [[all]](#all)
+      - [[cluster:children]](#clusterchildren)
+      - [[balancer], [control-plane], [worker]](#balancer-control-plane-worker)
+      - [[cluster:vars]](#clustervars)
   - [Cumulative Points](#cumulative-points)
 - [Supported Versions](#supported-versions)
-  - [Default Dependent Components Versions for Kubernetes Versions v1.29.10](#default-dependent-components-versions-for-kubernetes-versions-v12910)
-  - [Default Dependent Components Versions for Kubernetes Versions v1.30.10](#default-dependent-components-versions-for-kubernetes-versions-v13010)
-  - [Default Dependent Components Versions for Kubernetes Versions v1.31.6](#default-dependent-components-versions-for-kubernetes-versions-v1316)
-  - [Default Dependent Components Versions for Kubernetes Versions v1.32.2](#default-dependent-components-versions-for-kubernetes-versions-v1322)
 
 # Prerequisites
 
@@ -3776,28 +3743,6 @@ rbac:
 ```
 
 The yaml file that is created from the above template is applied to the cluster during the installation procedure.
-
-### RBAC Authenticated Issuer Discovery
-
-*Installation task*: `deploy.accounts`
-
-To configure service account issuer discovery authentication you can use
-following flag:
-```yaml
-rbac:
-  authenticated-issuer-discovery: False
-```
-
-By default KubeMarine sets this flag to `False`, 
-which allows unauthenticated access to 
-service account issuer discovery endpoint, usually found at 
-`https://<cluster_ip>:6443/.well-known/openid-configuration/`. 
-
-This is different from default K8s behavior, 
-where this endpoint requires authentication.
-We disable authentication by default, 
-because some applications do not support authentication 
-on OIDC discovery endpoints.
 
 ### Plugins
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -2,12 +2,14 @@ This section provides information about the inventory, features, and steps for i
 
 - [Prerequisites](#prerequisites)
   - [Prerequisites for Deployment Node](#prerequisites-for-deployment-node)
+    - [Windows Deployer Restrictions](#windows-deployer-restrictions)
   - [Prerequisites for Cluster Nodes](#prerequisites-for-cluster-nodes)
     - [Minimal Hardware Requirements](#minimal-hardware-requirements)
     - [Recommended Hardware Requirements](#recommended-hardware-requirements)
     - [Disk Partitioning Recommendation](#disk-partitioning-recommendation)
+      - [Disk Pressure](#disk-pressure)
     - [ETCD Recommendation](#etcd-recommendation)
-    - [SSH key Recommendation](#ssh-key-recommendation)
+    - [SSH Key Recommendation](#ssh-key-recommendation)
     - [Private Certificate Authority](#private-certificate-authority)
 - [Inventory Preparation](#inventory-preparation)
   - [Deployment Schemes](#deployment-schemes)
@@ -17,59 +19,85 @@ This section provides information about the inventory, features, and steps for i
       - [Mini-HA Scheme](#mini-ha-scheme)
       - [Full-HA Scheme](#full-ha-scheme)
   - [Taints and Toleration](#taints-and-toleration)
+      - [CoreDNS Deployment with Node Taints](#coredns-deployment-with-node-taints)
+      - [Plugins Deployment with Node Taints](#plugins-deployment-with-node-taints)
   - [Configuration](#configuration)
+      - [Inventory validation](#inventory-validation)
     - [globals](#globals)
-    - [node_defaults](#node_defaults)
+    - [node\_defaults](#node_defaults)
     - [nodes](#nodes)
-    - [cluster_name](#cluster_name)
-    - [control_plain](#control_plain)
-    - [public_cluster_ip](#public_cluster_ip)
+    - [cluster\_name](#cluster_name)
+    - [control\_plain](#control_plain)
+      - [control\_endpoint](#control_endpoint)
+    - [public\_cluster\_ip](#public_cluster_ip)
     - [registry](#registry)
-    - [gateway_nodes](#gateway_nodes)
-    - [vrrp_ips](#vrrp_ips)
+      - [registry (new endpoints format)](#registry-new-endpoints-format)
+      - [registry (old address-port format)](#registry-old-address-port-format)
+    - [gateway\_nodes](#gateway_nodes)
+    - [vrrp\_ips](#vrrp_ips)
+      - [maintenance type](#maintenance-type)
     - [services](#services)
       - [kubeadm](#kubeadm)
-        - [Kubernetes version](#kubernetes-version)
-        - [Service Account Issuer](#service-account-issuer)
-      - [kubeadm_kubelet](#kubeadm_kubelet)
-      - [kubeadm_kube-proxy](#kubeadm_kube-proxy)
-      - [kubeadm_patches](#kubeadm_patches)
-      - [kernel_security](#kernel_security)
+      - [Kubernetes version](#kubernetes-version)
+    - [Service Account Issuer](#service-account-issuer)
+      - [kubeadm\_kubelet](#kubeadm_kubelet)
+      - [kubeadm\_kube-proxy](#kubeadm_kube-proxy)
+      - [kubeadm\_patches](#kubeadm_patches)
+      - [kernel\_security](#kernel_security)
         - [selinux](#selinux)
         - [apparmor](#apparmor)
       - [packages](#packages)
-        - [package_manager](#package_manager)
+        - [package\_manager](#package_manager)
         - [management](#management)
+          - [mandatory](#mandatory)
+          - [custom](#custom)
         - [associations](#associations)
+          - [RHEL and Centos](#rhel-and-centos)
+          - [Ubuntu and Debian](#ubuntu-and-debian)
       - [thirdparties](#thirdparties)
+        - [secure registries for thirdparties](#secure-registries-for-thirdparties)
       - [CRI](#cri)
       - [modprobe](#modprobe)
       - [sysctl](#sysctl)
       - [audit](#audit)
-        - [Kubernetes Policy](#audit-kubernetes-policy)
-        - [Daemon](#audit-daemon)
+        - [Audit Kubernetes Policy](#audit-kubernetes-policy)
+        - [Audit Daemon](#audit-daemon)
       - [ntp](#ntp)
         - [chrony](#chrony)
         - [timesyncd](#timesyncd)
       - [resolv.conf](#resolvconf)
-      - [etc_hosts](#etc_hosts)
+      - [etc\_hosts](#etc_hosts)
       - [coredns](#coredns)
+        - [add\_etc\_hosts\_generated](#add_etc_hosts_generated)
+        - [configmap](#configmap)
+        - [deployment](#deployment)
       - [loadbalancer](#loadbalancer)
+          - [target\_ports](#target_ports)
+        - [haproxy](#haproxy)
+        - [keepalived](#keepalived)
+      - [maintenance mode](#maintenance-mode)
     - [patches](#patches)
     - [RBAC pss](#rbac-pss)
       - [Configuring Default Profiles](#configuring-default-profiles)
       - [Configuring Exemptions](#configuring-exemptions)
       - [Application Prerequisites](#application-prerequisites)
     - [RBAC Accounts](#rbac-accounts)
-      - [RBAC account_defaults](#rbac-account_defaults)
+    - [RBAC account\_defaults](#rbac-account_defaults)
+    - [RBAC Authenticated Issuer Discovery](#rbac-authenticated-issuer-discovery)
     - [Plugins](#plugins)
       - [Predefined Plugins](#predefined-plugins)
         - [calico](#calico)
+          - [Calico BGP Configuration](#calico-bgp-configuration)
+          - [Default Typha Tolerations](#default-typha-tolerations)
+          - [Calico Metrics Configuration](#calico-metrics-configuration)
+          - [Calico Environment Properties](#calico-environment-properties)
+          - [Calico API server](#calico-api-server)
         - [nginx-ingress-controller](#nginx-ingress-controller)
+          - [monitoring](#monitoring)
         - [kubernetes-dashboard](#kubernetes-dashboard)
         - [local-path-provisioner](#local-path-provisioner)
       - [Plugins Features](#plugins-features)
-        - [plugin_defaults](#plugin_defaults)
+        - [plugin\_defaults](#plugin_defaults)
         - [Plugins Reinstallation](#plugins-reinstallation)
         - [Plugins Installation Order](#plugins-installation-order)
         - [Node Selector](#node-selector)
@@ -103,15 +131,20 @@ This section provides information about the inventory, features, and steps for i
   - [Tasks List Redefinition](#tasks-list-redefinition)
   - [Logging](#logging)
   - [Dump Files](#dump-files)
+    - [Finalized Dump](#finalized-dump)
   - [Configurations Backup](#configurations-backup)
   - [Ansible Inventory](#ansible-inventory)
     - [Contents](#contents)
-      - [[all]](#all)
-      - [[cluster:children]](#clusterchildren)
-      - [[balancer], [control-plane], [worker]](#balancer-control-plane-worker)
-      - [[cluster:vars]](#clustervars)
+      - [\[all\]](#all)
+      - [\[cluster:children\]](#clusterchildren)
+      - [\[balancer\], \[control-plane\], \[worker\]](#balancer-control-plane-worker)
+      - [\[cluster:vars\]](#clustervars)
   - [Cumulative Points](#cumulative-points)
 - [Supported Versions](#supported-versions)
+  - [Default Dependent Components Versions for Kubernetes Versions v1.29.10](#default-dependent-components-versions-for-kubernetes-versions-v12910)
+  - [Default Dependent Components Versions for Kubernetes Versions v1.30.10](#default-dependent-components-versions-for-kubernetes-versions-v13010)
+  - [Default Dependent Components Versions for Kubernetes Versions v1.31.6](#default-dependent-components-versions-for-kubernetes-versions-v1316)
+  - [Default Dependent Components Versions for Kubernetes Versions v1.32.2](#default-dependent-components-versions-for-kubernetes-versions-v1322)
 
 # Prerequisites
 
@@ -3743,6 +3776,28 @@ rbac:
 ```
 
 The yaml file that is created from the above template is applied to the cluster during the installation procedure.
+
+### RBAC Authenticated Issuer Discovery
+
+*Installation task*: `deploy.accounts`
+
+To configure service account issuer discovery authentication you can use
+following flag:
+```yaml
+rbac:
+  authenticated-issuer-discovery: False
+```
+
+By default KubeMarine sets this flag to `False`, 
+which allows unauthenticated access to 
+service account issuer discovery endpoint, usually found at 
+`https://<cluster_ip>:6443/.well-known/openid-configuration/`. 
+
+This is different from default K8s behavior, 
+where this endpoint requires authentication.
+We disable authentication by default, 
+because some applications do not support authentication 
+on OIDC discovery endpoints.
 
 ### Plugins
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3798,6 +3798,7 @@ where this endpoint requires authentication.
 We disable authentication by default, 
 because some applications do not support authentication 
 on OIDC discovery endpoints.
+For more information see https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
 
 ### Plugins
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3753,10 +3753,10 @@ To configure service account issuer discovery authentication you can use
 following flag:
 ```yaml
 rbac:
-  authenticated-issuer-discovery: False
+  authenticated-issuer-discovery: false
 ```
 
-By default KubeMarine sets this flag to `False`, 
+By default KubeMarine sets this flag to `false`, 
 which allows unauthenticated access to 
 service account issuer discovery endpoint, usually found at 
 `https://<cluster_ip>:6443/.well-known/openid-configuration/`. 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3766,6 +3766,7 @@ where this endpoint requires authentication.
 We disable authentication by default, 
 because some applications do not support authentication 
 on OIDC discovery endpoints.
+For more information see https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
 
 ### Plugins
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3798,7 +3798,6 @@ where this endpoint requires authentication.
 We disable authentication by default, 
 because some applications do not support authentication 
 on OIDC discovery endpoints.
-For more information see https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
 
 ### Plugins
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -62,6 +62,7 @@ This section provides information about the inventory, features, and steps for i
       - [Application Prerequisites](#application-prerequisites)
     - [RBAC Accounts](#rbac-accounts)
       - [RBAC account_defaults](#rbac-account_defaults)
+    - [RBAC Authenticated Issuer Discovery](#rbac-authenticated-issuer-discovery)
     - [Plugins](#plugins)
       - [Predefined Plugins](#predefined-plugins)
         - [calico](#calico)
@@ -3743,6 +3744,28 @@ rbac:
 ```
 
 The yaml file that is created from the above template is applied to the cluster during the installation procedure.
+
+### RBAC Authenticated Issuer Discovery
+
+*Installation task*: `deploy.accounts`
+
+To configure service account issuer discovery authentication you can use
+following flag:
+```yaml
+rbac:
+  authenticated-issuer-discovery: False
+```
+
+By default KubeMarine sets this flag to `False`, 
+which allows unauthenticated access to 
+service account issuer discovery endpoint, usually found at 
+`https://<cluster_ip>:6443/.well-known/openid-configuration/`. 
+
+This is different from default K8s behavior, 
+where this endpoint requires authentication.
+We disable authentication by default, 
+because some applications do not support authentication 
+on OIDC discovery endpoints.
 
 ### Plugins
 

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -62,7 +62,8 @@ def handle_authenticated_sa_issuer_discovery(cluster: KubernetesCluster) -> None
     To disable authentication, we apply CRB which allows unauthenticated access.
     To enable authentication, we delete above CRB (if it is present).
 
-    For more information on the cluster role: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
+    For more information on the cluster role: 
+    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
     """
     mode = "unauthenticated"
     kubectl_cmd = "apply"

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -58,14 +58,9 @@ def enrich_inventory(cluster: KubernetesCluster) -> None:
 def handle_authenticated_sa_issuer_discovery(cluster: KubernetesCluster) -> None:
     """
     This function handles SA issuer discovery endpoint authentication
-    Endpoint URL is: https://<cluster_ip>:6443/.well-known/openid-configuration/
 
     To disable authentication, we apply CRB which allows unauthenticated access.
     To enable authentication, we delete above CRB (if it is present).
-
-    Enable/disable is controlled by "rbac.authenticated-issuer-discovery" flag.
-    By default, we disable authentication. 
-    This is in contrast to native k8s default, where it is enabled by default.
     """
     mode = "unauthenticated"
     kubectl_cmd = "apply"

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import io
+from textwrap import dedent
 from typing import Optional
 
 import yaml
@@ -54,7 +55,51 @@ def enrich_inventory(cluster: KubernetesCluster) -> None:
             rbac["accounts"][i]['configs'][2]['metadata']['namespace'] = account['namespace']
 
 
+def handle_authenticated_sa_issuer_discovery(cluster: KubernetesCluster) -> None:
+    """
+    This function handles SA issuer discovery endpoint authentication
+    Endpoint URL is: https://<cluster_ip>:6443/.well-known/openid-configuration/
+
+    To disable authentication, we apply CRB which allows unauthenticated access.
+    To enable authentication, we delete above CRB (if it is present).
+
+    Enable/disable is controlled by "rbac.authenticated-issuer-discovery" flag.
+    By default, we disable authentication. 
+    This is in contrast to native k8s default, where it is enabled by default.
+    """
+    mode = "unauthenticated"
+    kubectl_cmd = "apply"
+    if cluster.inventory.get("rbac", {}).get("authenticated-issuer-discovery", False):
+        mode = "authenticated"
+        kubectl_cmd = "delete --ignore-not-found"
+    issuer_discovery_crb = dedent("""\
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1
+        metadata:
+          name: kubemarine-unauthenticated-service-account-issuer-discovery
+        subjects:
+        - apiGroup: rbac.authorization.k8s.io
+          kind: Group
+          name: system:unauthenticated
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: system:service-account-issuer-discovery
+    """)
+
+    cluster.log.debug(f"Configuring {mode} service account issuer discovery...")
+    tmp_path = utils.get_remote_tmp_path()
+    node = cluster.nodes['control-plane'].get_first_member()
+    node.put(io.StringIO(issuer_discovery_crb), tmp_path, sudo=True)
+    node.sudo(f"kubectl {kubectl_cmd} -f {tmp_path}", hide=False)
+
+
 def install(cluster: KubernetesCluster) -> None:
+    # issuer discovery authentication is handled as part of deploy.accounts,
+    # because deploy.accounts is safe to re-run (idempotent) and
+    # discovery authentication does not worth a separate install task
+    handle_authenticated_sa_issuer_discovery(cluster)
+
     rbac = cluster.inventory['rbac']
     if not rbac.get("accounts"):
         cluster.log.debug("No accounts specified to install, skipping...")

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -58,9 +58,14 @@ def enrich_inventory(cluster: KubernetesCluster) -> None:
 def handle_authenticated_sa_issuer_discovery(cluster: KubernetesCluster) -> None:
     """
     This function handles SA issuer discovery endpoint authentication
+    Endpoint URL is: https://<cluster_ip>:6443/.well-known/openid-configuration/
 
     To disable authentication, we apply CRB which allows unauthenticated access.
     To enable authentication, we delete above CRB (if it is present).
+
+    Enable/disable is controlled by "rbac.authenticated-issuer-discovery" flag.
+    By default, we disable authentication. 
+    This is in contrast to native k8s default, where it is enabled by default.
     """
     mode = "unauthenticated"
     kubectl_cmd = "apply"

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -61,6 +61,8 @@ def handle_authenticated_sa_issuer_discovery(cluster: KubernetesCluster) -> None
 
     To disable authentication, we apply CRB which allows unauthenticated access.
     To enable authentication, we delete above CRB (if it is present).
+
+    For more information on the cluster role: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
     """
     mode = "unauthenticated"
     kubectl_cmd = "apply"

--- a/kubemarine/kubernetes_accounts.py
+++ b/kubemarine/kubernetes_accounts.py
@@ -61,8 +61,6 @@ def handle_authenticated_sa_issuer_discovery(cluster: KubernetesCluster) -> None
 
     To disable authentication, we apply CRB which allows unauthenticated access.
     To enable authentication, we delete above CRB (if it is present).
-
-    For more information on the cluster role: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
     """
     mode = "unauthenticated"
     kubectl_cmd = "apply"

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -22,8 +22,10 @@ The whole directory is automatically cleared and reset after new version of Kube
 from typing import List
 
 from kubemarine.core.patch import Patch
+from kubemarine.patches.configure_sa_issuer_discovery import ConfigureSAIssuerDiscovery
 
 patches: List[Patch] = [
+    ConfigureSAIssuerDiscovery()
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/configure_sa_issuer_discovery.py
+++ b/kubemarine/patches/configure_sa_issuer_discovery.py
@@ -1,0 +1,33 @@
+from textwrap import dedent
+
+from kubemarine.core.action import Action
+from kubemarine.core.patch import RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine import kubernetes_accounts
+
+
+class ConfigureSAIssuerDiscoveryAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Configure SA Issuer Discovery")
+
+    def run(self, res: DynamicResources) -> None:
+        cluster = res.cluster()
+        kubernetes_accounts.handle_authenticated_sa_issuer_discovery(cluster)
+
+
+class ConfigureSAIssuerDiscovery(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("configure_sa_issuer_discovery")
+
+    @property
+    def action(self) -> Action:
+        return ConfigureSAIssuerDiscoveryAction()
+
+    @property
+    def description(self) -> str:
+        return dedent(
+            f"""\
+            This patch applies new default parameter rbac.authenticated-issuer-discovery.
+            By default, it will allow unauthenticated access to service account issuer discovery endpoint.
+            """.rstrip()
+        )

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -893,6 +893,8 @@ rbac:
       usernames: []
       runtimeClasses: []
       namespaces: ["kube-system"]
+  
+  authenticated-issuer-discovery: false
 
 procedure_history:
   archive_threshold: 5

--- a/kubemarine/resources/schemas/definitions/rbac.json
+++ b/kubemarine/resources/schemas/definitions/rbac.json
@@ -19,6 +19,11 @@
       "default": "pss",
       "description": "Admission implementation switcher"
     },
+    "authenticated-issuer-discovery": {
+      "type": "boolean",
+      "default": false,
+      "description": "Authenticated issuer discovery switcher"
+    },
     "pss": {
       "$ref": "rbac/pss.json"
     }


### PR DESCRIPTION
### Description
Some applications do not support authenticated OIDC discovery endpoints, but Kubernetes by default enables authentication https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery

Need to disable this authentication by default, but allow to enable it if needed

### Solution
* added new boolean parameter `rbac.authenticated-issuer-discovery` which is set to `false` by default (disable authentication)
* `deploy.accounts` install task was extended to apply/delete CRB which allows unauthenticated users to access OIDC discovery endpoints
* added patch to apply new default on existing clusters
* added documentation


### How to apply
* `migrate_kubemarine` with patch `configure_sa_issuer_discovery`


### Test Cases

**TestCase 1**

New KubeMarine version migration should enable unauthenticated access to OIDC discovery endpoint

Steps:
1. Install cluster with previous KubeMarine version
2. Access OIDC discovery endpoint, e.g. `curl https://${CLUSTER_IP}:6443/.well-known/openid-configuration/ -k`
3. You should see 403 Forbidden error
4. Take new KubeMarine version and run `migrate_kubemarine` (do not modify `cluster.yaml`)
5. OIDC discovery endpoint should become available by default

**TestCase 2**

New KubeMarine version clean installation should allow unauthenticated access to OIDC discovery endpoint.
It should be possible to enable authentication afterwards.

Steps:
1. Install cluster with new KubeMarine version
2. Access OIDC discovery endpoint, e.g. `curl https://${CLUSTER_IP}:6443/.well-known/openid-configuration/ -k`
3. You should not see any error, endpoint should be available
4. Change cluster.yaml, set `rbac.authenticated-issuer-discovery: true`
5. Run install procedure with `deploy.accounts` task
6. OIDC discovery endpoint should become unavailable returning 403 Forbidden

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no breaking changes, or migration patch is provided
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


