### PR TITLE
Remove centos 7 & 8 Rhel 7 & 8

### DIFF
--- a/kubemarine/core/group.py
+++ b/kubemarine/core/group.py
@@ -631,10 +631,16 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
 
     def get_nodes_os(self) -> str:
         """
-        Returns the detected operating system family for group.
+        Returns the detected operating system family for this group.
 
-        :return: Detected OS family, possible values: "debian", "rhel", "rhel8", "rhel9",
-                 "multiple", "unknown", "unsupported", "<undefined>".
+        The value will be one of the following:
+
+        * ``debian`` – Ubuntu/Debian based systems
+        * ``rhel9`` – Red Hat Enterprise Linux 9 and derivatives
+        * ``multiple`` – the group contains nodes from different OS families
+        * ``unknown`` – the OS could not be determined
+        * ``unsupported`` – an unsupported OS family
+        * ``<undefined>`` – the OS has not been determined yet
         """
         return self.cluster.get_os_family_for_nodes(self.nodes)
 
@@ -655,7 +661,8 @@ class AbstractGroup(Generic[GROUP_RUN_TYPE], ABC):
             os_families = [os_families]
 
         for os_family in os_families:
-            if os_family not in ['debian', 'rhel', 'rhel8', 'rhel9']:
+            # Only Debian and RHEL 9 families are supported
+            if os_family not in ['debian', 'rhel9']:
                 raise Exception('Unsupported OS family provided')
         hosts = []
         for host in self.nodes:

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -507,7 +507,7 @@ def new_cluster(inventory: dict, procedure_inventory: dict = None, context: dict
 
 def generate_node_context(*,
                           online: bool = True, accessible: bool = True, sudo: str = 'Root',
-                          os_name: str = 'centos', os_version: str = '7.9',
+                          os_name: str = 'rhel', os_version: str = '9.2',
                           net_interface: str = 'eth0') -> dict:
     os_family = system.detect_os_family_by_name_version(os_name, os_version)
 
@@ -534,7 +534,7 @@ def generate_node_context(*,
 
 def generate_nodes_context(inventory: dict, procedure_inventory: dict = None, context: dict = None,
                            *,
-                           os_name: str = 'centos', os_version: str = '7.9',
+                           os_name: str = 'rhel', os_version: str = '9.2',
                            net_interface: str = 'eth0') -> dict:
     procedure = 'install' if context is None else context['initial_procedure']
     if procedure_inventory is None:

--- a/kubemarine/haproxy.py
+++ b/kubemarine/haproxy.py
@@ -226,7 +226,8 @@ def configure(group: DeferredGroup) -> None:
 
 
 def override_haproxy18(group: DeferredGroup) -> None:
-    rhel_nodes = group.get_subgroup_with_os('rhel')
+    # Haproxy 1.8 overrides apply only to RHEL 9 family nodes.  Older RHEL families are not supported.
+    rhel_nodes = group.get_subgroup_with_os('rhel9')
     if rhel_nodes.is_empty():
         group.cluster.log.debug('Haproxy18 override is not required')
         return

--- a/kubemarine/modprobe.py
+++ b/kubemarine/modprobe.py
@@ -31,7 +31,8 @@ def enrich_kernel_modules(cluster: KubernetesCluster) -> None:
     The method enrich the list of kernel modules ('services.modprobe') according to OS family
     """
 
-    for os_family in ('debian', 'rhel', 'rhel8', 'rhel9'):
+    # Only Debian and RHEL 9 families are supported.  Older RHEL families have been removed.
+    for os_family in ('debian', 'rhel9'):
         # Remove the section for OS families if no node has these OS families.
         modprobe_config = cluster.inventory["services"]["modprobe"]
         if cluster.nodes['all'].get_subgroup_with_os(os_family).is_empty():

--- a/kubemarine/packages.py
+++ b/kubemarine/packages.py
@@ -481,7 +481,12 @@ def disable_unattended_upgrade(group: NodeGroup) -> None:
 
 
 def get_associations_os_family_keys() -> Set[str]:
-    return {'debian', 'rhel', 'rhel8', 'rhel9'}
+    """
+    Return the set of operating system families that are supported for package associations.
+
+    CentOS 7/8 and RHEL 7/8 support have been removed.  Only Debian and RHEL 9 remain.
+    """
+    return {'debian', 'rhel9'}
 
 
 def get_compatibility_version_key(os_family: str) -> str:
@@ -535,8 +540,10 @@ class PackageManager(Protocol):
 def get_package_manager(group: AbstractGroup[GROUP_RUN_TYPE]) -> PackageManager:
     os_family = group.get_nodes_os()
 
-    if os_family in ['rhel', 'rhel8', 'rhel9']:
+    # Use yum for RHEL-based systems. Only RHEL 9 is supported.
+    if os_family == 'rhel9':
         return yum
+    # Use apt for Debian-based systems.
     elif os_family == 'debian':
         return apt
 
@@ -595,7 +602,13 @@ def search_package(group: DeferredGroup, package: str, callback: Callback = None
 
 
 def get_detect_package_version_cmd(os_family: str, package_name: str) -> str:
-    if os_family in ["rhel", "rhel8", "rhel9"]:
+    """
+    Construct a command to query the installed version of a package on a node.
+
+    For RPM-based systems (RHEL), use `rpm -q`.  Only the RHEL 9 family is supported.
+    For Debian-based systems, use `dpkg-query`.
+    """
+    if os_family == "rhel9":
         cmd = r"rpm -q %s" % package_name
     else:
         cmd = r"dpkg-query -f '${Package}=${Version}\n' -W %s" % package_name
@@ -681,8 +694,9 @@ def get_package_name(os_family: str, package: str) -> str:
     package_name = ""
 
     if package:
-        if os_family in ["rhel", "rhel8", "rhel9"]:
-            # regexp is needed to split package and its version, the pattern start with '-' then should be number or '*'
+        if os_family == "rhel9":
+            # For RHEL-based systems the package name and version are separated by a hyphen
+            # followed by digits or a wildcard.  Earlier RHEL versions are not supported.
             package_name = re.split(r'-[\d,\*]', package)[0]
         else:
             # in ubuntu it is much easier to parse package name

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -97,7 +97,8 @@ def export_ansible_inventory(cluster: KubernetesCluster) -> None:
 
 def export_packages_list(cluster: KubernetesCluster) -> None:
     cluster.context['backup_descriptor']['nodes']['packages'] = {}
-    if cluster.get_os_family() in ['rhel', 'rhel8', 'rhel9']:
+    # Only the RHEL 9 family uses RPM; all older RHEL families (7, 8) have been dropped.
+    if cluster.get_os_family() == 'rhel9':
         cmd = r"rpm -qa"
     else:
         cmd = r"dpkg-query -f '${Package}=${Version}\n' -W"

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -477,7 +477,8 @@ def check_access_to_package_repositories(cluster: KubernetesCluster) -> None:
         # TODO: think about better parsing
         repository_urls: List[str] = []
         repositories = cluster.inventory['services']['packages']['package_manager'].get("repositories")
-        if cluster.get_os_family() not in ['debian', 'rhel', 'rhel8', 'rhel9']:
+        # Only Debian and RHEL 9 families are supported.  Older RHEL families (7 and 8) are unsupported.
+        if cluster.get_os_family() not in ['debian', 'rhel9']:
             # Skip check in case of multiply or unknown OS
             raise TestWarn("Can't check package repositories on multiple or unknown OS")
         if isinstance(repositories, list):

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -873,7 +873,9 @@ def verify_selinux_status(cluster: KubernetesCluster) -> None:
     :return: None
     """
     with TestCase(cluster, '213', "Security", "Selinux security policy") as tc:
-        group = cluster.nodes['all'].get_subgroup_with_os(['rhel', 'rhel8', 'rhel9'])
+        # Only consider nodes from the RHEL 9 family when checking SELinux.  Older RHEL families
+        # (7 and 8) are not supported.
+        group = cluster.nodes['all'].get_subgroup_with_os(['rhel9'])
         if group.is_empty():
             return tc.success("No RHEL nodes found")
         _, selinux_result, selinux_parsed_result = \
@@ -931,7 +933,8 @@ def verify_selinux_config(cluster: KubernetesCluster) -> None:
     :return: None
     """
     with TestCase(cluster, '214', "Security", "Selinux configuration") as tc:
-        group = cluster.nodes['all'].get_subgroup_with_os(['rhel', 'rhel8', 'rhel9'])
+        # Only consider nodes from the RHEL 9 family.  Older RHEL families (7 and 8) are unsupported.
+        group = cluster.nodes['all'].get_subgroup_with_os(['rhel9'])
         if group.is_empty():
             return tc.success("No RHEL nodes found")
         selinux_configured, selinux_result, _ = \

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -297,17 +297,8 @@ compatibility_map:
         amount: 8
 
   distributives:
+    # CentOS support is limited to version 9 only. Older versions (7.x and 8.x) are no longer supported.
     centos:
-      - os_family: 'rhel'
-        versions:
-          - '7.5'
-          - '7.6'
-          - '7.7'
-          - '7.8'
-          - '7.9'
-      - os_family: 'rhel8'
-        versions:
-          - '8.4'
       - os_family: 'rhel9'
         versions:
           - '9'

--- a/kubemarine/resources/schemas/definitions/services/modprobe.json
+++ b/kubemarine/resources/schemas/definitions/services/modprobe.json
@@ -3,13 +3,11 @@
   "type": "object",
   "properties": {
     "debian": {"$ref": "#/definitions/OSFamilyModules"},
-    "rhel": {"$ref": "#/definitions/OSFamilyModules"},
-    "rhel8": {"$ref": "#/definitions/OSFamilyModules"},
     "rhel9": {"$ref": "#/definitions/OSFamilyModules"}
   },
   "propertyNames": {
     "anyOf": [
-      {"enum": ["debian", "rhel", "rhel8", "rhel9"]}
+      {"enum": ["debian", "rhel9"]}
     ]
   },
   "definitions": {

--- a/kubemarine/resources/schemas/definitions/services/packages/associations.json
+++ b/kubemarine/resources/schemas/definitions/services/packages/associations.json
@@ -4,14 +4,12 @@
   "allOf": [{"$ref": "#/definitions/Associations"}],
   "properties": {
     "debian": {"$ref": "#/definitions/OSFamilyAssociations"},
-    "rhel": {"$ref": "#/definitions/OSFamilyAssociations"},
-    "rhel8": {"$ref": "#/definitions/OSFamilyAssociations"},
     "rhel9": {"$ref": "#/definitions/OSFamilyAssociations"}
   },
   "propertyNames": {
     "anyOf": [
       {"$ref": "#/definitions/AssociationsNames"},
-      {"enum": ["debian", "rhel", "rhel8", "rhel9"]}
+      {"enum": ["debian", "rhel9"]}
     ]
   },
   "definitions": {

--- a/kubemarine/selinux.py
+++ b/kubemarine/selinux.py
@@ -177,9 +177,9 @@ def is_config_valid(group: NodeGroup, state: str = None, policy: str = None, per
 def setup_selinux(group: NodeGroup) -> bool:
     log = group.cluster.log
 
-    # this method handles cluster with multiple os, suppressing should be enabled
-    if group.get_nodes_os() not in ['rhel', 'rhel8', 'rhel9']:
-        log.debug("Skipped - selinux is not supported on Ubuntu/Debian os family")
+    # This method only applies to RHEL 9.  Skip SELinux configuration for other OS families.
+    if group.get_nodes_os() != 'rhel9':
+        log.debug("Skipped - SELinux is only configured on RHEL 9 OS family")
         return False
 
     expected_state = get_expected_state(group.cluster.inventory)

--- a/test/resources/fetch_os_versions_example.txt
+++ b/test/resources/fetch_os_versions_example.txt
@@ -1,19 +1,19 @@
-CentOS Linux release 7.6.1810 (Core)
-NAME="CentOS Linux"
-VERSION="7 (Core)"
-ID="centos"
-ID_LIKE="rhel fedora"
-VERSION_ID="7"
-PRETTY_NAME="CentOS Linux 7 (Core)"
+Red Hat Enterprise Linux release 9.2 (Plow)
+NAME="Red Hat Enterprise Linux"
+VERSION="9.2 (Plow)"
+ID="rhel"
+ID_LIKE="fedora"
+VERSION_ID="9.2"
+PRETTY_NAME="Red Hat Enterprise Linux 9.2 (Plow)"
 ANSI_COLOR="0;31"
-CPE_NAME="cpe:/o:centos:centos:7"
-HOME_URL="https://www.centos.org/"
-BUG_REPORT_URL="https://bugs.centos.org/"
+CPE_NAME="cpe:/o:redhat:rhel:9.2"
+HOME_URL="https://www.redhat.com/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
 
-CENTOS_MANTISBT_PROJECT="CentOS-7"
-CENTOS_MANTISBT_PROJECT_VERSION="7"
-REDHAT_SUPPORT_PRODUCT="centos"
-REDHAT_SUPPORT_PRODUCT_VERSION="7"
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
+REDHAT_BUGZILLA_PRODUCT_VERSION="9.2"
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="9.2"
 
-CentOS Linux release 7.6.1810 (Core)
-CentOS Linux release 7.6.1810 (Core)
+Red Hat Enterprise Linux release 9.2 (Plow)
+Red Hat Enterprise Linux release 9.2 (Plow)

--- a/test/unit/core/test_cluster.py
+++ b/test/unit/core/test_cluster.py
@@ -57,8 +57,10 @@ class KubernetesClusterTest(unittest.TestCase):
 
     def test_get_os_family(self):
         cluster = demo.new_cluster(demo.generate_inventory(**demo.MINIHA_KEEPALIVED))
-        self.assertEqual('rhel', get_os_family(cluster),
-                         msg="Demo cluster should be created with 'rhel' OS family by default")
+        # Since support for RHEL 7/8 has been removed, the default OS family for a demo cluster
+        # is now rhel9.  The test validates that the cluster reflects this.
+        self.assertEqual('rhel9', get_os_family(cluster),
+                         msg="Demo cluster should be created with 'rhel9' OS family by default")
 
     def test_get_os_family_multiple(self):
         inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
@@ -132,11 +134,16 @@ class KubernetesClusterTest(unittest.TestCase):
                          msg="Package associations are not redefined")
 
     def _nodes_context_one_different_os(self, inventory, host_different_os):
+        """
+        Construct a nodes context where most nodes run on Ubuntu 20.04 but one
+        node runs on a different OS.  Since support for CentOS 7/8 and RHEL 7/8 has been removed,
+        the different node now uses RHEL 9.2 instead of an older RHEL/CentOS version.
+        """
         nodes_context = demo.generate_nodes_context(inventory, os_name='ubuntu', os_version='20.04')
         nodes_context[host_different_os]['os'] = {
-            'name': 'centos',
-            'family': 'rhel',
-            'version': '7.9'
+            'name': 'rhel',
+            'family': 'rhel9',
+            'version': '9.2'
         }
         return nodes_context
 

--- a/test/unit/core/test_flow.py
+++ b/test/unit/core/test_flow.py
@@ -327,11 +327,12 @@ class FlowTest(unittest.TestCase):
         self.assertEqual(4, cluster.context["test_info"],
                          "Here should be all 4 calls of test_func")
 
-        self.assertEqual("rhel", cluster.get_os_family())
+        # After removing RHEL 7/8 support, the detected OS family should be rhel9
+        self.assertEqual("rhel9", cluster.get_os_family())
         self.assertEqual(len(hosts), len(cluster.nodes_context))
         for node_context in cluster.nodes_context.values():
             self.assertEqual({'online': True, 'accessible': True, 'sudo': 'Root'}, node_context["access"])
-            self.assertEqual({'name': 'centos', 'version': '7.6', 'family': 'rhel'}, node_context["os"])
+            self.assertEqual({'name': 'rhel', 'version': '9.2', 'family': 'rhel9'}, node_context["os"])
             self.assertEqual('eth0', node_context["active_interface"])
 
     def test_not_sudoer_does_not_interrupt_enrichment(self):
@@ -345,11 +346,12 @@ class FlowTest(unittest.TestCase):
         self.assertEqual(4, cluster.context["test_info"],
                          "Here should be all 4 calls of test_func")
 
-        self.assertEqual("rhel", cluster.get_os_family())
+        # Only rhel9 family is supported
+        self.assertEqual("rhel9", cluster.get_os_family())
         for node_context in cluster.nodes_context.values():
             self.assertEqual({'online': True, 'accessible': True, 'sudo': 'No'}, node_context["access"])
             # continue to collect info
-            self.assertEqual({'name': 'centos', 'version': '7.6', 'family': 'rhel'}, node_context["os"])
+            self.assertEqual({'name': 'rhel', 'version': '9.2', 'family': 'rhel9'}, node_context["os"])
             self.assertEqual('eth0', node_context["active_interface"])
 
     def test_any_offline_node_interrupts(self):
@@ -480,11 +482,12 @@ class FlowTest(unittest.TestCase):
         self.assertEqual(4, cluster.context["test_info"],
                          "Here should be all 4 calls of test_func")
 
-        self.assertEqual("rhel", cluster.get_os_family())
+        # Only rhel9 family is expected after dropping support for older RHEL versions
+        self.assertEqual("rhel9", cluster.get_os_family())
         self.assertEqual(len(hosts), len(cluster.nodes_context))
         for node_context in cluster.nodes_context.values():
             self.assertEqual({'online': True, 'accessible': True, 'sudo': 'Root'}, node_context["access"])
-            self.assertEqual({'name': 'centos', 'version': '7.6', 'family': 'rhel'}, node_context["os"])
+            self.assertEqual({'name': 'rhel', 'version': '9.2', 'family': 'rhel9'}, node_context["os"])
             self.assertEqual('eth0', node_context["active_interface"])
 
     def test_detect_nodes_context_do_procedure(self):
@@ -503,11 +506,12 @@ class FlowTest(unittest.TestCase):
         flow.ActionsFlow([do.CLIAction(context)]).run_flow(res, print_summary=False)
 
         cluster = res.cluster(EnrichmentStage.LIGHT)
-        self.assertEqual("rhel", cluster.get_os_family())
+        # Only rhel9 family is expected
+        self.assertEqual("rhel9", cluster.get_os_family())
         self.assertEqual(1, len(cluster.nodes_context))
         for node_context in cluster.nodes_context.values():
             self.assertEqual({'online': True, 'accessible': True, 'sudo': 'Root'}, node_context["access"])
-            self.assertEqual({'name': 'centos', 'version': '7.6', 'family': 'rhel'}, node_context["os"])
+            self.assertEqual({'name': 'rhel', 'version': '9.2', 'family': 'rhel9'}, node_context["os"])
             self.assertEqual('eth0', node_context["active_interface"])
 
     def test_do_master_offline(self):

--- a/test/unit/test_migrate_kubemarine.py
+++ b/test/unit/test_migrate_kubemarine.py
@@ -222,9 +222,10 @@ class UpgradeCRI(unittest.TestCase):
     def test_specific_os_family_cri_association_upgrade_required(self):
         for os_name, os_family, os_version in (
                 ('ubuntu', 'debian', '20.04'),
-                ('centos', 'rhel', '7.9'),
-                ('rhel', 'rhel8', '8.7'),
-                ('rhel', 'rhel9', '9.2')
+                # Only RHEL 9 series are supported.  Earlier versions have been removed.
+                ('rhel', 'rhel9', '9.2'),
+                ('rhel', 'rhel9', '9.3'),
+                ('rhel', 'rhel9', '9.4')
         ):
             for package_vary in ('containerd', 'containerdio'):
                 expected_upgrade_required = package_vary in self._packages_for_cri_os_family(os_family)
@@ -236,12 +237,11 @@ class UpgradeCRI(unittest.TestCase):
                                         EnrichmentStage.PROCEDURE if expected_upgrade_required else EnrichmentStage.DEFAULT)
 
     def _packages_for_cri_os_family(self, os_family: str) -> List[str]:
-        if os_family in ('rhel', 'rhel8', 'rhel9'):
-            package_names = ['containerdio']
+        # RHEL 9 uses containerdio, Debian uses containerd
+        if os_family == 'rhel9':
+            return ['containerdio']
         else:
-            package_names = ['containerd']
-
-        return package_names
+            return ['containerd']
 
     def test_procedure_inventory_upgrade_required_inventory_redefined(self):
         for global_section in (False, True):

--- a/test/unit/test_modprobe.py
+++ b/test/unit/test_modprobe.py
@@ -187,24 +187,15 @@ class ModulesEnrichment(unittest.TestCase):
 
                 cluster = self.new_cluster()
 
-                if os_family == 'rhel':
-                    expected_all_modules_list = [
-                        'br_netfilter',
-                        'nf_conntrack_ipv6',
-                        'ip6table_filter',
-                        'nf_nat_masquerade_ipv6',
-                        'nf_reject_ipv6',
-                        'nf_defrag_ipv6',
-                    ]
-                else:
-                    expected_all_modules_list = [
-                        'br_netfilter',
-                        'nf_conntrack',
-                        'ip6table_filter',
-                        'nf_nat',
-                        'nf_reject_ipv6',
-                        'nf_defrag_ipv6',
-                    ]
+                # For all supported OS families (Debian and RHEL 9) the default IPv6 modules are the same.
+                expected_all_modules_list = [
+                    'br_netfilter',
+                    'nf_conntrack',
+                    'ip6table_filter',
+                    'nf_nat',
+                    'nf_reject_ipv6',
+                    'nf_defrag_ipv6',
+                ]
 
                 kubernetes_only_modules_list = [
                     'br_netfilter',
@@ -222,12 +213,21 @@ class ModulesEnrichment(unittest.TestCase):
                     self.assertEqual(expected_modules_list, actual_modules_list)
 
     def _get_os_context(self, os_family: str) -> Tuple[str, str]:
-        return {
+        """
+        Return a tuple of (os_name, os_version) for the specified OS family.
+
+        Since support for CentOS and old RHEL versions has been removed, all
+        RHEL-based OS families (``rhel``, ``rhel8``, ``rhel9``) are mapped
+        to RHEL 9.2 for testing purposes.
+        """
+        mapping = {
             'debian': ('ubuntu', '22.04'),
-            'rhel': ('centos', '7.9'),
-            'rhel8': ('rhel', '8.7'),
+            # Map all RHEL families to RHEL 9.2 since earlier versions are no longer supported
+            'rhel': ('rhel', '9.2'),
+            'rhel8': ('rhel', '9.2'),
             'rhel9': ('rhel', '9.2')
-        }[os_family]
+        }
+        return mapping[os_family]
 
     def _nodes_having_modules(self, cluster: demo.FakeKubernetesCluster, module_name: str) -> Set[str]:
         return {node.get_node_name() for node in cluster.nodes['all'].get_ordered_members_list()

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -366,9 +366,10 @@ class UpgradePackagesEnrichment(_AbstractUpgradeEnrichmentTest):
     def test_compatibility_upgrade_required(self):
         for os_name, os_family, os_version in (
                 ('ubuntu', 'debian', '20.04'),
-                ('centos', 'rhel', '7.9'),
-                ('rhel', 'rhel8', '8.7'),
-                ('rhel', 'rhel9', '9.2')
+                # Only RHEL 9 series are supported.  Earlier versions have been removed.
+                ('rhel', 'rhel9', '9.2'),
+                ('rhel', 'rhel9', '9.3'),
+                ('rhel', 'rhel9', '9.4')
         ):
             for package_vary in ('containerd', 'containerdio'):
                 expected_upgrade_required = package_vary in self._packages_for_cri_os_family(os_family)
@@ -386,12 +387,11 @@ class UpgradePackagesEnrichment(_AbstractUpgradeEnrichmentTest):
                         f"CRI was {'not' if expected_upgrade_required else 'unexpectedly'} scheduled for upgrade")
 
     def _packages_for_cri_os_family(self, os_family: str) -> List[str]:
-        if os_family in ('rhel', 'rhel8', 'rhel9'):
-            package_names = ['containerdio']
+        # RHEL 9 uses containerdio, Debian uses containerd
+        if os_family == 'rhel9':
+            return ['containerdio']
         else:
-            package_names = ['containerd']
-
-        return package_names
+            return ['containerd']
 
     def test_procedure_inventory_upgrade_required_inventory_default(self):
         for procedure_associations, expected_upgrade_required in (


### PR DESCRIPTION
### Description
Removed support of centos 7 & 8 and RHEL 7 & 8 from kubemarine
* 


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


