### PR TITLE
Feature/backup

### DIFF
--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -577,6 +577,8 @@ You can specify two types of path in it:
   /home/centos/backup-{cluster_name}-20201214-162731.tar.gz
 ```
 
+Also, the latest backup is stored on control plane nodes in `/etc/kubemarine/backup.tar.gz` file.
+
 #### etcd Parameters
 
 You can specify custom parameters for ETCD snapshot creation task. The following options are available:
@@ -746,6 +748,8 @@ Example:
 ```
 backup_location: /home/centos/backup-{cluster_name}-20201214-162731.tar.gz
 ```
+
+If `backup_location` is empty, the latest backup that is stored on control plane nodes in `/etc/kubemarine/backup.tar.gz` file will be used.
 
 #### etcd Parameters
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -749,7 +749,7 @@ Example:
 backup_location: /home/centos/backup-{cluster_name}-20201214-162731.tar.gz
 ```
 
-If `backup_location` parameter value is empty, the latest backup that is stored on the control plane nodes in the `/etc/kubemarine/backup.tar.gz` file will be used.
+If `source_node` parameter is set, the backup archive will be used from that control plane node. The `backup_location` must be set accordingly because it needs the location (`/etc/kubemarine/backup.tar.gz`) on control plane node.
 
 #### etcd Parameters
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -577,11 +577,11 @@ You can specify two types of path in it:
   /home/centos/backup-{cluster_name}-20201214-162731.tar.gz
 ```
 
-Also, the latest backup is stored on control plane nodes in `/etc/kubemarine/backup.tar.gz` file.
+Also, the latest backup is stored on control plane nodes in the `/etc/kubemarine/backup.tar.gz` file.
 
 #### etcd Parameters
 
-You can specify custom parameters for ETCD snapshot creation task. The following options are available:
+You can specify the custom parameters for ETCD snapshot creation task. The following options are available:
 
 * `source_node` - the name of the node to create snapshot from. The node must be a control-plane and have a ETCD data located on it.
 
@@ -749,7 +749,7 @@ Example:
 backup_location: /home/centos/backup-{cluster_name}-20201214-162731.tar.gz
 ```
 
-If `backup_location` is empty, the latest backup that is stored on control plane nodes in `/etc/kubemarine/backup.tar.gz` file will be used.
+If `backup_location` parameter value is empty, the latest backup that is stored on the control plane nodes in the `/etc/kubemarine/backup.tar.gz` file will be used.
 
 #### etcd Parameters
 

--- a/documentation/Maintenance.md
+++ b/documentation/Maintenance.md
@@ -747,9 +747,10 @@ Example:
 
 ```
 backup_location: /home/centos/backup-{cluster_name}-20201214-162731.tar.gz
+source_node: ''
 ```
 
-If `source_node` parameter is set, the backup archive will be used from that control plane node. The `backup_location` must be set accordingly because it needs the location (`/etc/kubemarine/backup.tar.gz`) on control plane node.
+If `source_node` parameter is set, the backup archive will be used from that control plane node. The `backup_location` must be set accordingly because it needs the location on control plane node, e.g.: [full-restore_with_source_node.yaml](../examples/procedure.yaml/full-restore_with_source_node.yaml)
 
 #### etcd Parameters
 

--- a/examples/procedure.yaml/full-restore_with_source_node.yaml
+++ b/examples/procedure.yaml/full-restore_with_source_node.yaml
@@ -1,0 +1,24 @@
+backup_location: /etc/kubemarine/backup.tar.gz
+source_node: control-plane-1
+
+restore_plan:
+  etcd:
+    image: registry.k8s.io/etcd:3.3.15-0
+    certificates:
+      cert: /etc/kubernetes/pki/etcd/server.crt
+      key: /etc/kubernetes/pki/etcd/server.key
+      cacert: /etc/kubernetes/pki/etcd/ca.crt
+      peer_cert: /etc/kubernetes/pki/etcd/peer.crt
+      peer_key: /etc/kubernetes/pki/etcd/peer.key
+      peer_cacert: /etc/kubernetes/pki/etcd/ca.crt
+  thirdparties:
+    /usr/bin/kubeadm:
+      source: https://dl.k8s.io/v1.18.8/bin/linux/amd64/kubeadm
+    /usr/bin/kubelet:
+      source: https://dl.k8s.io/v1.18.8/bin/linux/amd64/kubelet
+    /usr/bin/kubectl:
+      source: https://dl.k8s.io/v1.18.8/bin/linux/amd64/kubectl
+    /opt/cni/cni-plugins-linux.tgz:
+      source: https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
+    /usr/bin/calicoctl:
+      source: https://github.com/projectcalico/calicoctl/releases/download/v3.14.1/calicoctl-linux-amd64

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -86,7 +86,6 @@ def prepare_backup_tmpdir(logger: log.EnhancedLogger, context: dict) -> str:
 
 
 def verify_backup_location(cluster: KubernetesCluster) -> None:
-    # TODO: S3
     target = utils.get_external_resource_path(cluster.procedure_inventory.get('backup_location', 'backup.tar.gz'))
     if not os.path.isdir(target) and not os.path.isdir(os.path.abspath(os.path.join(target, os.pardir))):
         cluster.log.warning('Backup location directory not exists. The backup will be stored only on control plane nodes')

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -38,6 +38,7 @@ from kubemarine.cri import containerd
 
 local_backup = "/etc/kubemarine/backup.tar.gz"
 
+
 def get_default_backup_files_list(cluster: KubernetesCluster) -> List[str]:
     haproxy_service = cluster.get_package_association('haproxy', 'service_name')
     keepalived_service = cluster.get_package_association('keepalived', 'service_name')

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -36,6 +36,8 @@ from kubemarine.core.group import NodeGroup, RemoteExecutor
 from kubemarine.cri import containerd
 
 
+local_backup = "/etc/kubemarine/backup.tar.gz"
+
 def get_default_backup_files_list(cluster: KubernetesCluster) -> List[str]:
     haproxy_service = cluster.get_package_association('haproxy', 'service_name')
     keepalived_service = cluster.get_package_association('keepalived', 'service_name')
@@ -83,9 +85,11 @@ def prepare_backup_tmpdir(logger: log.EnhancedLogger, context: dict) -> str:
 
 
 def verify_backup_location(cluster: KubernetesCluster) -> None:
+    # TODO: S3
     target = utils.get_external_resource_path(cluster.procedure_inventory.get('backup_location', 'backup.tar.gz'))
     if not os.path.isdir(target) and not os.path.isdir(os.path.abspath(os.path.join(target, os.pardir))):
-        raise FileNotFoundError('Backup location directory not exists')
+        cluster.log.warning('Backup location directory not exists. The backup will be stored only on control plane nodes')
+        cluster.context['use_archive_tmpdir'] = True
 
 
 def export_ansible_inventory(cluster: KubernetesCluster) -> None:
@@ -724,12 +728,17 @@ def pack_data(cluster: KubernetesCluster) -> None:
 
     backup_filename = 'backup-%s-%s.tar.gz' % (cluster_name, utils.get_current_timestamp_formatted())
 
-    target = utils.get_external_resource_path(cluster.procedure_inventory.get('backup_location', backup_filename))
+    if cluster.context.get('use_archive_tmpdir', False):
+        target = utils.get_dump_filepath(cluster.context, backup_filename)
+    else:
+        target = utils.get_external_resource_path(cluster.procedure_inventory.get('backup_location', backup_filename))
     if os.path.isdir(target):
         target = os.path.join(target, backup_filename)
 
     cluster.log.debug('Packing all data...')
     pack_to_tgz(target, backup_directory)
+    # Put archive into control-plane nodes. It will replace previous backup
+    cluster.nodes['control-plane'].put(target, local_backup, sudo=True, mkdir=True)
 
     cluster.log.verbose('Cleaning up...')
     shutil.rmtree(backup_directory, ignore_errors=True)

--- a/kubemarine/procedures/backup.py
+++ b/kubemarine/procedures/backup.py
@@ -88,8 +88,7 @@ def prepare_backup_tmpdir(logger: log.EnhancedLogger, context: dict) -> str:
 def verify_backup_location(cluster: KubernetesCluster) -> None:
     target = utils.get_external_resource_path(cluster.procedure_inventory.get('backup_location', 'backup.tar.gz'))
     if not os.path.isdir(target) and not os.path.isdir(os.path.abspath(os.path.join(target, os.pardir))):
-        cluster.log.warning('Backup location directory not exists. The backup will be stored only on control plane nodes')
-        cluster.context['use_archive_tmpdir'] = True
+        raise FileNotFoundError('Backup location directory not exists')
 
 
 def export_ansible_inventory(cluster: KubernetesCluster) -> None:
@@ -728,10 +727,7 @@ def pack_data(cluster: KubernetesCluster) -> None:
 
     backup_filename = 'backup-%s-%s.tar.gz' % (cluster_name, utils.get_current_timestamp_formatted())
 
-    if cluster.context.get('use_archive_tmpdir', False):
-        target = utils.get_dump_filepath(cluster.context, backup_filename)
-    else:
-        target = utils.get_external_resource_path(cluster.procedure_inventory.get('backup_location', backup_filename))
+    target = utils.get_external_resource_path(cluster.procedure_inventory.get('backup_location', backup_filename))
     if os.path.isdir(target):
         target = os.path.join(target, backup_filename)
 

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -64,7 +64,7 @@ def unpack_data(resources: DynamicResources) -> None:
     logger = resources.logger()
     context = resources.context
     backup_tmp_directory = backup.prepare_backup_tmpdir(logger, context)
-    backup_file_source = resources.procedure_inventory().get('backup_location')
+    backup_file_source = resources.procedure_inventory().get('backup_location', '')
 
     # The backup archive from node
     node_name = resources.procedure_inventory().get('source_node', '')
@@ -73,7 +73,7 @@ def unpack_data(resources: DynamicResources) -> None:
         cluster = resources.cluster()
         logger.warning('The archive from control plane node will be used')
         backup_file_source = utils.get_dump_filepath(context, 'backup.tar.gz')
-        on_node_backup_file_source: str = resources.procedure_inventory().get('backup_location', '')
+        on_node_backup_file_source = resources.procedure_inventory().get('backup_location', '')
         control_plane_node = cluster.nodes['control-plane'].get_member_by_name(node_name)
         control_plane_node.get(on_node_backup_file_source, backup_file_source)
         # Previously created cluster must be reset to run enrichment from the beginning

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -63,29 +63,35 @@ def replace_config_from_backup_if_needed(procedure_inventory_filepath: str, conf
             tar.close()
 
 
-def unpack_data(cluster: KubernetesCluster) -> None:
-    backup_tmp_directory = backup.prepare_backup_tmpdir(cluster.log, cluster.context)
-    backup_file_source = cluster.procedure_inventory.get('backup_location')
+def unpack_data(resources: DynamicResources) -> None:
+    logger = resources.logger()
+    context = resources.context
+    backup_tmp_directory = backup.prepare_backup_tmpdir(logger, context)
+    backup_file_source = resources.procedure_inventory().get('backup_location')
 
     # Local backup archive usage if 'backup_location' is not defined
     if not backup_file_source:
-        cluster.log.debug('Backup source not specified in procedure. The archive from node will be used')
-        backup_file_source = utils.get_dump_filepath(cluster.context, 'backup.tar.gz')
+        # Create cluster
+        cluster = resources.cluster()
+        logger.debug('Backup source not specified in procedure. The archive from node will be used')
+        backup_file_source = utils.get_dump_filepath(context, 'backup.tar.gz')
         control_plane_node = cluster.nodes['control-plane'].get_any_member()
         control_plane_node.get(local_backup, backup_file_source)
+        # Reset cluster
+        resources.reset_cluster()
 
     backup_file_source = utils.get_external_resource_path(backup_file_source)
     if not os.path.isfile(backup_file_source):
         raise FileNotFoundError('Backup file "%s" not found' % backup_file_source)
 
 
-    cluster.log.debug('Unpacking all data...')
+    logger.debug('Unpacking all data...')
     with tarfile.open(backup_file_source, 'r:gz') as tar:
         for member in tar:
             if member.isdir():
                 continue
             fname = os.path.join(backup_tmp_directory, member.name)
-            cluster.log.debug(fname)
+            logger.debug(fname)
             fname_parts = fname.split('/')
             if len(fname_parts) > 1:
                 fname_dir = "/".join(fname_parts[:-1])
@@ -99,7 +105,7 @@ def unpack_data(cluster: KubernetesCluster) -> None:
         raise FileNotFoundError('Descriptor not found in backup file')
 
     with utils.open_external(descriptor_filepath, 'r') as stream:
-        cluster.context['backup_descriptor'] = yaml.safe_load(stream)
+         context['backup_descriptor'] = yaml.safe_load(stream)
 
 
 def stop_cluster(cluster: KubernetesCluster) -> None:
@@ -264,7 +270,6 @@ def reboot(cluster: KubernetesCluster) -> None:
 
 tasks = OrderedDict({
     "prepare": {
-        "unpack_archive": unpack_data,
         "stop_cluster": stop_cluster,
     },
     "restore": {
@@ -283,6 +288,7 @@ tasks = OrderedDict({
 
 class RestoreFlow(flow.Flow):
     def _run(self, resources: DynamicResources) -> None:
+        unpack_data(resources)
         flow.run_actions(resources, [RestoreAction()])
 
 

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -71,10 +71,11 @@ def unpack_data(resources: DynamicResources) -> None:
     if node_name:
         # Since `unpack_data` method is out of tasks scope we need to create cluster
         cluster = resources.cluster()
-        logger.warning('The archive from node will be used')
+        logger.warning('The archive from control plane node will be used')
         backup_file_source = utils.get_dump_filepath(context, 'backup.tar.gz')
+        on_node_backup_file_source: str = resources.procedure_inventory().get('backup_location')
         control_plane_node = cluster.nodes['control-plane'].get_member_by_name(node_name)
-        control_plane_node.get(resources.procedure_inventory().get('backup_location'), backup_file_source)
+        control_plane_node.get(on_node_backup_file_source, backup_file_source)
         # Previously created cluster must be reset to run enrichment from the beginning
         resources.reset_cluster(EnrichmentStage.DEFAULT)
 

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -25,7 +25,7 @@ from typing import List
 import yaml
 
 from kubemarine.core import utils, flow
-from kubemarine.core.cluster import KubernetesCluster
+from kubemarine.core.cluster import KubernetesCluster, EnrichmentStage
 from kubemarine.core.resources import DynamicResources
 from kubemarine.procedures import install, backup
 from kubemarine import system, kubernetes, etcd
@@ -78,7 +78,7 @@ def unpack_data(resources: DynamicResources) -> None:
         control_plane_node = cluster.nodes['control-plane'].get_any_member()
         control_plane_node.get(local_backup, backup_file_source)
         # Reset cluster
-        resources.reset_cluster()
+        resources.reset_cluster(EnrichmentStage.DEFAULT)
 
     backup_file_source = utils.get_external_resource_path(backup_file_source)
     if not os.path.isfile(backup_file_source):
@@ -105,7 +105,7 @@ def unpack_data(resources: DynamicResources) -> None:
         raise FileNotFoundError('Descriptor not found in backup file')
 
     with utils.open_external(descriptor_filepath, 'r') as stream:
-         context['backup_descriptor'] = yaml.safe_load(stream)
+        context['backup_descriptor'] = yaml.safe_load(stream)
 
 
 def stop_cluster(cluster: KubernetesCluster) -> None:

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -75,7 +75,7 @@ def unpack_data(cluster: KubernetesCluster) -> None:
         control_plane_node.get(local_backup, backup_file_source)
 
     backup_file_source = utils.get_external_resource_path(backup_file_source)
-    if not os.path.isfile(backup_file_source) and not use_archive_from_node:
+    if not os.path.isfile(backup_file_source):
         raise FileNotFoundError('Backup file "%s" not found' % backup_file_source)
 
 

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -84,7 +84,6 @@ def unpack_data(resources: DynamicResources) -> None:
     if not os.path.isfile(backup_file_source):
         raise FileNotFoundError('Backup file "%s" not found' % backup_file_source)
 
-
     logger.debug('Unpacking all data...')
     with tarfile.open(backup_file_source, 'r:gz') as tar:
         for member in tar:

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -73,7 +73,7 @@ def unpack_data(resources: DynamicResources) -> None:
         cluster = resources.cluster()
         logger.warning('The archive from control plane node will be used')
         backup_file_source = utils.get_dump_filepath(context, 'backup.tar.gz')
-        on_node_backup_file_source: str = resources.procedure_inventory().get('backup_location')
+        on_node_backup_file_source: str = resources.procedure_inventory().get('backup_location', '')
         control_plane_node = cluster.nodes['control-plane'].get_member_by_name(node_name)
         control_plane_node.get(on_node_backup_file_source, backup_file_source)
         # Previously created cluster must be reset to run enrichment from the beginning

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -31,6 +31,9 @@ from kubemarine.procedures import install, backup
 from kubemarine import system, kubernetes, etcd
 
 
+local_backup = "/etc/kubemarine/backup.tar.gz"
+
+
 def missing_or_empty(file: str) -> bool:
     if not os.path.exists(file):
         return True
@@ -60,26 +63,29 @@ def replace_config_from_backup_if_needed(procedure_inventory_filepath: str, conf
             tar.close()
 
 
-def unpack_data(resources: DynamicResources) -> None:
-    logger = resources.logger()
-    context = resources.context
-    backup_tmp_directory = backup.prepare_backup_tmpdir(logger, context)
-    backup_file_source = resources.procedure_inventory().get('backup_location')
+def unpack_data(cluster: KubernetesCluster) -> None:
+    backup_tmp_directory = backup.prepare_backup_tmpdir(cluster.log, cluster.context)
+    backup_file_source = cluster.procedure_inventory.get('backup_location')
 
+    # Local backup archive usage if 'backup_location' is not defined
     if not backup_file_source:
-        raise Exception('Backup source not specified in procedure')
+        cluster.log.debug('Backup source not specified in procedure. The archive from node will be used')
+        backup_file_source = utils.get_dump_filepath(cluster.context, 'backup.tar.gz')
+        control_plane_node = cluster.nodes['control-plane'].get_any_member()
+        control_plane_node.get(local_backup, backup_file_source)
 
     backup_file_source = utils.get_external_resource_path(backup_file_source)
-    if not os.path.isfile(backup_file_source):
+    if not os.path.isfile(backup_file_source) and not use_archive_from_node:
         raise FileNotFoundError('Backup file "%s" not found' % backup_file_source)
 
-    logger.debug('Unpacking all data...')
+
+    cluster.log.debug('Unpacking all data...')
     with tarfile.open(backup_file_source, 'r:gz') as tar:
         for member in tar:
             if member.isdir():
                 continue
             fname = os.path.join(backup_tmp_directory, member.name)
-            logger.debug(fname)
+            cluster.log.debug(fname)
             fname_parts = fname.split('/')
             if len(fname_parts) > 1:
                 fname_dir = "/".join(fname_parts[:-1])
@@ -93,7 +99,7 @@ def unpack_data(resources: DynamicResources) -> None:
         raise FileNotFoundError('Descriptor not found in backup file')
 
     with utils.open_external(descriptor_filepath, 'r') as stream:
-        context['backup_descriptor'] = yaml.safe_load(stream)
+        cluster.context['backup_descriptor'] = yaml.safe_load(stream)
 
 
 def stop_cluster(cluster: KubernetesCluster) -> None:
@@ -258,6 +264,7 @@ def reboot(cluster: KubernetesCluster) -> None:
 
 tasks = OrderedDict({
     "prepare": {
+        "unpack_archive": unpack_data,
         "stop_cluster": stop_cluster,
     },
     "restore": {
@@ -276,7 +283,6 @@ tasks = OrderedDict({
 
 class RestoreFlow(flow.Flow):
     def _run(self, resources: DynamicResources) -> None:
-        unpack_data(resources)
         flow.run_actions(resources, [RestoreAction()])
 
 

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -71,13 +71,13 @@ def unpack_data(resources: DynamicResources) -> None:
 
     # Local backup archive usage if 'backup_location' is not defined
     if not backup_file_source:
-        # Create cluster
+        # Since `unpack_data` method is out of tasks scope we need to create cluster
         cluster = resources.cluster()
-        logger.debug('Backup source not specified in procedure. The archive from node will be used')
+        logger.warning('Backup source not specified in procedure. The archive from node will be used')
         backup_file_source = utils.get_dump_filepath(context, 'backup.tar.gz')
         control_plane_node = cluster.nodes['control-plane'].get_any_member()
         control_plane_node.get(local_backup, backup_file_source)
-        # Reset cluster
+        # Previously created cluster must be reset to run enrichment from the beginning
         resources.reset_cluster(EnrichmentStage.DEFAULT)
 
     backup_file_source = utils.get_external_resource_path(backup_file_source)

--- a/kubemarine/procedures/restore.py
+++ b/kubemarine/procedures/restore.py
@@ -31,9 +31,6 @@ from kubemarine.procedures import install, backup
 from kubemarine import system, kubernetes, etcd
 
 
-local_backup = "/etc/kubemarine/backup.tar.gz"
-
-
 def missing_or_empty(file: str) -> bool:
     if not os.path.exists(file):
         return True
@@ -69,14 +66,15 @@ def unpack_data(resources: DynamicResources) -> None:
     backup_tmp_directory = backup.prepare_backup_tmpdir(logger, context)
     backup_file_source = resources.procedure_inventory().get('backup_location')
 
-    # Local backup archive usage if 'backup_location' is not defined
-    if not backup_file_source:
+    # The backup archive from node
+    node_name = resources.procedure_inventory().get('source_node', '')
+    if node_name:
         # Since `unpack_data` method is out of tasks scope we need to create cluster
         cluster = resources.cluster()
-        logger.warning('Backup source not specified in procedure. The archive from node will be used')
+        logger.warning('The archive from node will be used')
         backup_file_source = utils.get_dump_filepath(context, 'backup.tar.gz')
-        control_plane_node = cluster.nodes['control-plane'].get_any_member()
-        control_plane_node.get(local_backup, backup_file_source)
+        control_plane_node = cluster.nodes['control-plane'].get_member_by_name(node_name)
+        control_plane_node.get(resources.procedure_inventory().get('backup_location'), backup_file_source)
         # Previously created cluster must be reset to run enrichment from the beginning
         resources.reset_cluster(EnrichmentStage.DEFAULT)
 

--- a/kubemarine/resources/schemas/restore.json
+++ b/kubemarine/resources/schemas/restore.json
@@ -6,6 +6,10 @@
       "type": "string",
       "description": "Path to the file with the backup from which the recovery is performed"
     },
+    "source_node": {
+      "$ref": "definitions/common/node_ref.json#/definitions/Name",
+      "description": "The name of the node to get backup archive from. The node must be a control-plane."
+    },
     "restore_plan": {
       "type": "object",
       "description": "Restore procedure configuration",


### PR DESCRIPTION
### Description
* Make backup/restore procedure more flexible and independent from `backup_location` option

### Solution
* Code changes in `backup` procedure to save backup archive on the control plane nodes
* Code changes in `restore` procedure to restore from backup archive on the control plane nodes
* Documentation update

### Test Cases

**TestCase 1**
Check if backup archive is stored on the control plane nodes

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 22.04
- Inventory: miniHA

Steps:

1. Install K8S cluster
2. Run `backup` procedure

Results:

| Before | After |
| ------ | ------ |
| Not applicable | archive additionally stored on control plane nodes in `/etc/kubemarine/backup.tar.gz` |

**TestCase 2**
Check if restore procedure could use archive from the control plane nodes

Test Configuration:

- Hardware: 4CPU/8GB
- OS: Ubuntu 22.04
- Inventory: miniHA

Steps:

1. Install K8S cluster
2. Set `backup_location` to `/etc/kubemarine/backup.tar.gz` and `source_node` to one of the control plane nodes in procedure.yaml
3. Run `restore` procedure

Results:

| Before | After |
| ------ | ------ |
| Success | Success |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Integration CI passed
- [x] There is no merge conflicts