### PR TITLE
feat: etcd reunion procedure

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -15,6 +15,7 @@ This section describes the features and steps for performing maintenance procedu
     - [Manage PSS Procedure](#manage-pss-procedure)
     - [Reboot Procedure](#reboot-procedure)
     - [Certificate Renew Procedure](#certificate-renew-procedure)
+    - [Etcd Member Reunion](#etcd-member-reunion)
 - [Procedure Execution](#procedure-execution)
     - [Procedure Execution From CLI](#procedure-execution-from-cli)
     - [Logging](#logging)
@@ -1469,6 +1470,19 @@ The `cert_renew` procedure executes the following sequence of tasks:
 3. envoy_gateway
 4. calico
 5. certs_overview
+
+## Etcd Member Reunion
+
+The `reunion` procedure allows to remove and add once again the particular etcd member. It might be useful when one etcd member failed and the other `control-plane` services are up and running on the node. The **procedure.yaml** looks the following:
+
+```yaml
+corrupted_node: "control-plane-1"
+healthy_node: "control-plane-2"
+```
+
+The `reunion` procedure executes only one task:
+
+1. reunion_member
 
 # Procedure Execution
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -1473,12 +1473,14 @@ The `cert_renew` procedure executes the following sequence of tasks:
 
 ## Etcd Member Reunion
 
-The `reunion` procedure allows to remove and add once again the particular etcd member. It might be useful when one etcd member failed and the other `control-plane` services are up and running on the node. Also, it's quite important the `etcdctl member list` command returns correct result with all members of the cluster, otherwise reunion procedure won't work. The **procedure.yaml** looks the following:
+The `reunion` procedure allows to remove and add once again the particular etcd member. It's  useful when only one etcd member failed and the other `control-plane` services are up and running on that node. Also, it's quite important the `etcdctl member list` command returns correct result with all members of the cluster, otherwise reunion procedure won't work. The **procedure.yaml** looks the following:
 
 ```yaml
 corrupted_node: "control-plane-1"
 healthy_node: "control-plane-2"
 ```
+
+**Warning**: Do not run the procedure if more than one etcd member has an issues or other issues could affect removal and addition member
 
 The `corrupted_node` is a k8s node where etcd member must be removed and added. The `healthy_node` is one of the k8s nodes where etcd is up and running properly.
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -1480,6 +1480,8 @@ corrupted_node: "control-plane-1"
 healthy_node: "control-plane-2"
 ```
 
+The `corrupted_node` is a k8s node where etcd member must be removed and added. The `healthy_node` is one of the k8s nodes where etcd is up and running properly.
+
 The `reunion` procedure executes only one task:
 
 1. reunion_member

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -1473,16 +1473,16 @@ The `cert_renew` procedure executes the following sequence of tasks:
 
 ## Etcd Member Reunion
 
-The `reunion` procedure allows to remove and add once again the particular etcd member. It's  useful when only one etcd member failed and the other `control-plane` services are up and running on that node. Also, it's quite important the `etcdctl member list` command returns correct result with all members of the cluster, otherwise reunion procedure won't work. The **procedure.yaml** looks the following:
+The `reunion` procedure allows to remove and add a particular etcd member again. It is useful when only when one etcd member failed and the other `control-plane` services are up and running on that node. Also, it's quite important that the `etcdctl member list` command returns correct result with all members of the cluster, otherwise reunion procedure won't work. The **procedure.yaml** looks the following:
 
 ```yaml
 corrupted_node: "control-plane-1"
 healthy_node: "control-plane-2"
 ```
 
-**Warning**: Do not run the procedure if more than one etcd member has an issues or other issues could affect removal and addition member
+**Warning**: Do not run the procedure, if more than one etcd member has issues or other issues could affect the removal and addition of the member.
 
-The `corrupted_node` is a k8s node where etcd member must be removed and added. The `healthy_node` is one of the k8s nodes where etcd is up and running properly.
+The `corrupted_node` is a k8s node, where etcd member must be removed and added. The `healthy_node` is one of the k8s nodes, where etcd is up and running properly.
 
 The `reunion` procedure executes only one task:
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -1473,7 +1473,7 @@ The `cert_renew` procedure executes the following sequence of tasks:
 
 ## Etcd Member Reunion
 
-The `reunion` procedure allows to remove and add once again the particular etcd member. It might be useful when one etcd member failed and the other `control-plane` services are up and running on the node. The **procedure.yaml** looks the following:
+The `reunion` procedure allows to remove and add once again the particular etcd member. It might be useful when one etcd member failed and the other `control-plane` services are up and running on the node. Also, it's quite important the `etcdctl member list` command returns correct result with all members of the cluster, otherwise reunion procedure won't work. The **procedure.yaml** looks the following:
 
 ```yaml
 corrupted_node: "control-plane-1"

--- a/kubemarine/__main__.py
+++ b/kubemarine/__main__.py
@@ -125,6 +125,10 @@ procedures = OrderedDict({
         'description': "Test internal imports and resources presence",
         'group': 'other'
     },
+    'reunion': {
+        'description': "Remove corrupted ETCD member from the cluster and add once again",
+        'group': 'maintenance'
+    },
 })
 
 

--- a/kubemarine/procedures/__init__.py
+++ b/kubemarine/procedures/__init__.py
@@ -61,6 +61,8 @@ def _import_tasks_procedure(name: str) -> TasksProcedure:
         from kubemarine.procedures import remove_node as procedure
     elif name == "restore":
         from kubemarine.procedures import restore as procedure
+    elif name == "reunion":
+        from kubemarine.procedures import reunion as procedure
     elif name == "upgrade":
         from kubemarine.procedures import upgrade as procedure
     else:

--- a/kubemarine/procedures/reunion.py
+++ b/kubemarine/procedures/reunion.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021-2022 NetCracker Technology Corporation
+# Copyright 2021-2026 NetCracker Technology Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubemarine/procedures/reunion.py
+++ b/kubemarine/procedures/reunion.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from collections import OrderedDict
+from typing import List
+
+from kubemarine import reunion
+from kubemarine.core import flow
+
+tasks = OrderedDict({
+    "reunion_member": reunion.reunion_member
+})
+
+
+class ReunionAction(flow.TasksAction):
+    def __init__(self) -> None:
+        super().__init__('reunion', tasks, recreate_inventory=True)
+
+
+def create_context(cli_arguments: List[str] = None) -> dict:
+
+    cli_help = '''
+    Script for reunion corrupted member into ETCD cluster.
+
+    How to use:
+
+    '''
+
+    parser = flow.new_procedure_parser(cli_help, tasks=tasks)
+    context = flow.create_context(parser, cli_arguments, procedure='reunion')
+    return context
+
+
+def main(cli_arguments: List[str] = None) -> None:
+    context = create_context(cli_arguments)
+    flow.ActionsFlow([ReunionAction()]).run_flow(context)
+
+
+if __name__ == '__main__':
+    main()

--- a/kubemarine/resources/schemas/reunion.json
+++ b/kubemarine/resources/schemas/reunion.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "corrupted_node": {
+      "type": "string",
+      "description": "ETCD member that will be removed and added once again."
+    }
+  }
+}

--- a/kubemarine/resources/schemas/reunion.json
+++ b/kubemarine/resources/schemas/reunion.json
@@ -4,7 +4,14 @@
   "properties": {
     "corrupted_node": {
       "type": "string",
-      "description": "ETCD member that will be removed and added once again."
+      "description": "ETCD member that will be removed and added once again.",
+      "minLength": 1
+    },
+    "healthy_node": {
+      "type": "string",
+      "description": "ETCD member that will be used to remove and add the corrupted node.",
+      "minLength": 1
     }
-  }
+  },
+  "required": ["corrupted_node", "healthy_node"]
 }

--- a/kubemarine/reunion.py
+++ b/kubemarine/reunion.py
@@ -89,12 +89,12 @@ def reunion_member(cluster: KubernetesCluster) -> None:
 
     if not f'--initial-advertise-peer-urls={member_peer}' in yaml['spec']['containers'][0]['command']:
         yaml['spec']['containers'][0]['command'].append(f'--initial-advertise-peer-urls={member_peer}')
-    if not f'--initial-advertise-peer-urls={member_peer}' in yaml['spec']['containers'][0]['command']:
+    if not f'--initial-cluster={init_cluster}' in yaml['spec']['containers'][0]['command']:
         yaml['spec']['containers'][0]['command'].append(f'--initial-cluster={init_cluster}')
     if not '--initial-cluster-state=existing' in yaml['spec']['containers'][0]['command']:
         yaml['spec']['containers'][0]['command'].append('--initial-cluster-state=existing')
 
-    cluster.log.debug(f'Puting etcd manifest on the corrupted node')
+    cluster.log.debug(f'Putting etcd manifest on the corrupted node')
     buf = io.StringIO()
     ruamel.yaml.YAML().dump(yaml, buf)
     corrupted_node.put(buf, etcd_manifest, sudo=True)

--- a/kubemarine/reunion.py
+++ b/kubemarine/reunion.py
@@ -32,7 +32,8 @@ def reunion_member(cluster: KubernetesCluster) -> None:
     corrupted_node = cluster.nodes['control-plane'].get_member_by_name(cluster.procedure_inventory.get('corrupted_node', ''))
     # Getting healthy etcd node
     healthy_node = cluster.nodes['control-plane'].get_member_by_name(cluster.procedure_inventory.get('healthy_node', ''))
-    cluster.log.debug(f'The corrupted etcd node is: {corrupted_node.get_node_name()}. The healthy etcd node is: {healthy_node.get_node_name()}')
+    cluster.log.debug(f'The corrupted etcd node is: "{corrupted_node.get_node_name()}". '
+                      f'The healthy etcd node is: "{healthy_node.get_node_name()}"')
 
     cluster.log.debug(f'Checking members list')
     member_id = ''

--- a/kubemarine/reunion.py
+++ b/kubemarine/reunion.py
@@ -56,7 +56,8 @@ def reunion_member(cluster: KubernetesCluster) -> None:
         cluster.log.debug(f'Corrupted member has ID: "{member_id}"; Endpoint: "{member_ep}"; Peer: "{member_peer}"')
     cluster.log.debug(f'Removing corrupted member {member_id}')
     # Moving etcd.yaml to temporary folder
-    corrupted_node.sudo(f'mv {etcd_manifest} {tmp_dir}')
+    corrupted_node.sudo(f'mkdir -p {tmp_dir}'
+                        f'&& sudo mv {etcd_manifest} {tmp_dir}')
     # Checking if etcd container has been deleted
     corrupted_node.sudo('crictl rm -f $(sudo crictl ps --name etcd -q) || true > /dev/null')
     # Removing corrupted member

--- a/kubemarine/reunion.py
+++ b/kubemarine/reunion.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 NetCracker Technology Corporation
+# Copyright 2021-2026 NetCracker Technology Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,24 +48,18 @@ def reunion_member(cluster: KubernetesCluster) -> None:
                 member_ep = member.split(", ")[4]
                 member_peer = member.split(", ")[3]
 
-    # Checking if corrupted node is already deleted
-    if member_id != '':
-        cluster.log.debug(f'Corrupted member has ID: "{member_id}"; Endpoint: "{member_ep}"; Peer: "{member_peer}"')
-        result = healthy_node.sudo('etcdctl endpoint status --cluster')
-        # Checking if the node is not a leader
-        for member in result[healthy_node.get_host()].stdout.split("\n"):
-            if len(member) > 0:
-                if member_ep == member.split(", ")[0] and member.split(", ")[8] == "true":
-                    raise Exception('Leader cannot be removed')
-        cluster.log.debug(f'Removing corrupted member {member_id}')
-        # Moving etcd.yaml to temporary folder or checking the etcd.yaml in temporary folder
-        corrupted_node.sudo(f'mv --backup {etcd_manifest} {tmp_dir} || ls -1 {tmp_dir}/etcd.yaml')
-        # Removing corrupted member
-        healthy_node.sudo(f'etcdctl member remove {member_id}')
+    if not member_id:
+        raise Exception('The corrupted member cannot be identified')
     else:
-        cluster.log.debug(f'The {corrupted_node.get_node_name()} member must be already removed from the etcd cluster')
-        member_peer = f'https://{corrupted_node.get_config()["internal_address"]}:2380'
-    # Removing erasing etcd storage
+        cluster.log.debug(f'Corrupted member has ID: "{member_id}"; Endpoint: "{member_ep}"; Peer: "{member_peer}"')
+    cluster.log.debug(f'Removing corrupted member {member_id}')
+    # Moving etcd.yaml to temporary folder
+    corrupted_node.sudo(f'mv {etcd_manifest} {tmp_dir}')
+    # Checking if etcd container has been deleted
+    corrupted_node.sudo('crictl rm -f $(sudo crictl ps --name etcd -q) || true > /dev/null')
+    # Removing corrupted member
+    healthy_node.sudo(f'etcdctl member remove {member_id}')
+    # Erasing etcd storage
     cluster.log.debug(f'Erasing data directory')
     corrupted_node.sudo(f'rm -Rf /var/lib/etcd'
                         '&& sudo mkdir /var/lib/etcd')
@@ -75,20 +69,21 @@ def reunion_member(cluster: KubernetesCluster) -> None:
     result = healthy_node.sudo(f'etcdctl member add {corrupted_node.get_node_name()} --peer-urls={member_peer}')
     for line in result[healthy_node.get_host()].stdout.split("\n"):
         if line.startswith('ETCD_INITIAL_CLUSTER='):
-            init_cluster = line.split('ETCD_INITIAL_CLUSTER=')[1]
+            init_cluster = line.split('ETCD_INITIAL_CLUSTER=')[1].replace('"','')
 
     # Preraring etcd manifest
     collector = CollectorCallback(cluster)
     corrupted_node.sudo(f'cat {tmp_dir}/etcd.yaml', callback=collector)
     results = collector.results[corrupted_node.get_host()]
     yaml = ruamel.yaml.YAML().load(results[0].stdout)
-    for command in yaml['spec']['containers'][0]['command']:
+    commands: List[str] = yaml['spec']['containers'][0]['command']
+    for i, command in enumerate(commands):
         if command.startswith('--initial-advertise-peer-urls='):
-            command = f'--initial-advertise-peer-urls={member_peer}'
+            commands[i] = f'--initial-advertise-peer-urls={member_peer}'
         if command.startswith('--initial-cluster='):
-            command = f'--initial-cluster={init_cluster}'
+            commands[i] = f'--initial-cluster={init_cluster}'
         if command.startswith('--initial-cluster-state='):
-            command = '--initial-cluster-state=existing'
+            commands[i] = '--initial-cluster-state=existing'
 
     if not f'--initial-advertise-peer-urls={member_peer}' in yaml['spec']['containers'][0]['command']:
         yaml['spec']['containers'][0]['command'].append(f'--initial-advertise-peer-urls={member_peer}')

--- a/kubemarine/reunion.py
+++ b/kubemarine/reunion.py
@@ -14,9 +14,9 @@
 
 import io
 
-import ruamel.yaml
-
 from typing import List
+
+import ruamel.yaml
 
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.group import CollectorCallback

--- a/kubemarine/reunion.py
+++ b/kubemarine/reunion.py
@@ -27,7 +27,7 @@ tmp_dir = '/etc/kubernetes/tmp/'
 
 def reunion_member(cluster: KubernetesCluster) -> None:
     if cluster.procedure_inventory.get('corrupted_node', '') == cluster.procedure_inventory.get('healthy_node', ''):
-        raise Exception('Corrupted and healthy nodes cannot be the same one')
+        raise Exception('Corrupted and healthy nodes must be different')
     # Checking corrupted node
     corrupted_node = cluster.nodes['control-plane'].get_member_by_name(cluster.procedure_inventory.get('corrupted_node', ''))
     # Getting healthy etcd node
@@ -47,7 +47,6 @@ def reunion_member(cluster: KubernetesCluster) -> None:
                 member_ep = member.split(", ")[4]
                 member_peer = member.split(", ")[3]
 
-
     # Checking if corrupted node is already deleted
     if member_id != '':
         cluster.log.debug(f'Corrupted member has ID: "{member_id}"; Endpoint: "{member_ep}"; Peer: "{member_peer}"')
@@ -64,6 +63,7 @@ def reunion_member(cluster: KubernetesCluster) -> None:
         healthy_node.sudo(f'etcdctl member remove {member_id}')
     else:
         cluster.log.debug(f'The {corrupted_node.get_node_name()} member must be already removed from the etcd cluster')
+        member_peer = f'https://{corrupted_node.get_config()["internal_address"]}:2380'
     # Removing erasing etcd storage
     cluster.log.debug(f'Erasing data directory')
     corrupted_node.sudo(f'rm -Rf /var/lib/etcd'
@@ -102,7 +102,6 @@ def reunion_member(cluster: KubernetesCluster) -> None:
     corrupted_node.put(buf, etcd_manifest, sudo=True)
     corrupted_node.sudo(f'rm {tmp_dir}/etcd.yaml', callback=collector)
     cluster.log.debug(f'Checking members list and cluster status')
-    result = corrupted_node.sudo('etcdctl endpoint status --cluster')
     # Waiting for etcd pod
-    _ = etcd.wait_for_health(cluster, corrupted_node)
+    etcd.wait_for_health(cluster, corrupted_node)
     kubernetes.wait_for_nodes(cluster.nodes['control-plane'])

--- a/kubemarine/reunion.py
+++ b/kubemarine/reunion.py
@@ -16,6 +16,8 @@ import io
 
 import ruamel.yaml
 
+from typing import List
+
 from kubemarine.core.cluster import KubernetesCluster
 from kubemarine.core.group import CollectorCallback
 from kubemarine import kubernetes, etcd

--- a/kubemarine/reunion.py
+++ b/kubemarine/reunion.py
@@ -50,7 +50,7 @@ def reunion_member(cluster: KubernetesCluster) -> None:
 
     # Checking if corrupted node is already deleted
     if member_id != '':
-        cluster.log.debug(f'Corrupted member has {member_id} id, {member_ep} endpoint, and {member_peer} peer')
+        cluster.log.debug(f'Corrupted member has ID: "{member_id}"; Endpoint: "{member_ep}"; Peer: "{member_peer}"')
         result = healthy_node.sudo('etcdctl endpoint status --cluster')
         # Checking if the node is not a leader
         for member in result[healthy_node.get_host()].stdout.split("\n"):

--- a/kubemarine/reunion.py
+++ b/kubemarine/reunion.py
@@ -1,0 +1,108 @@
+# Copyright 2021-2022 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+
+import ruamel.yaml
+
+from kubemarine.core.cluster import KubernetesCluster
+from kubemarine.core.group import CollectorCallback
+from kubemarine import kubernetes, etcd
+
+
+etcd_manifest = '/etc/kubernetes/manifests/etcd.yaml'
+tmp_dir = '/etc/kubernetes/tmp/'
+
+
+def reunion_member(cluster: KubernetesCluster) -> None:
+    if cluster.procedure_inventory.get('corrupted_node', '') == cluster.procedure_inventory.get('healthy_node', ''):
+        raise Exception('Corrupted and healthy nodes cannot be the same one')
+    # Checking corrupted node
+    corrupted_node = cluster.nodes['control-plane'].get_member_by_name(cluster.procedure_inventory.get('corrupted_node', ''))
+    # Getting healthy etcd node
+    healthy_node = cluster.nodes['control-plane'].get_member_by_name(cluster.procedure_inventory.get('healthy_node', ''))
+    cluster.log.debug(f'The corrupted etcd node is: {corrupted_node.get_node_name()}. The healthy etcd node is: {healthy_node.get_node_name()}')
+
+    cluster.log.debug(f'Checking members list')
+    member_id = ''
+    member_ep = ''
+    member_peer = ''
+    result = healthy_node.sudo('etcdctl member list')
+    # Getting member ID
+    for member in result[healthy_node.get_host()].stdout.split("\n"):
+        if len(member) > 0:
+            if member.split(", ")[2] == corrupted_node.get_node_name():
+                member_id = member.split(", ")[0]
+                member_ep = member.split(", ")[4]
+                member_peer = member.split(", ")[3]
+
+
+    # Checking if corrupted node is already deleted
+    if member_id != '':
+        cluster.log.debug(f'Corrupted member has {member_id} id, {member_ep} endpoint, and {member_peer} peer')
+        result = healthy_node.sudo('etcdctl endpoint status --cluster')
+        # Checking if the node is not a leader
+        for member in result[healthy_node.get_host()].stdout.split("\n"):
+            if len(member) > 0:
+                if member_ep == member.split(", ")[0] and member.split(", ")[8] == "true":
+                    raise Exception('Leader cannot be removed')
+        cluster.log.debug(f'Removing corrupted member {member_id}')
+        # Moving etcd.yaml to temporary folder or checking the etcd.yaml in temporary folder
+        corrupted_node.sudo(f'mv --backup {etcd_manifest} {tmp_dir} || ls -1 {tmp_dir}/etcd.yaml')
+        # Removing corrupted member
+        healthy_node.sudo(f'etcdctl member remove {member_id}')
+    else:
+        cluster.log.debug(f'The {corrupted_node.get_node_name()} member must be already removed from the etcd cluster')
+    # Removing erasing etcd storage
+    cluster.log.debug(f'Erasing data directory')
+    corrupted_node.sudo(f'rm -Rf /var/lib/etcd'
+                        '&& sudo mkdir /var/lib/etcd')
+
+    cluster.log.debug(f'Adding member')
+    # Adding member into the etcd cluster
+    result = healthy_node.sudo(f'etcdctl member add {corrupted_node.get_node_name()} --peer-urls={member_peer}')
+    for line in result[healthy_node.get_host()].stdout.split("\n"):
+        if line.startswith('ETCD_INITIAL_CLUSTER='):
+            init_cluster = line.split('ETCD_INITIAL_CLUSTER=')[1]
+
+    # Preraring etcd manifest
+    collector = CollectorCallback(cluster)
+    corrupted_node.sudo(f'cat {tmp_dir}/etcd.yaml', callback=collector)
+    results = collector.results[corrupted_node.get_host()]
+    yaml = ruamel.yaml.YAML().load(results[0].stdout)
+    for command in yaml['spec']['containers'][0]['command']:
+        if command.startswith('--initial-advertise-peer-urls='):
+            command = f'--initial-advertise-peer-urls={member_peer}'
+        if command.startswith('--initial-cluster='):
+            command = f'--initial-cluster={init_cluster}'
+        if command.startswith('--initial-cluster-state='):
+            command = '--initial-cluster-state=existing'
+
+    if not f'--initial-advertise-peer-urls={member_peer}' in yaml['spec']['containers'][0]['command']:
+        yaml['spec']['containers'][0]['command'].append(f'--initial-advertise-peer-urls={member_peer}')
+    if not f'--initial-advertise-peer-urls={member_peer}' in yaml['spec']['containers'][0]['command']:
+        yaml['spec']['containers'][0]['command'].append(f'--initial-cluster={init_cluster}')
+    if not '--initial-cluster-state=existing' in yaml['spec']['containers'][0]['command']:
+        yaml['spec']['containers'][0]['command'].append('--initial-cluster-state=existing')
+
+    cluster.log.debug(f'Puting etcd manifest on the corrupted node')
+    buf = io.StringIO()
+    ruamel.yaml.YAML().dump(yaml, buf)
+    corrupted_node.put(buf, etcd_manifest, sudo=True)
+    corrupted_node.sudo(f'rm {tmp_dir}/etcd.yaml', callback=collector)
+    cluster.log.debug(f'Checking members list and cluster status')
+    result = corrupted_node.sudo('etcdctl endpoint status --cluster')
+    # Waiting for etcd pod
+    _ = etcd.wait_for_health(cluster, corrupted_node)
+    kubernetes.wait_for_nodes(cluster.nodes['control-plane'])


### PR DESCRIPTION
### Description
* Provide an automation procedure to remove and add etcd member. It might be useful in case of corruption one of etcd members.

### Solution
* Add new KubeMarine procedure
* Implement particular steps to remove and add corrupted etcd member
* Add an article into maintenance guide


### Test Cases

**TestCase 1**
Check if the `reunion` procedure is working (all members are up and running)

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 22.04
- Inventory: miniHA

Steps:

1. Install K8S
2. Run the `kubemarine reunion` procedure

Results:

| Before | After |
| ------ | ------ |
| Not applicable | The etcd cluster is healthy and all of k8s cluster nodes are ready |


**TestCase 2**
Check if the `reunion` procedure is working (one member is corrupted)

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 22.04
- Inventory: miniHA

Steps:

1. Install K8S
2. Run the following commands on one of the control plane nodes:

```shell
$ mv /etc/kubernetes/manifests/etcd.yaml /etc/kubernetes/tmp/
$ dd if=/dev/urandom of=/var/lib/etcd/member/snap/db bs=1k count=100 seek=100 conv=notrunc
$ mv /etc/kubernetes/tmp/etcd /etc/kubernetes/manifests/etcd.yaml
```

3. Set that node as corrupted in procedure.yaml
4. Run the `kubemarine reunion` procedure

Results:

| Before | After |
| ------ | ------ |
| Not applicable | The etcd cluster is healthy and all of k8s cluster nodes are ready |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] There is no merge conflicts