### PR TITLE
[CPCAP-760]_Removed centos 7&8 and rhel 7&8

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -165,16 +165,16 @@ For cluster machines, ensure the following requirements are met:
 
 * The following distributives and versions are supported:
 
-  * Centos 7.5+, 8.4, 9
-  * RHEL 7.5+, 8.4, 8.6, 8.7, 8.8, 8.9, 9.2
-  * Oracle Linux 7.5+, 8.4, 9.2
+  * CentOS Stream 9
+  * RHEL 9.2, 9.3, 9.4
+  * Oracle Linux 9.2
   * RockyLinux 8.6, 8.7, 8.8, 9.2, 9.3 ,9.4, 9.5
   * Ubuntu 20.04, 22.04.1, 24.04.1
  
 **Note**: Ubuntu 24.04 is supported only with kubernetes versions starting from v1.29.7 and above.
 
 <!-- #GFCFilterMarkerStart# -->
-The actual information about the supported versions can be found in `compatibility_map.distributives` section of [globals.yaml configuration](../kubemarine/resources/configurations/globals.yaml#L256).
+The actual information about the supported versions can be found in `compatibility_map.distributives` section of [globals.yaml configuration](../kubemarine/resources/configurations/globals.yaml#L299).
 <!-- #GFCFilterMarkerEnd# -->
 
 **Networking**
@@ -244,13 +244,7 @@ For example, specify `conntrack-tools` instead of `conntrack`.
 **Note**:
 
 * You can install a version other than the recommended version, but it is not supported and can cause unpredictable consequences.
-* rh-haproxy18 (build provided by RedHat) is supported only for now.
-
-**Warning**: RHEL 8 does not have Python preinstalled. For `check_iaas` to work correctly, it is required to install Python on the nodes. Execute the following step before the installation procedure.
-* Install `python 3.9` from the standard RHEL repository:
-```
-# dnf install python3.9 -y
-```
+* Note: RHEL 7/8 and CentOS 7/8 are no longer supported.
 
 **Unattended-upgrades** 
 
@@ -1622,7 +1616,7 @@ services:
           name: "Kubernetes"
           enabled: 1
           gpgcheck: 0
-          baseurl: "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64"
+          baseurl: "https://packages.cloud.google.com/yum/repos/kubernetes-el9-x86_64"
         my_own_repo:
           name: "My repository"
           enabled: 1
@@ -1825,15 +1819,15 @@ The following associations are used by default:
   <tr>
     <td rowspan="4">haproxy</td>
     <td>executable_name</td>
-    <td>/opt/rh/rh-haproxy18/root/usr/sbin/haproxy</td>
+    <td>haproxy</td>
   </tr>
   <tr>
     <td>package_name</td>
-    <td>rh-haproxy18-haproxy-{{k8s-version-specific}}</td>
+    <td>haproxy</td>
   </tr>
   <tr>
     <td>service_name</td>
-    <td>rh-haproxy18-haproxy</td>
+    <td>haproxy</td>
   </tr>
   <tr>
     <td>config_location</td>
@@ -2061,13 +2055,13 @@ services:
         haproxy:
           executable_name: '/usr/sbin/haproxy'
           package_name: haproxy=1.8.*
-      rhel:
+      rhel9:
         haproxy:
-          executable_name: '/opt/rh/rh-haproxy18/root/usr/sbin/haproxy'
-          package_name: rh-haproxy18-haproxy-1.8*
+          executable_name: 'haproxy'
+          package_name: haproxy
 ```
 
-**Note**: There are only 4 supported OS families: **debian**, **rhel**, **rhel8** (for RHEL based version 8), and **rhel9** (for RHEL based version 8).
+**Note**: Supported OS families are: **debian** and **rhel9**.
 
 #### thirdparties
 
@@ -2383,8 +2377,6 @@ By default, the following modules are loaded:
     <th scope="col" rowspan="2">Note</th>
   </tr>
   <tr>
-    <th scope="col">rhel</th>
-    <th scope="col">rhel8</th>
     <th scope="col">rhel9</th>
     <th scope="col">debian</th>
   </tr>
@@ -2392,21 +2384,20 @@ By default, the following modules are loaded:
 <tbody align="center">
   <tr>
     <th scope="row" rowspan="2">IPv4</th>
-    <td colspan="4">br_netfilter</td>
+    <td colspan="2">br_netfilter</td>
     <td align="left">Loaded on roles: <code>control-plane</code>, <code>worker</code></td>
   </tr>
   <tr>
-    <td colspan="4">nf_conntrack</td>
+    <td colspan="2">nf_conntrack</td>
     <td align="left">Loaded on roles: <code>control-plane</code>, <code>worker</code></td>
   </tr>
   <tr>
     <th scope="row" rowspan="8">IPv6</th>
-    <td colspan="4">br_netfilter</td>
+    <td colspan="2">br_netfilter</td>
     <td align="left">Loaded on roles: <code>control-plane</code>, <code>worker</code></td>
   </tr>
   <tr>
-    <td></td>
-    <td colspan="3">nf_conntrack</td>
+    <td colspan="2">nf_conntrack</td>
     <td align="left">Loaded on roles: <code>control-plane</code>, <code>worker</code></td>
   </tr>
   <tr>
@@ -3813,7 +3804,7 @@ Before proceeding, refer to the _Official Documentation of the Kubernetes Cluste
 
 Calico plugin is installed by default and does not require any special enablement or configuration. However, it is possible to explicitly enable or disable the installation of this plugin through the `install` plugin parameter.
 
-**Warning**: According to the Calico kernel requirements, CentOS 7 with a kernel lower than `3.10.0-940.el7.x86_64` is not compatible with Calico 3.24 and higher. For more information, refer to Kubernetes requirements_ at [https://docs.tigera.io/calico/3.24/getting-started/kubernetes/requirements#kubernetes-requirements](https://docs.tigera.io/calico/3.24/getting-started/kubernetes/requirements#kubernetes-requirements).
+Legacy note: CentOS 7 kernel requirements for Calico are not applicable; CentOS 7 is unsupported.
 
 The following is an example to enable the calico plugin:
 
@@ -5827,16 +5818,16 @@ services:
         containerd:
           executable_name: 'containerd'
           package_name:
-            - containerd.io-1.6.32-3.1.el7.x86_64
+            - containerd.io-1.7.*
           service_name: 'containerd'
           config_location: '/etc/containerd/config.toml'
         conntrack:
-          package_name: conntrack-tools-1.4.4-7.el7.x86_64
+          package_name: conntrack-tools
     install:
       include:
-        - ethtool-4.8-10.el7.x86_64
-        - ebtables-2.0.10-16.el7.x86_64
-        - socat-1.7.3.2-2.el7.x86_64
+        - ethtool
+        - ebtables
+        - socat
 ```
 
 **Note**: Some of the packages are impossible to be detected in the system, therefore such packages remain unchanged.
@@ -6040,17 +6031,17 @@ The tables below shows the correspondence of versions that are supported and is 
 
 
 ## Default Dependent Components Versions for Kubernetes Versions v1.31.6
-| Type     | Name                                                           | Versions         |                              |              |              |                   |           |           | Note                                                                                                       |
-|----------|----------------------------------------------------------------|------------------|------------------------------|--------------|--------------|-------------------|-----------|-----------|------------------------------------------------------------------------------------------------------------|
-|          |                                                                | CentOS RHEL 7.5+ | CentOS RHEL Oracle Linux 8.4 | Ubuntu 20.04,22.04 | Ubuntu 24.04 | Oracle Linux 7.5+ | RHEL 8.6+ | RockyLinux 8.6+ |                                                                                                      |
+| Type     | Name                                                           | Versions         |                       |              |                   |           | Note                                                                                                       |
+|----------|----------------------------------------------------------------|------------------|-----------------------|--------------|-------------------|-----------|------------------------------------------------------------------------------------------------------------|
+|          |                                                                | Ubuntu 20.04,22.04 | Ubuntu 24.04 | RHEL 9.2+          | RockyLinux 9.x |                                                                                                      |
 | binaries | kubeadm                                                        | v1.31.6          | v1.31.6                      | v1.31.6      | v1.31.6      | v1.31.6           | v1.31.6   | v1.31.6   | SHA1: 01b061a1a828bca9986f532f086a2bf89879e87e          |
 |          | kubelet                                                        | v1.31.6          | v1.31.6                      | v1.31.6      | v1.31.6      | v1.31.6           | v1.31.6   | v1.31.6   | SHA1: 9c0cd5bf9f36a159d3d72a8241d743500c116cf5          |
 |          | kubectl                                                        | v1.31.6          | v1.31.6                      | v1.31.6      | v1.31.6      | v1.31.6           | v1.31.6   | v1.31.6   | SHA1: af8b272a4d21d427d502ce24d737ffe2d6fc2164          |
 |          | calicoctl                                                      | v3.29.5          | v3.29.5                      | v3.29.5      | v3.29.5      | v3.29.5           | v3.29.5   | v3.29.5   | SHA1: 19999e25caa5ebb663a3f5c8df2ce7ed48ad6126 Required only if calico is installed.                       |
 |          | crictl                                                         | v1.30.0          | v1.30.0                      | v1.30.0      | v1.30.0      | v1.30.0           | v1.30.0   | v1.30.0   | SHA1: c81e76d5d4bf64d6b513485490722d2fc0a9a83b          |
-| rpms     | containerd.io                                                  | 1.6.*            | 1.6.*                        | 1.7.*        | 1.7.*        | 1.6.*             | 1.6.*     | 1.6.*     |                                                         |
-|          | haproxy/rh-haproxy                                             | 1.8              | 1.8                          | 2.*          | 2.*          | 1.8               | 1.8       | 1.8       | Required only if balancers are presented in the deployment scheme.| 
-|          | keepalived                                                     | 1.3              | 2.1                          | 2.*          | 2.*          | 1.3               | 2.1       | 2.1       | Required only if VRRP is presented in the deployment scheme.                                               |
+| rpms     | containerd.io                                                  | 1.7.*            | 1.7.*        | 1.7.*             | 1.7.*     |                                                         |
+|          | haproxy                                                        | 2.*              | 2.*          | 2.*               | 2.*       | Required only if balancers are presented in the deployment scheme.| 
+|          | keepalived                                                     | 2.*              | 2.*          | 2.*               | 2.*       | Required only if VRRP is presented in the deployment scheme.                                               |
 | images   | registry.k8s.io/kube-apiserver                                 | v1.31.6          | v1.31.6                      | v1.31.6      | v1.31.6      | v1.31.6           | v1.31.6   | v1.31.6   |                                                         |
 |          | registry.k8s.io/kube-controller-manager                        | v1.31.6          | v1.31.6                      | v1.31.6      | v1.31.6      | v1.31.6           | v1.31.6   | v1.31.6   |                                                         |
 |          | registry.k8s.io/kube-proxy                                     | v1.31.6          | v1.31.6                      | v1.31.6      | v1.31.6      | v1.31.6           | v1.31.6   | v1.31.6   |                                                         |
@@ -6071,17 +6062,17 @@ The tables below shows the correspondence of versions that are supported and is 
 
 
 ## Default Dependent Components Versions for Kubernetes Versions v1.32.2
-| Type     | Name                                                           | Versions         |                              |              |              |                   |           |           | Note                                                                                                       |
-|----------|----------------------------------------------------------------|------------------|------------------------------|--------------|--------------|-------------------|-----------|-----------|------------------------------------------------------------------------------------------------------------|
-|          |                                                                | CentOS RHEL 7.5+ | CentOS RHEL Oracle Linux 8.4 | Ubuntu 20.04,22.04 | Ubuntu 24.04 | Oracle Linux 7.5+ | RHEL 8.6+ | RockyLinux 8.6+ |                                                                                                      |
+| Type     | Name                                                           | Versions         |                       |              |                   |           | Note                                                                                                       |
+|----------|----------------------------------------------------------------|------------------|-----------------------|--------------|-------------------|-----------|------------------------------------------------------------------------------------------------------------|
+|          |                                                                | Ubuntu 20.04,22.04 | Ubuntu 24.04 | RHEL 9.2+          | RockyLinux 9.x |                                                                                                      |
 | binaries | kubeadm                                                        | v1.32.2          | v1.32.2                      | v1.32.2      | v1.32.2      | v1.32.2           | v1.32.2   | v1.32.2   | SHA1: 7aef86d97edf97e50ac7112a4ada49fe74619ebc          |
 |          | kubelet                                                        | v1.32.2          | v1.32.2                      | v1.32.2      | v1.32.2      | v1.32.2           | v1.32.2   | v1.32.2   | SHA1: 9d8446943a6aab092156b7ee0a6d74c27f742ffc          |
 |          | kubectl                                                        | v1.32.2          | v1.32.2                      | v1.32.2      | v1.32.2      | v1.32.2           | v1.32.2   | v1.32.2   | SHA1: 87e59e4ae4a6b99d3ee8c37dea2db6b3466b41bc          |
 |          | calicoctl                                                      | v3.29.5          | v3.29.5                      | v3.29.5      | v3.29.5      | v3.29.5           | v3.29.5   | v3.29.5   | SHA1: 19999e25caa5ebb663a3f5c8df2ce7ed48ad6126 Required only if calico is installed.  |
 |          | crictl                                                         | v1.32.0          | v1.32.0                      | v1.32.0      | v1.32.0      | v1.32.0           | v1.32.0   | v1.32.0   | SHA1: c503051cf6e809a691f776ddf544abfc2a15e790          |
-| rpms     | containerd.io                                                  | 1.6.*            | 1.6.*                        | 1.7.*        | 1.7.*        | 1.6.*             | 1.6.*     | 1.6.*     |                                                         |
-|          | haproxy/rh-haproxy                                             | 1.8              | 1.8                          | 2.*          | 2.*          | 1.8               | 1.8       | 1.8       | Required only if balancers are presented in the deployment scheme.    |
-|          | keepalived                                                     | 1.3              | 2.1                          | 2.*          | 2.*          | 1.3               | 2.1       | 2.1       | Required only if VRRP is presented in the deployment scheme.    |
+| rpms     | containerd.io                                                  | 1.7.*            | 1.7.*        | 1.7.*             | 1.7.*     |                                                         |
+|          | haproxy                                                        | 2.*              | 2.*          | 2.*               | 2.*       | Required only if balancers are presented in the deployment scheme.    |
+|          | keepalived                                                     | 2.*              | 2.*          | 2.*               | 2.*       | Required only if VRRP is presented in the deployment scheme.    |
 | images   | registry.k8s.io/kube-apiserver                                 | v1.32.2          | v1.32.2                      | v1.32.2      | v1.32.2      | v1.32.2           | v1.32.2   | v1.32.2   |                                                         |
 |          | registry.k8s.io/kube-controller-manager                        | v1.32.2          | v1.32.2                      | v1.32.2      | v1.32.2      | v1.32.2           | v1.32.2   | v1.32.2   |                                                         |
 |          | registry.k8s.io/kube-proxy                                     | v1.32.2          | v1.32.2                      | v1.32.2      | v1.32.2      | v1.32.2           | v1.32.2   | v1.32.2   |                                                         |
@@ -6104,7 +6095,7 @@ The tables below shows the correspondence of versions that are supported and is 
 ## Default Dependent Components Versions for Kubernetes Versions v1.33.0
 | Type     | Name                                                           | Versions         |                              |              |              |                   |           |           | Note                                                                                                       |
 |----------|----------------------------------------------------------------|------------------|------------------------------|--------------|--------------|-------------------|-----------|-----------|------------------------------------------------------------------------------------------------------------|
-|          |                                                                | CentOS RHEL 7.5+ | CentOS RHEL Oracle Linux 8.4 | Ubuntu 20.04,22.04 | Ubuntu 24.04 | Oracle Linux 7.5+ | RHEL 8.6+ | RockyLinux 8.6+ |                                                                                                      |
+|          |                                                                | Ubuntu 20.04,22.04 | Ubuntu 24.04 | RHEL 9.2+ | RockyLinux 9.x |                                                                                                      |
 | binaries | kubeadm                                                        | v1.33.0          | v1.33.0                      | v1.33.0      | v1.33.0      | v1.33.0           | v1.33.0   | v1.33.0   | SHA1: bc411a208e067c63976eeecf02d1bf5c5c823bff          |
 |          | kubelet                                                        | v1.33.0          | v1.33.0                      | v1.33.0      | v1.33.0      | v1.33.0           | v1.33.0   | v1.33.0   | SHA1: 984fc4e063e8df34f4beaa9212e5429ee70e5997          |
 |          | kubectl                                                        | v1.33.0          | v1.33.0                      | v1.33.0      | v1.33.0      | v1.33.0           | v1.33.0   | v1.33.0   | SHA1: aab40d38db50c728dbbe2e7b8144ba18f93480c2          |

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -1222,7 +1222,7 @@ To avoid this issue in the future:
 ## Pods Stuck in "Terminating" Status During Deletion
 
 ### Description
-This issue occurs when pods get stuck in the "Terminating" status and are not deleted properly. It is specifically applicable to hosts running RHEL or CentOS 7.x versions (starting from 7.4) where the `containerd` container runtime is used.
+This issue applies to legacy, unsupported OS releases (RHEL/CentOS 7.x) and should not occur on supported platforms.
 
 ### Alerts
 Not applicable.
@@ -1241,10 +1241,10 @@ sysctl -p
 ```
 
 ### Recommendations
-Ensure that this setting is only applied on RHEL or CentOS 7.x systems (starting from 7.4) where the `containerd` container runtime is being used.
+Note: The workaround described here was relevant for RHEL/CentOS 7.x, which are no longer supported.
 
 >**Note**  
->This solution is specifically intended for RHEL and CentOS 7.x environments.
+>Legacy note: This solution targeted RHEL/CentOS 7.x environments and is retained for historical context.
 
 ## Random 504 Error on Ingresses
 
@@ -1767,7 +1767,7 @@ To fix this issue:
    
 2. **Use additional grants** for the Kubemarine container by adding the `--privileged` or `--cap-add` options to the Docker command to provide the necessary permissions.
 
-Example of the problem: Kubemarine image `v0.25.0` runs the `ls -la` command on `CentOS 7.5` with Docker version `1.13.1-102`:
+Legacy example: Kubemarine image `v0.25.0` on `CentOS 7.5` with Docker `1.13.1-102`:
 ```bash
 $ docker run --entrypoint ls kubemarine:v0.25.0 -la
 ls: cannot access '.': Operation not permitted

--- a/kubemarine/demo.py
+++ b/kubemarine/demo.py
@@ -507,7 +507,7 @@ def new_cluster(inventory: dict, procedure_inventory: dict = None, context: dict
 
 def generate_node_context(*,
                           online: bool = True, accessible: bool = True, sudo: str = 'Root',
-                          os_name: str = 'centos', os_version: str = '7.9',
+                          os_name: str = 'rhel', os_version: str = '9.2',
                           net_interface: str = 'eth0') -> dict:
     os_family = system.detect_os_family_by_name_version(os_name, os_version)
 
@@ -534,7 +534,7 @@ def generate_node_context(*,
 
 def generate_nodes_context(inventory: dict, procedure_inventory: dict = None, context: dict = None,
                            *,
-                           os_name: str = 'centos', os_version: str = '7.9',
+                           os_name: str = 'rhel', os_version: str = '9.2',
                            net_interface: str = 'eth0') -> dict:
     procedure = 'install' if context is None else context['initial_procedure']
     if procedure_inventory is None:

--- a/kubemarine/packages.py
+++ b/kubemarine/packages.py
@@ -51,6 +51,11 @@ def enrich_inventory_associations(cluster: KubernetesCluster) -> None:
     associations: dict = inventory['services']['packages']['associations']
     inventory['services']['packages']['associations'] = enriched_associations = {}
 
+    # Drop associations for unsupported OS families (e.g., legacy RHEL/CentOS 7/8)
+    for legacy_family in ('rhel', 'rhel8'):
+        if legacy_family in associations:
+            associations.pop(legacy_family)
+
     # Move associations for OS families and merge with globals
     for association_name in get_associations_os_family_keys():
         redefined_associations = associations.pop(association_name)
@@ -481,7 +486,8 @@ def disable_unattended_upgrade(group: NodeGroup) -> None:
 
 
 def get_associations_os_family_keys() -> Set[str]:
-    return {'debian', 'rhel', 'rhel8', 'rhel9'}
+    # Supported OS families after dropping RHEL/CentOS 7/8
+    return {'debian', 'rhel9'}
 
 
 def get_compatibility_version_key(os_family: str) -> str:

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -298,35 +298,10 @@ compatibility_map:
 
   distributives:
     centos:
-      - os_family: 'rhel'
-        versions:
-          - '7.5'
-          - '7.6'
-          - '7.7'
-          - '7.8'
-          - '7.9'
-      - os_family: 'rhel8'
-        versions:
-          - '8.4'
       - os_family: 'rhel9'
         versions:
           - '9'
     rhel:
-      - os_family: 'rhel'
-        versions:
-          - '7.5'
-          - '7.6'
-          - '7.7'
-          - '7.8'
-          - '7.9'
-      - os_family: 'rhel8'
-        versions:
-          - '8.4'
-          - '8.6'
-          - '8.7'
-          - '8.8'
-          - '8.9'
-          - '8.10'  
       - os_family: 'rhel9'
         versions:
           - '9.2'

--- a/test/resources/fetch_os_versions_example.txt
+++ b/test/resources/fetch_os_versions_example.txt
@@ -1,19 +1,17 @@
-CentOS Linux release 7.6.1810 (Core)
-NAME="CentOS Linux"
-VERSION="7 (Core)"
+CentOS Stream release 9
+NAME="CentOS Stream"
+VERSION="9"
 ID="centos"
 ID_LIKE="rhel fedora"
-VERSION_ID="7"
-PRETTY_NAME="CentOS Linux 7 (Core)"
+VERSION_ID="9"
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="CentOS Stream 9"
 ANSI_COLOR="0;31"
-CPE_NAME="cpe:/o:centos:centos:7"
-HOME_URL="https://www.centos.org/"
-BUG_REPORT_URL="https://bugs.centos.org/"
+CPE_NAME="cpe:/o:centos:centos:9"
+HOME_URL="https://centos.org/"
+BUG_REPORT_URL="https://issues.redhat.com/"
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 9"
+REDHAT_SUPPORT_PRODUCT_VERSION="9.0"
 
-CENTOS_MANTISBT_PROJECT="CentOS-7"
-CENTOS_MANTISBT_PROJECT_VERSION="7"
-REDHAT_SUPPORT_PRODUCT="centos"
-REDHAT_SUPPORT_PRODUCT_VERSION="7"
-
-CentOS Linux release 7.6.1810 (Core)
-CentOS Linux release 7.6.1810 (Core)
+CentOS Stream release 9
+CentOS Stream release 9

--- a/test/unit/core/test_cluster.py
+++ b/test/unit/core/test_cluster.py
@@ -57,8 +57,8 @@ class KubernetesClusterTest(unittest.TestCase):
 
     def test_get_os_family(self):
         cluster = demo.new_cluster(demo.generate_inventory(**demo.MINIHA_KEEPALIVED))
-        self.assertEqual('rhel', get_os_family(cluster),
-                         msg="Demo cluster should be created with 'rhel' OS family by default")
+        self.assertEqual('rhel9', get_os_family(cluster),
+                         msg="Demo cluster should be created with 'rhel9' OS family by default")
 
     def test_get_os_family_multiple(self):
         inventory = demo.generate_inventory(**demo.MINIHA_KEEPALIVED)
@@ -134,9 +134,9 @@ class KubernetesClusterTest(unittest.TestCase):
     def _nodes_context_one_different_os(self, inventory, host_different_os):
         nodes_context = demo.generate_nodes_context(inventory, os_name='ubuntu', os_version='20.04')
         nodes_context[host_different_os]['os'] = {
-            'name': 'centos',
-            'family': 'rhel',
-            'version': '7.9'
+            'name': 'rhel',
+            'family': 'rhel9',
+            'version': '9.2'
         }
         return nodes_context
 

--- a/test/unit/core/test_env.py
+++ b/test/unit/core/test_env.py
@@ -186,7 +186,7 @@ class TestEnvironmentVariables(test_utils.CommonTest):
         self.assertEqual(f'https://dl.k8s.io/{after}/bin/linux/amd64/kubeadm',
                          inventory['services']['thirdparties']['/usr/bin/kubeadm']['source'])
         self.assertEqual('containerd_new',
-                         inventory['services']['packages']['associations']['rhel']['containerd']['package_name'])
+                         inventory['services']['packages']['associations']['rhel9']['containerd']['package_name'])
 
     @test_utils.temporary_directory
     def test_kubernetes_version_env_variable_migrate_kubemarine_upgrade_patches(self):

--- a/test/unit/test_audit.py
+++ b/test/unit/test_audit.py
@@ -35,10 +35,10 @@ class TestAuditInstallation(unittest.TestCase):
 
     def test_audit_installation_for_centos(self):
         context = demo.create_silent_context()
-        nodes_context = demo.generate_nodes_context(self.inventory, os_name='centos', os_version='7.9')
+        nodes_context = demo.generate_nodes_context(self.inventory, os_name='rhel', os_version='9.2')
         cluster = demo.new_cluster(self.inventory, context=context, nodes_context=nodes_context)
 
-        package_associations = cluster.inventory['services']['packages']['associations']['rhel']['audit']
+        package_associations = cluster.inventory['services']['packages']['associations']['rhel9']['audit']
 
         package_name = package_associations['package_name']
         service_name = package_associations['service_name']
@@ -46,7 +46,7 @@ class TestAuditInstallation(unittest.TestCase):
         # simulate package detection command
         exp_results1 = demo.create_nodegroup_result(cluster.nodes['control-plane'], code=1,
                                                     stderr='package %s is not installed' % package_name)
-        cluster.fake_shell.add(exp_results1, 'sudo', [self.get_detect_package_version_cmd('rhel', package_name)])
+        cluster.fake_shell.add(exp_results1, 'sudo', [self.get_detect_package_version_cmd('rhel9', package_name)])
 
         # simulate package installation command
         installation_command = [yum.get_install_cmd(cluster, package_name)]

--- a/test/unit/test_haproxy.py
+++ b/test/unit/test_haproxy.py
@@ -66,7 +66,7 @@ class TestHaproxyInstallation(unittest.TestCase):
         inventory = demo.generate_inventory(**demo.FULLHA)
         cluster = demo.new_cluster(inventory)
 
-        package_associations = cluster.inventory['services']['packages']['associations']['rhel']['haproxy']
+        package_associations = cluster.inventory['services']['packages']['associations']['rhel9']['haproxy']
 
         # simulate already installed haproxy package
         expected_results_1 = demo.create_nodegroup_result(cluster.nodes['balancer'], stdout='Haproxy v1.2.3')
@@ -74,7 +74,7 @@ class TestHaproxyInstallation(unittest.TestCase):
 
         # simulate mkdir command
         expected_results_2 = demo.create_nodegroup_result(cluster.nodes['balancer'])
-        cluster.fake_shell.add(expected_results_2, 'sudo', ["mkdir -p /etc/systemd/system/rh-haproxy18-haproxy.service.d"])
+        cluster.fake_shell.add(expected_results_2, 'sudo', ["mkdir -p /etc/systemd/system/haproxy.service.d"])
 
         # simulate systemd daemon reload
         expected_results_3 = demo.create_nodegroup_result(cluster.nodes['balancer'])
@@ -94,7 +94,7 @@ class TestHaproxyInstallation(unittest.TestCase):
         inventory = demo.generate_inventory(**demo.FULLHA)
         cluster = demo.new_cluster(inventory)
 
-        package_associations = cluster.inventory['services']['packages']['associations']['rhel']['haproxy']
+        package_associations = cluster.inventory['services']['packages']['associations']['rhel9']['haproxy']
 
         # simulate haproxy package missing
         missing_package_command = ['%s -v' % package_associations['executable_name']]
@@ -116,7 +116,7 @@ class TestHaproxyInstallation(unittest.TestCase):
 
         # simulate mkdir command
         expected_results_2 = demo.create_nodegroup_result(cluster.nodes['balancer'])
-        cluster.fake_shell.add(expected_results_2, 'sudo', ["mkdir -p /etc/systemd/system/rh-haproxy18-haproxy.service.d"])
+        cluster.fake_shell.add(expected_results_2, 'sudo', ["mkdir -p /etc/systemd/system/haproxy.service.d"])
 
         # simulate systemd daemon reload
         expected_results_3 = demo.create_nodegroup_result(cluster.nodes['balancer'])

--- a/test/unit/test_keepalived.py
+++ b/test/unit/test_keepalived.py
@@ -286,7 +286,7 @@ class TestKeepalivedInstallation(unittest.TestCase):
         inventory = demo.generate_inventory(**demo.FULLHA_KEEPALIVED)
         cluster = demo.new_cluster(inventory)
 
-        package_associations = cluster.inventory['services']['packages']['associations']['rhel']['keepalived']
+        package_associations = cluster.inventory['services']['packages']['associations']['rhel9']['keepalived']
 
         # simulate already installed keepalived package
         expected_results_1 = demo.create_nodegroup_result(cluster.nodes['keepalived'], stdout='Keepalived v1.2.3')
@@ -319,7 +319,7 @@ class TestKeepalivedInstallation(unittest.TestCase):
         inventory = demo.generate_inventory(**demo.FULLHA_KEEPALIVED)
         cluster = demo.new_cluster(inventory)
 
-        package_associations = cluster.inventory['services']['packages']['associations']['rhel']['keepalived']
+        package_associations = cluster.inventory['services']['packages']['associations']['rhel9']['keepalived']
 
         # simulate keepalived package missing
         missing_package_command = ['%s -v' % package_associations['executable_name']]
@@ -451,7 +451,7 @@ class TestKeepalivedConfigApply(unittest.TestCase):
         node = cluster.nodes['keepalived'].get_first_member()
         expected_config = keepalived.generate_config(cluster, node.get_config())
 
-        package_associations = cluster.inventory['services']['packages']['associations']['rhel']['keepalived']
+        package_associations = cluster.inventory['services']['packages']['associations']['rhel9']['keepalived']
         configs_directory = '/'.join(package_associations['config_location'].split('/')[:-1])
 
         # simulate mkdir for configs

--- a/test/unit/test_migrate_kubemarine.py
+++ b/test/unit/test_migrate_kubemarine.py
@@ -222,8 +222,6 @@ class UpgradeCRI(unittest.TestCase):
     def test_specific_os_family_cri_association_upgrade_required(self):
         for os_name, os_family, os_version in (
                 ('ubuntu', 'debian', '20.04'),
-                ('centos', 'rhel', '7.9'),
-                ('rhel', 'rhel8', '8.7'),
                 ('rhel', 'rhel9', '9.2')
         ):
             for package_vary in ('containerd', 'containerdio'):
@@ -236,7 +234,7 @@ class UpgradeCRI(unittest.TestCase):
                                         EnrichmentStage.PROCEDURE if expected_upgrade_required else EnrichmentStage.DEFAULT)
 
     def _packages_for_cri_os_family(self, os_family: str) -> List[str]:
-        if os_family in ('rhel', 'rhel8', 'rhel9'):
+        if os_family in ('rhel9',):
             package_names = ['containerdio']
         else:
             package_names = ['containerd']

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -366,8 +366,6 @@ class UpgradePackagesEnrichment(_AbstractUpgradeEnrichmentTest):
     def test_compatibility_upgrade_required(self):
         for os_name, os_family, os_version in (
                 ('ubuntu', 'debian', '20.04'),
-                ('centos', 'rhel', '7.9'),
-                ('rhel', 'rhel8', '8.7'),
                 ('rhel', 'rhel9', '9.2')
         ):
             for package_vary in ('containerd', 'containerdio'):
@@ -386,7 +384,7 @@ class UpgradePackagesEnrichment(_AbstractUpgradeEnrichmentTest):
                         f"CRI was {'not' if expected_upgrade_required else 'unexpectedly'} scheduled for upgrade")
 
     def _packages_for_cri_os_family(self, os_family: str) -> List[str]:
-        if os_family in ('rhel', 'rhel8', 'rhel9'):
+        if os_family in ('rhel9',):
             package_names = ['containerdio']
         else:
             package_names = ['containerd']


### PR DESCRIPTION
### Description
Drop support for RHEL/CentOS 7–8; standardize HAProxy to native haproxy on RHEL 9; update tests and docs



### Solution
1. Removes RHEL 7/8 and CentOS 7/8 from supported OS list.
2. Switches HAProxy service artifacts from legacy SCL (rh-haproxy18-haproxy) to native haproxy on RHEL 9.
3. Aligns code paths, tests, and documentation with the supported OS families: debian and rhel9.



### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] There is no breaking changes, or migration patch is provided
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


