### PR TITLE
Support switching "target_backend" on HAProxy

### DIFF
--- a/ci/default_cluster.yaml
+++ b/ci/default_cluster.yaml
@@ -11,6 +11,10 @@ nodes:
 cluster_name: "test-local-k8s.com"
 
 services:
+  loadbalancer:
+    target_ports:
+      envoy_http: 21080
+      envoy_https: 21443
   kubeadm:
     kubernetesVersion: '{{ env.KUBERNETES_VERSION }}'
 

--- a/ci/extended_cluster.yaml
+++ b/ci/extended_cluster.yaml
@@ -16,6 +16,10 @@ vrrp_ips:
 cluster_name: "test-local-k8s.com"
 
 services:
+  loadbalancer:
+    target_ports:
+      envoy_http: 21080
+      envoy_https: 21443
   packages:
     install:
     - ethtool

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3276,6 +3276,10 @@ services:
       envoy_https: 21443
 ```
 
+**Note**: if you change `target_ports`, make sure you run `install` procedure with both below tasks for changes to take effect:
+* `deploy.loadbalancer.haproxy.configure`
+* `deploy.plugins`
+
 ###### target_backend
 
 This section selects which ingress stack receives traffic from HAProxy: `nginx` or `envoy`. Default is `nginx` if nginx-ingress-controller is installed, otherwise `envoy`. If you do not install nginx and envoy plugins, this option simply selects target_ports pair.

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3278,7 +3278,7 @@ services:
 
 ###### target_backend
 
-This section selects which ingress stack receives traffic from HAProxy: `nginx` or `envoy`. Default is `nginx` if nginx-ingress-controller is installed, otherwise `envoy`. If you do not install nginx and envoy plugins, this option has no effect.
+This section selects which ingress stack receives traffic from HAProxy: `nginx` or `envoy`. Default is `nginx` if nginx-ingress-controller is installed, otherwise `envoy`. If you do not install nginx and envoy plugins, this option simply selects target_ports pair.
 
 **Note**: Envoy Gateway uses Gateway API resources (HTTPRoutes, etc) instead of Ingresses. Thus, when you migrate cluster from Ingress-NGINX to Envoy Gateway, your applications should also migrate from Ingresses to Gateway API resources, otherwise routing will not work.
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -186,9 +186,9 @@ The actual information about the supported versions can be found in `compatibili
   * Internal communication:
     * 22: SSH 
     * 53: CoreDNS, if access is needed from services bound to the host network.
-    * 80 (or 20080, if balancers are presented): HTTP
+    * 80, 20080, 21080: HTTP
     * 179: Calico BGP
-    * 443 (or 20443, if balancers are presented): HTTPS
+    * 443, 20443, 21443: HTTPS
     * 5443: Calico API server, if enabled
     * 5473: Calico networking with Typha enabled
     * 6443: Kubernetes API server
@@ -396,6 +396,8 @@ This deployment provides a single Kubemarine control-plane.
 This scheme has one node assigned as control-plane and worker roles; balancer role is optional. This scheme is used for developing and demonstrating purposes only.
 An example of this scheme is available in the [All-in-one Inventory Example](../examples/cluster.yaml/allinone-cluster.yaml).
 
+**Note:** If you install both ingress-nginx and envoy-gateway at the same time in this schema, you should explicitly provide hostPorts configuration to these plugins, otherwise they both will compete for ports 80/443.
+
 The following image illustrates the All-in-one scheme.
 
 ![All-in-one Scheme](/documentation/images/all-in-one.png)
@@ -411,8 +413,10 @@ This schema might be useful if:
 In this case, you can use schema with single control plane node (which runs envoy-gateway/ingress-nginx) and many (1 or more) workers.
 An example of this schema is available in the [One Control Plane and Many Workers Inventory Example](../examples/cluster.yaml/one-cp-many-workers-cluster.yaml).
 
-**Note**: Optionally, if you want control-plane node to be able to run workloads, 
+**Note**: 
+* Optionally, if you want control-plane node to be able to run workloads, 
 you need to add "worker" role to this node.
+* If you install both ingress-nginx and envoy-gateway at the same time in this schema, you should explicitly provide hostPorts configuration to these plugins, otherwise they both will compete for ports 80/443.
 
 The following image illustrates the "One Control Plane and Many Workers" schema.
 

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -3215,8 +3215,12 @@ However, it is possible to add or modify any deployment parameters of the invent
 
 ###### target_ports
 
-This section describes the ports, which are used for http/https connections from balancer nodes to workers. 
-Those parameters are specified as backend ports in haproxy configuration and as host ports in envoy-gateay or ingress-nginx-controller plugin (depending on `target_backend` value).
+This section describes the ports used for http/https connections from balancer nodes to workers.
+
+- `target_ports.http` / `target_ports.https` — nginx ingress hostPorts on workers and HAProxy backend ports when `target_backend` is `nginx`.
+- `target_ports.envoy_http` / `target_ports.envoy_https` — Envoy Gateway hostPorts on workers and HAProxy backend ports when `target_backend` is `envoy`.
+
+Both ingress plugins can be installed at the same time; each binds its own port pair. HAProxy forwards traffic to the pair selected by `target_backend`.
 
 Default values depend on balancer availability:  
 
@@ -3242,6 +3246,18 @@ Default values depend on balancer availability:
     <td>20443</td>
     <td>443</td>
   </tr>
+  <tr>
+    <td>target_ports.envoy_http</td>
+    <td>integer</td>
+    <td>21080</td>
+    <td>80</td>
+  </tr>
+  <tr>
+    <td>target_ports.envoy_https</td>
+    <td>integer</td>
+    <td>21443</td>
+    <td>443</td>
+  </tr>
 </tbody>
 </table>
 
@@ -3252,15 +3268,15 @@ services:
     target_ports:
       http: 80
       https: 443
+      envoy_http: 21080
+      envoy_https: 21443
 ```
 
 ###### target_backend
 
-This section describes who should listen `target_ports` on worker nodes, either `nginx` or `envoy`. Default is `nginx` for backward compatibility, but it is recommended to use `envoy`. If you do not install nginx and envoy plugins, this option has no effect.
+This section selects which ingress stack receives traffic from HAProxy: `nginx` or `envoy`. Default is `nginx` if nginx-ingress-controller is installed, otherwise `envoy`. If you do not install nginx and envoy plugins, this option has no effect.
 
 **Note**: Envoy Gateway uses Gateway API resources (HTTPRoutes, etc) instead of Ingresses. Thus, when you migrate cluster from Ingress-NGINX to Envoy Gateway, your applications should also migrate from Ingresses to Gateway API resources, otherwise routing will not work.
-
-This options also influences plugins installation priority. Selected target backend (e.g. `nginx`) will be installed with priority `2`, while the other plugin (e.g. `envoy`) will be installed with priority `1`. This is to allow other plugin to configure first and free host ports for target backend.
 
 You can specify this option in `cluster.yaml` as following:
 ```yaml
@@ -3268,6 +3284,11 @@ services:
   loadbalancer:
     target_backend: "envoy"
 ```
+
+To switch traffic between nginx and envoy without redeploying ingress plugins:
+
+1. Set `services.loadbalancer.target_backend` to `"nginx"` or `"envoy"` in `cluster.yaml`.
+2. Run `kubemarine install --tasks=deploy.loadbalancer.haproxy.configure`.
 
 ##### haproxy
 
@@ -4319,8 +4340,8 @@ plugins:
       certificate:
         cert: ""
         key: ""
-      # HostPorts are enabled by default only if services.loadbalancer.target_backend is envoy,
-      # in this case hostPorts will be equal to LB target_ports.
+      # HostPorts are enabled by default when balancer nodes exist,
+      # using services.loadbalancer.target_ports.envoy_http/envoy_https.
       # HostPorts also could be enabled and configured explicitly.
       hostPorts:
         http: 0
@@ -4688,8 +4709,8 @@ Plugins are installed in a strict sequential order. The installation sequence is
 |Plugin|Priority|
 |---|---|
 |calico|`0`|
-|envoy-gateway|`1` if `services.lb.target_backend` is `nginx`, otherwise `2` |
-|nginx-ingress-controller|`2` if `services.lb.target_backend` is `nginx`, otherwise `1` |
+|envoy-gateway|`1`|
+|nginx-ingress-controller|`1`|
 |kubernetes-dashboard|`3`|
 |local-path-provisioner|`3`|
 

--- a/examples/cluster.yaml/one-cp-many-workers-cluster.yaml
+++ b/examples/cluster.yaml/one-cp-many-workers-cluster.yaml
@@ -19,6 +19,12 @@ nodes:
     internal_address: "192.168.0.99"
     roles: ["worker"]
 
+services:
+  loadbalancer:
+    target_ports:
+      envoy_http: 21080
+      envoy_https: 21443
+
 # NodeSelector and Tolerations are required to make sure
 # envoy-gateway/nginx-ingress runs on control-plane node
 plugins:

--- a/kubemarine/core/resources.py
+++ b/kubemarine/core/resources.py
@@ -480,7 +480,6 @@ class DynamicResources:
             kubemarine.plugins.kubernetes_dashboard.enrich_inventory,
             kubemarine.plugins.local_path_provisioner.enrich_inventory,
             kubemarine.plugins.nginx_ingress.enrich_inventory,
-            kubemarine.plugins.envoy_gateway.enrich_inventory,
             # Depends on kubemarine.packages.enrich_inventory
             kubemarine.audit.verify_inventory,
             kubemarine.system.verify_inventory,

--- a/kubemarine/haproxy.py
+++ b/kubemarine/haproxy.py
@@ -33,6 +33,10 @@ ERROR_NO_BOUND_VRRP_CONFIGURED_MNTC = \
     'Balancer is combined with other role and has no configured VRRP IP ' \
     'that is not marked with maintenance-type: "not bind"'
 
+ERROR_INGRESS_TARGET_PORTS_OVERLAP = \
+    'nginx-ingress-controller and envoy-gateway cannot use the same worker hostPorts: %s. ' \
+    'Use different values for services.loadbalancer.target_ports ' \
+    '(http/https for nginx and envoy_http/envoy_https for envoy).'
 
 def is_maintenance_mode(cluster: KubernetesCluster) -> bool:
     maintenance_mode: bool = cluster.inventory['services']['loadbalancer']['haproxy']['maintenance_mode']
@@ -78,9 +82,23 @@ def _get_bindings(inventory: dict, node: NodeConfig, *, maintenance: bool) -> Li
     return list(set(bindings))
 
 
+def _verify_target_ports_do_not_overlap(inventory: dict) -> None:
+    if not inventory['plugins']['envoy-gateway']['install'] or not inventory['plugins']['nginx-ingress-controller']['install']:
+        return
+
+    target_ports = inventory['services']['loadbalancer']['target_ports']
+    nginx_host_ports = {int(target_ports['http']), int(target_ports['https'])}
+    envoy_host_ports = {int(target_ports['envoy_http']), int(target_ports['envoy_https'])}
+
+    overlap = nginx_host_ports & envoy_host_ports
+    if overlap:
+        raise Exception(ERROR_INGRESS_TARGET_PORTS_OVERLAP % ', '.join(str(port) for port in overlap))
+
 @enrichment(EnrichmentStage.FULL)
 def enrich_inventory(cluster: KubernetesCluster) -> None:
     inventory = cluster.inventory
+
+    _verify_target_ports_do_not_overlap(inventory)
 
     for group in cluster.make_group_from_roles(['balancer']).get_accessible_nodes().get_ordered_members_list():
         node = group.get_config()

--- a/kubemarine/haproxy.py
+++ b/kubemarine/haproxy.py
@@ -135,6 +135,16 @@ def get_target_backend(inventory: dict) -> str:
 
     return "envoy"
 
+
+def get_haproxy_target_ports(inventory: dict) -> dict:
+    """
+    Returns http/https ports for HAProxy worker backends based on target_backend.
+    """
+    target_ports = inventory['services']['loadbalancer']['target_ports']
+    if get_target_backend(inventory) == "envoy":
+        return {'http': target_ports['envoy_http'], 'https': target_ports['envoy_https']}
+    return {'http': target_ports['http'], 'https': target_ports['https']}
+
 def install(group: NodeGroup) -> RunnersGroupResult:
     cluster = group.cluster
     defer = group.new_defer()
@@ -202,7 +212,7 @@ def get_config(cluster: KubernetesCluster, node: NodeConfig, maintenance: bool =
     if config_string is not None:
         return config_string
 
-    target_ports: dict = inventory['services']['loadbalancer']['target_ports']
+    target_ports: dict = get_haproxy_target_ports(inventory)
 
     # todo support custom template for maintenance mode
     if not maintenance and config_options.get('config_file'):

--- a/kubemarine/plugins/envoy_gateway.py
+++ b/kubemarine/plugins/envoy_gateway.py
@@ -17,17 +17,10 @@ import os
 import yaml
 from kubemarine.core import utils
 from kubemarine.core.cluster import KubernetesCluster, EnrichmentStage, enrichment
-from kubemarine import plugins, haproxy
+from kubemarine import plugins
 from kubemarine.core.yaml_merger import default_merger
 
 ERROR_CERT_RENEW_NOT_INSTALLED = "Certificates can not be renewed for envoy gateway plugin since it is not installed"
-
-@enrichment(EnrichmentStage.FULL)
-def enrich_inventory(cluster: KubernetesCluster) -> None:    
-    # We override priority from 1 to 2, to make envoy install after nginx if envoy is target_backend.
-    # This is required to make sure nginx frees hostPorts
-    if haproxy.get_target_backend(cluster.inventory) == "envoy":
-        cluster.inventory["plugins"]["envoy-gateway"]["installation"]["priority"] = 2
 
 @enrichment(EnrichmentStage.PROCEDURE, procedures=['cert_renew'])
 def cert_renew_enrichment(cluster: KubernetesCluster) -> None:
@@ -200,14 +193,15 @@ def apply_cr_chart(cluster: KubernetesCluster) -> None:
             "key": base64.b64encode(envoy_plugin["externalGateway"]["certificate"]["key"].encode("utf-8")).decode("ascii"),
         }
 
-    if haproxy.get_target_backend(cluster.inventory) == "envoy":
-        targetPorts = cluster.inventory["services"]["loadbalancer"]["target_ports"]
+    has_balancers = any('balancer' in node['roles'] for node in cluster.inventory['nodes'])
+    if has_balancers and envoy_plugin["externalGateway"]["hostPorts"]["http"] == 0 \
+            and envoy_plugin["externalGateway"]["hostPorts"]["https"] == 0:
+        target_ports = cluster.inventory["services"]["loadbalancer"]["target_ports"]
         helm_plugin_config["values"]["defaultGateways"]["external"]["proxyProtocol"] = True
         helm_plugin_config["values"]["defaultGateways"]["external"]["hostPorts"] = True
-        helm_plugin_config["values"]["defaultGateways"]["external"]["httpHostPort"] = targetPorts["http"]
-        helm_plugin_config["values"]["defaultGateways"]["external"]["httpsHostPort"] = targetPorts["https"]
-    else:
-        # If HAProxy is not used in front of Envoy, then we should not enable proxyProtocol
+        helm_plugin_config["values"]["defaultGateways"]["external"]["httpHostPort"] = target_ports["envoy_http"]
+        helm_plugin_config["values"]["defaultGateways"]["external"]["httpsHostPort"] = target_ports["envoy_https"]
+    elif not has_balancers:
         helm_plugin_config["values"]["defaultGateways"]["external"]["proxyProtocol"] = False
 
     if envoy_plugin["externalGateway"]["hostPorts"]["http"] != 0 \

--- a/kubemarine/plugins/nginx_ingress.py
+++ b/kubemarine/plugins/nginx_ingress.py
@@ -23,7 +23,6 @@ from kubemarine.core.cluster import KubernetesCluster, EnrichmentStage, enrichme
 from kubemarine.core.group import NodeGroup
 from kubemarine.kubernetes import secrets
 from kubemarine.plugins.manifest import Processor, EnrichmentFunction, Manifest, Identity
-from kubemarine import haproxy
 
 ERROR_CERT_RENEW_NOT_INSTALLED = "Certificates can not be renewed for nginx plugin since it is not installed"
 
@@ -55,21 +54,12 @@ def enrich_inventory(cluster: KubernetesCluster) -> None:
         if not inventory["plugins"]["nginx-ingress-controller"]['config_map'].get('proxy-set-headers'):
             inventory["plugins"]["nginx-ingress-controller"]['config_map']['proxy-set-headers'] = 'ingress-nginx/custom-headers'
 
-    # We use sentinel "0" value for nginx hostPorts by default, because our default is dynamic, it depends on LB target backend.
-    # So, if this sentinel "0" value is present for nginx hostPorts (i.e. user did not override it),
-    # then we put our default - if LB target backend is "nginx", then hostPorts are taken from LB "target_ports",
-    # otherwise, we do not use hostPorts for nginx and thus simply delete hostPort with "0" sentinel value   
+    # We use sentinel "0" value for nginx hostPorts by default, because our default is dynamic.
+    # If this sentinel "0" value is present (i.e. user did not override it),
+    # hostPorts are taken from LB target_ports.http/https.
     for port in inventory["plugins"]["nginx-ingress-controller"]["ports"]:
         if port["name"] in ("http", "https") and "hostPort" in port and port["hostPort"] == 0:
-            if haproxy.get_target_backend(cluster.inventory) == "nginx":
-                port["hostPort"] = int(cluster.inventory['services']['loadbalancer']['target_ports'][port["name"]])
-            else:
-                del port["hostPort"]
-    
-    # We override priority from 1 to 2, to make nginx install after envoy if nginx is target_backend.
-    # This is required to make sure envoy frees hostPorts
-    if haproxy.get_target_backend(cluster.inventory) == "nginx":
-        inventory["plugins"]["nginx-ingress-controller"]["installation"]["priority"] = 2
+            port["hostPort"] = int(cluster.inventory['services']['loadbalancer']['target_ports'][port["name"]])
 
     # if user defined resources himself, we should use them as is, instead of merging with our defaults
     raw_controller = cluster.raw_inventory.get("plugins", {}).get("nginx-ingress-controller", {}).get("controller", {})

--- a/kubemarine/procedures/check_iaas.py
+++ b/kubemarine/procedures/check_iaas.py
@@ -662,7 +662,10 @@ def get_ports_connectivity(cluster: KubernetesCluster, proto: str) -> Dict[str, 
     random_user_port = str(random.randint(1024, 65535))
     if proto == 'tcp':
         target_ports = cluster.inventory['services']['loadbalancer']['target_ports']
-        ingress_ports = [str(target_ports['http']), str(target_ports['https'])]
+        ingress_ports = [
+            str(target_ports['http']), str(target_ports['https']), 
+            str(target_ports['envoy_http']), str(target_ports['envoy_https'])
+        ]
         connectivity_ports = {
             'internal': {
                 'input': {

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -451,6 +451,8 @@ services:
     target_ports:
       http: '{% if nodes | select("has_role", "balancer") | first %}20080{% else %}80{% endif %}'
       https: '{% if nodes | select("has_role", "balancer") | first %}20443{% else %}443{% endif %}'
+      envoy_http: '{% if nodes | select("has_role", "balancer") | first %}21080{% else %}80{% endif %}'
+      envoy_https: '{% if nodes | select("has_role", "balancer") | first %}21443{% else %}443{% endif %}'
     keepalived:
       keep_configs_updated: True
       global: {}
@@ -692,7 +694,7 @@ plugins:
     install: true
     installation:
       registry: ghcr.io
-      priority: 1 # will be changed to 2 if LB target_backend is nginx
+      priority: 1
       procedures:
         - python:
             module: plugins/nginx_ingress.py
@@ -770,8 +772,8 @@ plugins:
       certificate:
         cert: ""
         key: ""
-      # HostPorts are enabled by default only if LB target_backend is envoy,
-      # in this case hostPorts will be equal to LB target_ports.
+      # HostPorts are enabled by default when balancer nodes exist,
+      # using services.loadbalancer.target_ports.envoy_http/envoy_https.
       # HostPorts also could be enabled and configured explicitly.
       hostPorts:
         http: 0
@@ -779,7 +781,7 @@ plugins:
     valuesOverride: {}
     crValuesOverride: {}
     installation:
-      priority: 1 # will be changed to 2 if LB target_backend is envoy
+      priority: 1
       procedures:
         - python:
             module: plugins/envoy_gateway.py

--- a/kubemarine/resources/schemas/definitions/services/loadbalancer.json
+++ b/kubemarine/resources/schemas/definitions/services/loadbalancer.json
@@ -89,17 +89,27 @@
     },
     "target_ports": {
       "type": "object",
-      "description": "The section contains the information about http/https ports, which are used in connection from balancers to worker nodes",
+      "description": "HTTP/HTTPS ports on worker nodes. Nginx uses http/https; Envoy uses envoy_http/envoy_https. HAProxy backends use http/https or envoy_http/envoy_https depending on target_backend.",
       "properties": {
         "http": {
           "type": ["string", "integer"],
           "default": 80,
-          "description": "Target http port"
+          "description": "Nginx ingress HTTP hostPort and HAProxy backend when target_backend is nginx"
         },
         "https": {
           "type": ["string", "integer"],
           "default": 443,
-          "description": "Target https port"
+          "description": "Nginx ingress HTTPS hostPort and HAProxy backend when target_backend is nginx"
+        },
+        "envoy_http": {
+          "type": ["string", "integer"],
+          "default": 80,
+          "description": "Envoy Gateway HTTP hostPort and HAProxy backend when target_backend is envoy"
+        },
+        "envoy_https": {
+          "type": ["string", "integer"],
+          "default": 443,
+          "description": "Envoy Gateway HTTPS hostPort and HAProxy backend when target_backend is envoy"
         }
       },
       "additionalProperties": false

--- a/test/unit/test_haproxy.py
+++ b/test/unit/test_haproxy.py
@@ -89,6 +89,35 @@ class TestHaproxyTargetPorts(unittest.TestCase):
         self.assertNotIn(':20080', config)
         self.assertNotIn(':20443', config)
 
+    def test_overlapping_ingress_target_ports_fail_when_both_plugins_installed(self):
+        inventory = demo.generate_inventory(**demo.FULLHA)
+        inventory.setdefault('plugins', {}).setdefault('envoy-gateway', {})['install'] = True
+        inventory.setdefault('services', {}).setdefault('loadbalancer', {})['target_ports'] = {
+            'http': 20080,
+            'https': 20443,
+            'envoy_http': 20080,
+            'envoy_https': 20443,
+        }
+
+        with self.assertRaises(Exception) as cm:
+            demo.new_cluster(inventory)
+
+        self.assertEqual(
+            haproxy.ERROR_INGRESS_TARGET_PORTS_OVERLAP % '20080, 20443',
+            str(cm.exception),
+        )
+
+    def test_overlapping_target_ports_allowed_if_nginx_not_installed(self):
+        inventory = demo.generate_inventory(**demo.FULLHA)
+        inventory.setdefault('plugins', {}).setdefault('nginx-ingress-controller', {})['install'] = False
+        inventory.setdefault('services', {}).setdefault('loadbalancer', {})['target_ports'] = {
+            'http': 20080,
+            'https': 20443,
+            'envoy_http': 20080,
+            'envoy_https': 20443,
+        }
+
+        demo.new_cluster(inventory)
 
 class TestHaproxyInstallation(unittest.TestCase):
 

--- a/test/unit/test_haproxy.py
+++ b/test/unit/test_haproxy.py
@@ -60,6 +60,36 @@ class HAProxyDefaultsEnrichment(unittest.TestCase):
                                      "Invalid exception message")
 
 
+class TestHaproxyTargetPorts(unittest.TestCase):
+
+    def test_get_haproxy_target_ports_for_nginx_backend(self):
+        inventory = demo.generate_inventory(**demo.FULLHA)
+        inventory.setdefault('services', {}).setdefault('loadbalancer', {})['target_backend'] = 'nginx'
+        cluster = demo.new_cluster(inventory)
+        target_ports = haproxy.get_haproxy_target_ports(cluster.inventory)
+        self.assertEqual(20080, int(target_ports['http']))
+        self.assertEqual(20443, int(target_ports['https']))
+
+    def test_get_haproxy_target_ports_for_envoy_backend(self):
+        inventory = demo.generate_inventory(**demo.FULLHA)
+        inventory.setdefault('services', {}).setdefault('loadbalancer', {})['target_backend'] = 'envoy'
+        cluster = demo.new_cluster(inventory)
+        target_ports = haproxy.get_haproxy_target_ports(cluster.inventory)
+        self.assertEqual(21080, int(target_ports['http']))
+        self.assertEqual(21443, int(target_ports['https']))
+
+    def test_haproxy_config_uses_envoy_backend_ports(self):
+        inventory = demo.generate_inventory(**demo.FULLHA)
+        inventory.setdefault('services', {}).setdefault('loadbalancer', {})['target_backend'] = 'envoy'
+        cluster = demo.new_cluster(inventory)
+        balancer_node = cluster.nodes['balancer'].get_first_member()
+        config = haproxy.get_config(cluster, balancer_node.get_config())
+        self.assertIn(':21080', config)
+        self.assertIn(':21443', config)
+        self.assertNotIn(':20080', config)
+        self.assertNotIn(':20443', config)
+
+
 class TestHaproxyInstallation(unittest.TestCase):
 
     def test_haproxy_installation_when_already_installed(self):

--- a/test/unit/test_inventory.py
+++ b/test/unit/test_inventory.py
@@ -318,6 +318,8 @@ class TestInventoryValidation(unittest.TestCase):
         cluster = demo.new_cluster(inventory)
         self.assertEqual(80, int(cluster.inventory['services']['loadbalancer']['target_ports']['http']))
         self.assertEqual(443, int(cluster.inventory['services']['loadbalancer']['target_ports']['https']))
+        self.assertEqual(80, int(cluster.inventory['services']['loadbalancer']['target_ports']['envoy_http']))
+        self.assertEqual(443, int(cluster.inventory['services']['loadbalancer']['target_ports']['envoy_https']))
         self.assertEqual(80, int(next(filter(
             lambda port: port['name'] == 'http',
             cluster.inventory['plugins']['nginx-ingress-controller']['ports']))['hostPort']))
@@ -330,6 +332,8 @@ class TestInventoryValidation(unittest.TestCase):
         cluster = demo.new_cluster(inventory)
         self.assertEqual(20080, int(cluster.inventory['services']['loadbalancer']['target_ports']['http']))
         self.assertEqual(20443, int(cluster.inventory['services']['loadbalancer']['target_ports']['https']))
+        self.assertEqual(21080, int(cluster.inventory['services']['loadbalancer']['target_ports']['envoy_http']))
+        self.assertEqual(21443, int(cluster.inventory['services']['loadbalancer']['target_ports']['envoy_https']))
         self.assertEqual(20080, int(next(filter(
             lambda port: port['name'] == 'http',
             cluster.inventory['plugins']['nginx-ingress-controller']['ports']))['hostPort']))
@@ -342,6 +346,8 @@ class TestInventoryValidation(unittest.TestCase):
         cluster = demo.new_cluster(inventory)
         self.assertEqual(20080, int(cluster.inventory['services']['loadbalancer']['target_ports']['http']))
         self.assertEqual(20443, int(cluster.inventory['services']['loadbalancer']['target_ports']['https']))
+        self.assertEqual(21080, int(cluster.inventory['services']['loadbalancer']['target_ports']['envoy_http']))
+        self.assertEqual(21443, int(cluster.inventory['services']['loadbalancer']['target_ports']['envoy_https']))
         self.assertEqual(20080, int(next(filter(
             lambda port: port['name'] == 'http',
             cluster.inventory['plugins']['nginx-ingress-controller']['ports']))['hostPort']))
@@ -354,6 +360,8 @@ class TestInventoryValidation(unittest.TestCase):
         cluster = demo.new_cluster(inventory)
         self.assertEqual(20080, int(cluster.inventory['services']['loadbalancer']['target_ports']['http']))
         self.assertEqual(20443, int(cluster.inventory['services']['loadbalancer']['target_ports']['https']))
+        self.assertEqual(21080, int(cluster.inventory['services']['loadbalancer']['target_ports']['envoy_http']))
+        self.assertEqual(21443, int(cluster.inventory['services']['loadbalancer']['target_ports']['envoy_https']))
         self.assertEqual(20080, int(next(filter(
             lambda port: port['name'] == 'http',
             cluster.inventory['plugins']['nginx-ingress-controller']['ports']))['hostPort']))
@@ -366,10 +374,23 @@ class TestInventoryValidation(unittest.TestCase):
         cluster = demo.new_cluster(inventory)
         self.assertEqual(80, int(cluster.inventory['services']['loadbalancer']['target_ports']['http']))
         self.assertEqual(443, int(cluster.inventory['services']['loadbalancer']['target_ports']['https']))
+        self.assertEqual(80, int(cluster.inventory['services']['loadbalancer']['target_ports']['envoy_http']))
+        self.assertEqual(443, int(cluster.inventory['services']['loadbalancer']['target_ports']['envoy_https']))
         self.assertEqual(80, int(next(filter(
             lambda port: port['name'] == 'http',
             cluster.inventory['plugins']['nginx-ingress-controller']['ports']))['hostPort']))
         self.assertEqual(443, int(next(filter(
+            lambda port: port['name'] == 'https',
+            cluster.inventory['plugins']['nginx-ingress-controller']['ports']))['hostPort']))
+
+    def test_nginx_host_ports_when_envoy_is_target_backend(self):
+        inventory = demo.generate_inventory(**demo.FULLHA)
+        inventory.setdefault('services', {}).setdefault('loadbalancer', {})['target_backend'] = 'envoy'
+        cluster = demo.new_cluster(inventory)
+        self.assertEqual(20080, int(next(filter(
+            lambda port: port['name'] == 'http',
+            cluster.inventory['plugins']['nginx-ingress-controller']['ports']))['hostPort']))
+        self.assertEqual(20443, int(next(filter(
             lambda port: port['name'] == 'https',
             cluster.inventory['plugins']['nginx-ingress-controller']['ports']))['hostPort']))
 


### PR DESCRIPTION
### Description
Currently KubeMarine supports switching between "nginx" and "envoy" on "services.loadbalancer.target_backend" cluster.yaml property, however, actual change happens not in HAProxy configuration, but in nginx/envoy configuration - they move hostPorts 20080/20443 between each other to determine who will be the target backend. This causes problems, since we want to be able to switch between nginx/envoy quickly and with minimal impact (and probably do it multiple times in both direction). Redeploying plugins is too impacting in this case. Thus, we need to implement this switching through HAProxy re-configuration, swapping between ports 20080/20443 (nginx) and 21080/21443 (envoy).


### Solution
Describe solution. List all changes that you made during implementation.
* Added new fields `envoy_http` and `envoy_https` to cluster.yaml section `services.loadbalancer.target_ports` with default values 21080 and 21443. These are used by envoy plugin as hostPorts, similar to nginx 20080/20443 ports.
  * In all-in-one and similar schemas the default is 80/443, same as nginx. It means that if user enabled both envoy and nginx in such schema, he also should reconfigure ports appropriately so that envoy/nginx do not bind same hostPorts.
* `target_backend` is now used by HAProxy configuration to determine which pair of ports (nginx 20080/20443 or envoy 21080/21443) to use as backend
* Updated docs/tests and check_iaas procedure accordingly

### How to apply
* to update previously installed Envoy to use ports 21080/21443, run install procedure task `deploy.plugins`

### Test Cases

1. Install cluster without specifying `services.loadbalancer` `target_backend` and `target_ports`, with both ingress-nginx and envoy-gateway plugins enabled (do not provide custom ports configuration in cluster.yaml)
2. Go to the load balancer IP and make sure you get 404 response from nginx `curl -kv https://$LB_IP`
3. Now, set cluster.yaml `services.loadbalancer.target_backend` to `envoy` and run install task `deploy.loadbalancer.haproxy.configure` to reconfigure HAProxy specifically
4. Go to the load balancer IP again and make sure you again get 404 response, but this time not from nginx, but from envoy `curl -kv https://$LB_IP`

### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no breaking changes, or migration patch is provided
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

