### PR TITLE
fix dashboard availability check

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -747,7 +747,8 @@ def kubernetes_dashboard_status(cluster: KubernetesCluster) -> None:
                         f'-s -S -w "%{{http_code}}"', pty=True, warn=True)
                 status = list(check_url.values())[0].stdout
                 lst = status.split('\n')
-                if lst[len(lst)-1] == '200':
+                http_code = lst[len(lst)-1].strip()
+                if http_code in ('200', '405'):
                     cluster.log.verbose(status)
                     cluster.log.debug('Dashboard ingress is OK')
                     test_ingress_succeeded = True


### PR DESCRIPTION
### Description
Dashboard Availability check (TC 208) fails on clusters with authentication enabled (oauth2-proxy + Keycloak). The ingress check strictly expects HTTP `200`, but the redirect chain ends with `405` from Keycloak rejecting curl's HEAD request, causing a false negative.

### Solution
Updated ingress http_code check in `kubernetes_dashboard_status` to accept `('200', '405')` instead of `== '200'`

### How to apply
NA

### Test Cases

**TestCase 1**

Test Configuration:

- OS: Ubuntu 22.04 LTS
- Inventory: kubernetes-dashboard with oauth2-proxy + Keycloak authentication enabled

Steps:

1. Run ` kubemarine check_paas --tasks kubernetes.plugins.dashboard`

Results:

| Before | After |
| ------ | ------ |
| TC 208 FAIL: `Dashboard ingress is not running yet...` | TC 208 PASS: `available` |

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no breaking changes, or migration patch is provided
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

#### Unit tests
N/A