### PR TITLE
[CPCAP-8532] Fix check_paas plugins health check

### DIFF
--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1368,7 +1368,7 @@ def default_services_health_status(cluster: KubernetesCluster) -> None:
                     for service in services:
                         deployment = Deployment(cluster, name=service, namespace=namespace)
                         deployment.reload(control_plane=first_control_plane, suppress_exceptions=True)
-                        if not daemon_set.is_actual_and_ready():
+                        if not deployment.is_actual_and_ready():
                             not_ready_entities.append(service)
         if len(not_ready_entities) == 0:
             tc.success(results='valid')

--- a/kubemarine/procedures/check_paas.py
+++ b/kubemarine/procedures/check_paas.py
@@ -1341,7 +1341,7 @@ def default_services_health_status(cluster: KubernetesCluster) -> None:
                 if calico.is_typha_enabled(cluster.inventory):
                     entities_to_check["kube-system"]["Deployment"].append("calico-typha")
 
-            if plugin == 'ingress-nginx-controller':
+            if plugin == 'nginx-ingress-controller':
                 entities_to_check['ingress-nginx'] = {"DaemonSet": ["ingress-nginx-controller"]}
             if plugin == 'envoy-gateway':
                 entities_to_check['gateway-system'] = {


### PR DESCRIPTION
### Description
There are two bugs with `check_paas` check `default_services.health_status`:
- nginx-ingress plugin is not checked due to incorrect plugin name
- if some daemonset is unhealthy, all further deployments are also treated as unhealthy


### Solution
* fixed `nginx-ingress-controller` plugin name
* fixed deployments health check to verify deployment status (instead of daemonset)

### Test Cases
**TestCase 1**
1. Install cluster
2. Run `check_paas --tasks "default_services.health_status"`, make sure it succeeds
3. Break ingress-nginx image on cluster (edit DaemonSet to use non-existent image)
4. Run `check_paas --tasks "default_services.health_status"` and verify result

Results:

| Before | After |
| ------ | ------ |
| no error at all | error for `ingress-nginx-controller` specifically |

**TestCase 2**
1. Install cluster
2. Run `check_paas --tasks "default_services.health_status"`, make sure it succeeds
3. Break envoy-external-gateway on cluster. To do this, edit envoy proxy image `kubectl --kubeconfig kubeconfig edit envoyproxy -n gateway-system external`, for example see "-broken" suffix
    ```
    spec:
      provider:
        kubernetes:
          envoyDaemonSet:
            container:
              image: registry:123/envoyproxy/envoy:distroless-v1.37.0-broken
    ```
6. Run `check_paas --tasks "default_services.health_status"` and verify result

Results:

| Before | After |
| ------ | ------ |
| error for `envoy-external-gateway` and other unrelated plugins | error for `envoy-external-gateway` only |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no breaking changes, or migration patch is provided
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts