### PR TITLE
Helm vulnerability fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt update && \
     else \
       pip3 install --no-cache-dir $(ls dist/*.whl)[ansible]; \
       apt install -y wget; \
-      wget -O - https://get.helm.sh/helm-v3.17.3-linux-amd64.tar.gz | tar xvz -C /usr/local/bin  linux-amd64/helm --strip-components 1; \
+      wget -O - https://get.helm.sh/helm-v3.18.3-linux-amd64.tar.gz | tar xvz -C /usr/local/bin  linux-amd64/helm --strip-components 1; \
       apt autoremove -y wget; \
       rm -r *; \
     fi && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,7 @@ RUN apt update && \
       find -not -path "./dist*" -delete; \
     else \
       pip3 install --no-cache-dir $(ls dist/*.whl)[ansible]; \
-      # minizip is installed to fix CVE-2023-45853
-      apt install -y wget minizip; \
+      apt install -y wget; \
       wget -O - https://get.helm.sh/helm-v3.18.3-linux-amd64.tar.gz | tar xvz -C /usr/local/bin  linux-amd64/helm --strip-components 1; \
       apt autoremove -y wget; \
       rm -r *; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN apt update && \
       find -not -path "./dist*" -delete; \
     else \
       pip3 install --no-cache-dir $(ls dist/*.whl)[ansible]; \
-      apt install -y wget; \
+      # minizip is installed to fix CVE-2023-45853
+      apt install -y wget minizip; \
       wget -O - https://get.helm.sh/helm-v3.18.3-linux-amd64.tar.gz | tar xvz -C /usr/local/bin  linux-amd64/helm --strip-components 1; \
       apt autoremove -y wget; \
       rm -r *; \


### PR DESCRIPTION
### Description
Need to update helm to fix vulnerability https://nvd.nist.gov/vuln/detail/CVE-2025-22871

Our helm version is affected, because it uses go 1.23.7.

### Solution
* Update to helm v3.18.3, which uses go 1.24 where this vulnerability is fixed
