### PR TITLE
Add note that Ubuntu 20.04 not supported for k8s 1.35+

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -171,9 +171,7 @@ For cluster machines, ensure the following requirements are met:
   * RockyLinux 8.6, 8.7, 8.8, 9.2, 9.3, 9.4, 9.5, 9.6
   * Ubuntu 20.04, 22.04.1, 24.04.1
  
-**Note**:
-* Ubuntu 20.04 is not supported for kubernetes 1.35 and higher 
-* Ubuntu 24.04 is supported only with kubernetes versions starting from v1.29.7 and above.
+**Note**: Ubuntu 20.04 is not supported for Kubernetes 1.35 and higher 
 
 <!-- #GFCFilterMarkerStart# -->
 The actual information about the supported versions can be found in `compatibility_map.distributives` section of [globals.yaml configuration](../kubemarine/resources/configurations/globals.yaml#L299).

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -6143,9 +6143,12 @@ The tables below shows the correspondence of versions that are supported and is 
 |          | rancher/local-path-provisioner                                 | v0.0.32          | v0.0.32                      | v0.0.32      | v0.0.32      | v0.0.32           | v0.0.32   | v0.0.32   | Required only if local-path provisioner plugin is set to be installed. |   
 
 ## Default Dependent Components Versions for Kubernetes Versions v1.35.0
+
+**Note**: Ubuntu 20.04 is not supported on Kubernetes v1.35+
+
 | Type     | Name                                                           | Versions         |                              |              |              |                   |           |           | Note                                                                                                       |
 |----------|----------------------------------------------------------------|------------------|------------------------------|--------------|--------------|-------------------|-----------|-----------|------------------------------------------------------------------------------------------------------------|
-|          |                                                                | CentOS Stream 9 | RHEL/Oracle Linux 8.4 | Ubuntu 20.04,22.04 | Ubuntu 24.04 | Oracle Linux 8.4+ | RHEL 8.6+ | RockyLinux 8.6+ |                                                                                                      |
+|          |                                                                | CentOS Stream 9 | RHEL/Oracle Linux 8.4 | Ubuntu 22.04 | Ubuntu 24.04 | Oracle Linux 8.4+ | RHEL 8.6+ | RockyLinux 8.6+ |                                                                                                      |
 | binaries | kubeadm                                                        | v1.35.0          | v1.35.0                      | v1.35.0      | v1.35.0      | v1.35.0           | v1.35.0   | v1.35.0   | SHA1: 3b332029396ff8f3e056c29a005d62fe6b09d05f          |
 |          | kubelet                                                        | v1.35.0          | v1.35.0                      | v1.35.0      | v1.35.0      | v1.35.0           | v1.35.0   | v1.35.0   | SHA1: 0ad7d08b9de3a526869088e0d0a2de4d6f5ffabc          |
 |          | kubectl                                                        | v1.35.0          | v1.35.0                      | v1.35.0      | v1.35.0      | v1.35.0           | v1.35.0   | v1.35.0   | SHA1: 8873116ce8aa124b6a3fed5f76e6b0b0989f87a3          |

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -171,7 +171,9 @@ For cluster machines, ensure the following requirements are met:
   * RockyLinux 8.6, 8.7, 8.8, 9.2, 9.3, 9.4, 9.5, 9.6
   * Ubuntu 20.04, 22.04.1, 24.04.1
  
-**Note**: Ubuntu 24.04 is supported only with kubernetes versions starting from v1.29.7 and above.
+**Note**:
+* Ubuntu 20.04 is not supported for kubernetes 1.35 and higher 
+* Ubuntu 24.04 is supported only with kubernetes versions starting from v1.29.7 and above.
 
 <!-- #GFCFilterMarkerStart# -->
 The actual information about the supported versions can be found in `compatibility_map.distributives` section of [globals.yaml configuration](../kubemarine/resources/configurations/globals.yaml#L299).


### PR DESCRIPTION
### Description
Ubuntu 20.04 uses cgroups v1 by default, while k8s 1.35+ recommends distributives with cgroups v2 by default. Also Ubuntu 20.04 has reached end of standard support. Need to deprecate it for now and later remove in once Ubuntu 26.04 is supported.

### Solution
Added note is supported version that k8s 1.35 does not support Ubuntu 20.04


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no breaking changes, or migration patch is provided
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts


