### PR TITLE
fix node removal

### DIFF
--- a/kubemarine/core/cluster.py
+++ b/kubemarine/core/cluster.py
@@ -563,7 +563,7 @@ class KubernetesCluster(Environment):
             return
         
         if procedure == 'remove_node':
-            group = self.make_group_from_roles(['control-plane', 'balancer'])
+            group = self.get_unchanged_nodes().having_roles(['control-plane', 'balancer'])
         else:
             group = self.make_group_from_roles(['control-plane', 'balancer']).include_group(self.get_new_nodes_or_self())
 

--- a/test/unit/core/test_flow.py
+++ b/test/unit/core/test_flow.py
@@ -414,6 +414,24 @@ class FlowTest(unittest.TestCase):
         # no exception should occur
         flow.run_tasks(res, tasks)
 
+    def test_remove_control_plane_if_offline(self):
+        inventory = demo.generate_inventory(**demo.FULLHA_KEEPALIVED)
+        online_hosts = [node["address"] for node in inventory["nodes"]]
+        control_planes = [i for i, node in enumerate(inventory["nodes"]) if 'control-plane' in node['roles']]
+
+        i = control_planes[0]
+        online_hosts.remove(inventory["nodes"][i]["address"])
+        procedure_inventory = demo.generate_procedure_inventory('remove_node')
+        procedure_inventory["nodes"] = [{"name": inventory["nodes"][i]["name"]}]
+
+        self._stub_detect_nodes_context(inventory, online_hosts, [])
+        context = demo.create_silent_context(['fake_path.yaml'], procedure='remove_node')
+        res = demo.FakeResources(context, inventory, procedure_inventory=procedure_inventory,
+                                 fake_shell=self.light_fake_shell)
+
+        # no exception should occur — offline control-plane being removed must not block the procedure
+        flow.run_tasks(res, tasks)
+
     def test_remove_node_if_worker_offline(self):
         inventory = demo.generate_inventory(**demo.FULLHA_KEEPALIVED)
         online_hosts = [node["address"] for node in inventory["nodes"]]


### PR DESCRIPTION
### Description
`remove_node` procedure fails immediately with `KME0006` when the control-plane node being removed is offline or powered off not reachable. 

* `check_nodes_accessibility` must only validate nodes that are **staying** in the cluster, not the ones being removed.


### Solution
Replaced `make_group_from_roles(['control-plane', 'balancer'])` with `get_unchanged_nodes().having_roles(['control-plane', 'balancer'])` in `check_nodes_accessibility()`. `get_unchanged_nodes()` returns all nodes minus those being added or removed, 

### How to apply
NA

### Test Cases

**TestCase 1**

Test Configuration:
- OS: Ubuntu 22.04
- Inventory: FullHA (3 control-planes, 2 balancers, 3 workers)

Steps:

1. Power off one control-plane node.
2. Add the node to `procedure.yaml` under `nodes`.
3. Run `kubemarine remove_node procedure.yaml`.

Results:

| Before | After |
| ------ | ------ |
| Fails immediately with `KME0006: Nodes ['x.x.x.x'] are not reachable` | Procedure proceeds; etcd member removed manually from surviving control-plane, node deleted from cluster |


### Checklist
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] There is no breaking changes, or migration patch is provided
- [X] Integration CI passed
- [X] Unit tests. If Yes list of new/changed tests with brief description
- [X] There is no merge conflicts


#### Unit tests
- `test_remove_control_plane_if_offline` — new test that marks a control-plane node as offline, sets it as the node to remove, and asserts no `KME0006` is raised during `run_tasks`.

