### PR TITLE
Centos7 and rhel 7 is removed from the supported versions

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -164,9 +164,9 @@ For cluster machines, ensure the following requirements are met:
 
 * The following distributives and versions are supported:
 
-  * Centos 7.5+, 8.4, 9
-  * RHEL 7.5+, 8.4, 8.6, 8.7, 8.8, 8.9, 9.2
-  * Oracle Linux 7.5+, 8.4, 9.2
+  * Centos 8.4, 9
+  * RHEL 8.4, 8.6, 8.7, 8.8, 8.9, 9.2
+  * Oracle Linux 8.4, 9.2
   * RockyLinux 8.6, 8.7, 8.8, 9.2, 9.3 ,9.4, 9.5
   * Ubuntu 20.04, 22.04.1, 24.04.1
  

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -298,13 +298,6 @@ compatibility_map:
 
   distributives:
     centos:
-      - os_family: 'rhel'
-        versions:
-          - '7.5'
-          - '7.6'
-          - '7.7'
-          - '7.8'
-          - '7.9'
       - os_family: 'rhel8'
         versions:
           - '8.4'
@@ -312,13 +305,6 @@ compatibility_map:
         versions:
           - '9'
     rhel:
-      - os_family: 'rhel'
-        versions:
-          - '7.5'
-          - '7.6'
-          - '7.7'
-          - '7.8'
-          - '7.9'
       - os_family: 'rhel8'
         versions:
           - '8.4'
@@ -358,13 +344,6 @@ compatibility_map:
           - '10.9'
           - '10.10'
     ol:
-      - os_family: 'rhel'
-        versions:
-          - '7.5'
-          - '7.6'
-          - '7.7'
-          - '7.8'
-          - '7.9'
       - os_family: 'rhel8'
         versions:
           - '8.4'


### PR DESCRIPTION
### Description
Need to remove Centos 7 and rhel 7 from supported OS because as in Kubernetes 1.32+, cgroups v2 are preferred, but cgroups v1 are still supported. The kernel version in centos 7 does not include support for cgroups v2, and might cause errors during adding node or or upgrade procedures.
* 



### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] There is no breaking changes, or migration patch is provided
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


