### PR TITLE
Patch for updating default k8s version

### DIFF
--- a/kubemarine/patches/p1_pin_kubernetes_version.py
+++ b/kubemarine/patches/p1_pin_kubernetes_version.py
@@ -27,8 +27,8 @@ class TheAction(Action):
         logger = res.logger()
         inventory = res.inventory()
         if 'kubernetesVersion' not in inventory.get('services', {}).get('kubeadm', {}):
-            logger.debug("Set services.kubeadm.kubernetesVersion = v1.33.0 in the inventory")
-            inventory.setdefault('services', {}).setdefault('kubeadm', {})['kubernetesVersion'] = 'v1.33.0'
+            logger.debug("Set services.kubeadm.kubernetesVersion = v1.32.2 in the inventory")
+            inventory.setdefault('services', {}).setdefault('kubeadm', {})['kubernetesVersion'] = 'v1.32.2'
         else:
             logger.info("Skipping the patch as services.kubeadm.kubernetesVersion is explicitly provided.")
 


### PR DESCRIPTION
### Description
*  Default version of k8s is updated to v1.33.0. The cluster already installed will get this updated through patch when we run **migrate_kubemarine** procedure.


### Checklist
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] There is no breaking changes, or migration patch is provided
- [X] Integration CI passed
- [X] Unit tests. If Yes list of new/changed tests with brief description
- [X] There is no merge conflicts


#### Unit tests
Indicate new or changed unit tests and what they do, if any.


