### PR TITLE
per-node kubelet upgrade

### DIFF
--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -25,7 +25,7 @@ import yaml
 from jinja2 import Template
 from ordered_set import OrderedSet
 
-from kubemarine import system, admission, etcd, packages, jinja, sysctl
+from kubemarine import system, admission, etcd, packages, jinja, sysctl, thirdparties
 from kubemarine.core import utils, static, summary, log, errors
 from kubemarine.core.cluster import KubernetesCluster, EnrichmentStage, enrichment
 from kubemarine.core.executor import Token
@@ -754,6 +754,7 @@ def upgrade_first_control_plane(upgrade_group: NodeGroup, cluster: KubernetesClu
     drain_cmd = prepare_drain_command(cluster, node_name, **drain_kwargs)
     first_control_plane.sudo(drain_cmd, hide=False, pty=True)
 
+    thirdparties.install_thirdparty(first_control_plane, "/usr/bin/kubelet")
     upgrade_cri_if_required(first_control_plane)
     fix_flag_kubelet(first_control_plane)
 
@@ -789,6 +790,7 @@ def upgrade_other_control_planes(upgrade_group: NodeGroup, cluster: KubernetesCl
             drain_cmd = prepare_drain_command(cluster, node_name, **drain_kwargs)
             node.sudo(drain_cmd, hide=False, pty=True)
 
+            thirdparties.install_thirdparty(node, "/usr/bin/kubelet")
             upgrade_cri_if_required(node)
             fix_flag_kubelet(node)
 
@@ -824,6 +826,7 @@ def upgrade_workers(upgrade_group: NodeGroup, cluster: KubernetesCluster, **drai
         drain_cmd = prepare_drain_command(cluster, node_name, **drain_kwargs)
         first_control_plane.sudo(drain_cmd, hide=False, pty=True)
 
+        thirdparties.install_thirdparty(node, "/usr/bin/kubelet")        
         upgrade_cri_if_required(node)
         fix_flag_kubelet(node)
 

--- a/kubemarine/procedures/install.py
+++ b/kubemarine/procedures/install.py
@@ -350,7 +350,7 @@ def system_prepare_thirdparties(group: NodeGroup) -> None:
         cluster.log.debug("Skipped - no thirdparties defined in config file")
         return
 
-    group.call(thirdparties.install_all_thirparties)
+    group.call(thirdparties.install_all_thirdparties)
 
 
 @_applicable_for_new_nodes_with_roles('balancer')

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -38,8 +38,9 @@ def system_prepare_thirdparties(cluster: KubernetesCluster) -> None:
         cluster.log.debug("Skipped - no thirdparties defined in config file")
         return
 
-    # We exclude kubelet from global thirdparties upgrade, because it is disruptive.
-    # We upgrade kubelet per-node.
+    # We exclude kubelet from global thirdparties upgrade, 
+    # because kubelet upgrade is disruptive.
+    # We upgrade kubelet per-node later during kubernetes upgrade process.
     all_nodes = cluster.nodes["all"]
     all_nodes.call(thirdparties.install_all_thirdparties, exclude=["/usr/bin/kubelet"])
 

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -38,10 +38,10 @@ def system_prepare_thirdparties(cluster: KubernetesCluster) -> None:
         cluster.log.debug("Skipped - no thirdparties defined in config file")
         return
 
-    # We exclude kubelet from global thirdparties upgrade, 
-    # because kubelet upgrade is disruptive.
-    # We upgrade kubelet per-node later during kubernetes upgrade process.
-    all_nodes = cluster.nodes["all"]
+    # We exclude kubelet from global cross-nodes thirdparties upgrade, 
+    # because kubelet upgrade may be disruptive for running nodes.
+    # We upgrade kubelet per-node later, after draining the node.
+    all_nodes = cluster.make_group_from_roles(["control-plane", "worker"])
     all_nodes.call(thirdparties.install_all_thirdparties, exclude=["/usr/bin/kubelet"])
 
 

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -392,7 +392,7 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> Optional[Ru
     return common_group.sudo(remote_commands, pty=True)
 
 
-def install_all_thirparties(group: NodeGroup) -> None:
+def install_all_thirdparties(group: NodeGroup, exclude: List[str] = []) -> None:
     cluster: KubernetesCluster = group.cluster
     log = cluster.log
 
@@ -401,6 +401,10 @@ def install_all_thirparties(group: NodeGroup) -> None:
 
     for destination in cluster.inventory['services']['thirdparties'].keys():
         managing_plugin: Optional[str] = None
+
+        if destination in exclude:
+            log.verbose(f'Thirdparty {destination} is excluded from installation')
+            continue
 
         # install and upgrade procedures have separate tasks for thirdparties managed by plugins
         if cluster.context.get("initial_procedure") in ("install", "upgrade"):

--- a/kubemarine/thirdparties.py
+++ b/kubemarine/thirdparties.py
@@ -392,7 +392,7 @@ def install_thirdparty(filter_group: NodeGroup, destination: str) -> Optional[Ru
     return common_group.sudo(remote_commands, pty=True)
 
 
-def install_all_thirdparties(group: NodeGroup, exclude: List[str] = []) -> None:
+def install_all_thirdparties(group: NodeGroup, exclude: List[str] = None) -> None:
     cluster: KubernetesCluster = group.cluster
     log = cluster.log
 
@@ -402,7 +402,7 @@ def install_all_thirdparties(group: NodeGroup, exclude: List[str] = []) -> None:
     for destination in cluster.inventory['services']['thirdparties'].keys():
         managing_plugin: Optional[str] = None
 
-        if destination in exclude:
+        if exclude and destination in exclude:
             log.verbose(f'Thirdparty {destination} is excluded from installation')
             continue
 


### PR DESCRIPTION
### Description
During upgrade, if new kubelet version is installed on all nodes and then kubelet service is immediately restarted on all nodes, upgrade will fail, because a lot of pods in the cluster will become non-functional due to inconsistent kubelet/kubernetes version.
Overall, this is risky to upgrade kubelet globally on all nodes at the beginning of the upgrade, because upgrade may fail and cluster will be left in a fragile state with inconsistent kubelet.


### Solution
As the least invasive fix, we could upgrade kubelet per-node, right after node draining:
* changed `install_all_thirdparties` task:
  * now this task allows excluding thirdparty from upgrade
  * fixed name typo
* during upgrade, kubelet is excluded from global thirdparties upgrade
* kubelet thirdparty is upgraded per-node during control-plane/worker upgrade, right after draining the node

### Test Cases

**TestCase 1**

Steps:
1. Install cluster with k8s `v1.30.10`
2. Run upgrade to `v1.31.6` with only following tasks (first in upgrade tasks sequence):
    ```
    cleanup_tmp_dir,verify_upgrade_versions,thirdparties,prepull_images
    ``` 
3. Restart kubelet on all nodes, e.g. 
    ```
    kubemarine do -g all --no_stream -- systemctl restart kubelet
    ```
    These steps will simulate sudden upgrade and cluster failure after "prepull_images"
4.  Rerun upgrade from `v1.30.10` (make sure this version still used in `cluster.yaml`) to `v1.31.6` as usual, with all tasks included

Results:

| Before | After |
| ------ | ------ |
| Upgrade fails, since system containers are in a bad state after global kubelet upgrade/restart | Upgrade completes, since kubelet is not globally upgraded |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no breaking changes, or migration patch is provided
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

