### PR TITLE
revert calico update for old k8s patch versions

### DIFF
--- a/kubemarine/patches/software_upgrade.yaml
+++ b/kubemarine/patches/software_upgrade.yaml
@@ -9,12 +9,8 @@
 
 thirdparties:
   calicoctl:
-  - v1.30.1
-  - v1.30.3
   - v1.30.10
-  - v1.31.1
   - v1.31.6
-  - v1.32.0
   - v1.32.2
   - v1.33.0
   crictl: []
@@ -37,12 +33,8 @@ packages:
     version_debian: false
 plugins:
   calico:
-  - v1.30.1
-  - v1.30.3
   - v1.30.10
-  - v1.31.1
   - v1.31.6
-  - v1.32.0
   - v1.32.2
   - v1.33.0
   nginx-ingress-controller: []

--- a/kubemarine/resources/configurations/compatibility/internal/plugins.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/plugins.yaml
@@ -14,17 +14,17 @@ calico:
   v1.29.10:
     version: v3.29.1
   v1.30.1:
-    version: v3.29.4
+    version: v3.29.1
   v1.30.3:
-    version: v3.29.4
+    version: v3.29.1
   v1.30.10:
     version: v3.29.4
   v1.31.1:
-    version: v3.29.4
+    version: v3.29.1
   v1.31.6:
     version: v3.29.4
   v1.32.0:
-    version: v3.29.4
+    version: v3.29.1
   v1.32.2:
     version: v3.29.4
   v1.33.0:

--- a/kubemarine/resources/configurations/compatibility/internal/thirdparties.yaml
+++ b/kubemarine/resources/configurations/compatibility/internal/thirdparties.yaml
@@ -92,23 +92,23 @@ calicoctl:
     version: v3.29.1
     sha1: 00be749d257eee5035d3ba408aca15fcaf8be7c2
   v1.30.1:
-    version: v3.29.4
-    sha1: 899eba9872bd7362e19a17d4380ed16bf4d39717
+    version: v3.29.1
+    sha1: 00be749d257eee5035d3ba408aca15fcaf8be7c2
   v1.30.3:
-    version: v3.29.4
-    sha1: 899eba9872bd7362e19a17d4380ed16bf4d39717
+    version: v3.29.1
+    sha1: 00be749d257eee5035d3ba408aca15fcaf8be7c2
   v1.30.10:
     version: v3.29.4
     sha1: 899eba9872bd7362e19a17d4380ed16bf4d39717
   v1.31.1:
-    version: v3.29.4
-    sha1: 899eba9872bd7362e19a17d4380ed16bf4d39717
+    version: v3.29.1
+    sha1: 00be749d257eee5035d3ba408aca15fcaf8be7c2
   v1.31.6:
     version: v3.29.4
     sha1: 899eba9872bd7362e19a17d4380ed16bf4d39717
   v1.32.0:
-    version: v3.29.4
-    sha1: 899eba9872bd7362e19a17d4380ed16bf4d39717
+    version: v3.29.1
+    sha1: 00be749d257eee5035d3ba408aca15fcaf8be7c2
   v1.32.2:
     version: v3.29.4
     sha1: 899eba9872bd7362e19a17d4380ed16bf4d39717

--- a/kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
+++ b/kubemarine/resources/configurations/compatibility/kubernetes_versions.yaml
@@ -37,13 +37,13 @@ compatibility_map:
     local-path-provisioner: v0.0.27
     crictl: v1.30.0
   v1.30.1:
-    calico: v3.29.4
+    calico: v3.29.1
     nginx-ingress-controller: v1.11.6
     kubernetes-dashboard: v2.7.0
     local-path-provisioner: v0.0.26
     crictl: v1.30.0
   v1.30.3:
-    calico: v3.29.4
+    calico: v3.29.1
     nginx-ingress-controller: v1.11.6
     kubernetes-dashboard: v2.7.0
     local-path-provisioner: v0.0.27
@@ -55,7 +55,7 @@ compatibility_map:
     local-path-provisioner: v0.0.27
     crictl: v1.30.0
   v1.31.1:
-    calico: v3.29.4
+    calico: v3.29.1
     nginx-ingress-controller: v1.11.6
     kubernetes-dashboard: v2.7.0
     local-path-provisioner: v0.0.27
@@ -67,7 +67,7 @@ compatibility_map:
     local-path-provisioner: v0.0.27
     crictl: v1.30.0
   v1.32.0:
-    calico: v3.29.4
+    calico: v3.29.1
     nginx-ingress-controller: v1.11.6
     kubernetes-dashboard: v2.7.0
     local-path-provisioner: v0.0.27


### PR DESCRIPTION
### Description
We do not support old k8s patch versions, users should upgrade to latest k8s patch versions. So calico update in old k8s patch versions is reverted to reduce support efforts

### Solution
* Reverted calico image and calicoctl update for old k8s patch versions
* Removed old k8s patch versions from migrate patch (since there is nothing to migrate)