### PR TITLE
Troubleshooting Guide for OL9 OpenSSL version mismatch problem

### DIFF
--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -2197,10 +2197,10 @@ Ensure that the cluster's certificate management process is aligned with the sec
 
 **Note**: Not applicable.
 
-## OpenSSH server becomes unavailable during cluster installation on Centos9
+## OpenSSH server becomes unavailable during cluster installation
 
 ### Description
-During cluster installation on Centos9, the OpenSSH server becomes unavailable, leading to a failure in the installation process at the `kubemarine.system.reboot_nodes` stage. This issue is caused by a version mismatch between OpenSSL and OpenSSH, which results in OpenSSH being unable to start.
+During cluster installation on Centos9 or Oracle Linux 9, the OpenSSH server becomes unavailable, leading to a failure in the installation process at the `kubemarine.system.reboot_nodes` stage. This issue is caused by a version mismatch between OpenSSL and OpenSSH, which results in OpenSSH being unable to start.
 
 ### Alerts
 Not applicable.


### PR DESCRIPTION
### Description
During installation on OL9, SSH stops working after OpenSSL package installation with following error:
```
May 14 06:35:45 ol9-test sshd[17583]: OpenSSL version mismatch. Built against 30000070, you have 30200020
May 14 06:35:48 ol9-test sshd[17584]: OpenSSL version mismatch. Built against 30000070, you have 30200020
```
This problem is already described in our TG, but only for Centos 9

### Solution
* Updated TG to mention that OpenSSL version mismatch problem is relevant to OL9 too

### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] There is no breaking changes, or migration patch is provided
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts