### PR TITLE
[CPCAP-12250] feature: etcd defaults

### DIFF
--- a/docs/public/Installation.md
+++ b/docs/public/Installation.md
@@ -1142,6 +1142,9 @@ By default, the installer uses the following parameters:
 | controllerManager.extraArgs.profiling                   | `false`                                                  |                                                                                        |
 | controllerManager.extraArgs.terminated-pod-gc-threshold | `1000`                                                   |                                                                                        |
 | featureGates.ControlPlaneKubeletLocalMode               | `true`                                                   | Provided for Kubernetes versions 1.33, 1.34 and 1.35                                               |
+| etcd.local.extraArgs.auto-compaction-mode               | `periodic`                                               |
+| etcd.local.extraArgs.auto-compaction-retention          | `1h`                               |                     |
+| etcd.local.extraArgs.snapshot-count                     | `100000`                           |                     |
 
 The following is an example of kubeadm defaults override:
 

--- a/docs/public/Installation.md
+++ b/docs/public/Installation.md
@@ -1145,6 +1145,8 @@ By default, the installer uses the following parameters:
 | etcd.local.extraArgs.auto-compaction-mode               | `periodic`                                               |
 | etcd.local.extraArgs.auto-compaction-retention          | `1h`                               |                     |
 | etcd.local.extraArgs.snapshot-count                     | `100000`                           |                     |
+| etcd.local.extraArgs.experimental-watch-progress-notify-interval | `5m`                           | Provided for Kubernetes versions up to v1.33 |
+| etcd.local.extraArgs.watch-progress-notify-interval              | `5m`                           | Provided for Kubernetes versions from v1.34  |
 
 The following is an example of kubeadm defaults override:
 

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -48,6 +48,7 @@ ERROR_UPGRADE_UNEXPECTED_PROPERTY='Unexpected %s properties in the procedure inv
 
 ERROR_AMBIGUOUS_CONNTRACK_MAX = "Detected ambiguous 'net.netfilter.nf_conntrack_max' value: {values}"
 
+WATCH_PROGRESS_NOTIFY_ARG_VERSION = "1.34"
 
 @enrichment(EnrichmentStage.PROCEDURE, procedures=['upgrade'])
 def enrich_upgrade_inventory(cluster: KubernetesCluster) -> None:
@@ -188,6 +189,22 @@ def enrich_inventory(cluster: KubernetesCluster) -> None:
     inventory["services"]["kubeadm_flags"]["ignorePreflightErrors"] = ",".join(set(preflight_errors))
 
     enrich_kube_proxy(cluster)
+    _enrich_etcd_watch_progress(cluster)
+
+
+def _enrich_etcd_watch_progress(cluster: KubernetesCluster) -> None:
+    kubernetes_version = get_kubernetes_version(cluster.inventory)
+    etcd_extra_args = cluster.inventory['services']['kubeadm']['etcd']['local']['extraArgs']
+
+    if utils.version_key(kubernetes_version)[0:2] >= utils.minor_version_key(f"v{WATCH_PROGRESS_NOTIFY_ARG_VERSION}"):
+        arg_name = "watch-progress-notify-interval"
+    else:
+        arg_name = "experimental-watch-progress-notify-interval"
+
+    # Only set the default if the user has not explicitly provided either arg
+    if "watch-progress-notify-interval" not in etcd_extra_args \
+            and "experimental-watch-progress-notify-interval" not in etcd_extra_args:
+        etcd_extra_args[arg_name] = "5m"
 
 
 @enrichment(EnrichmentStage.FULL)

--- a/kubemarine/kubernetes/__init__.py
+++ b/kubemarine/kubernetes/__init__.py
@@ -201,7 +201,7 @@ def _enrich_etcd_watch_progress(cluster: KubernetesCluster) -> None:
     else:
         arg_name = "experimental-watch-progress-notify-interval"
 
-    # Only set the default if the user has not explicitly provided either arg
+    # Set the default if the option has not explicitly provided
     if "watch-progress-notify-interval" not in etcd_extra_args \
             and "experimental-watch-progress-notify-interval" not in etcd_extra_args:
         etcd_extra_args[arg_name] = "5m"

--- a/kubemarine/kubernetes/components.py
+++ b/kubemarine/kubernetes/components.py
@@ -830,7 +830,7 @@ def compare_manifests(cluster: KubernetesCluster, *, with_inventory: bool) \
                 pattern = r"- --snapshot-count=\d+"
                 snapshot_count_st = re.search(pattern, stored)
                 snapshot_count_gen = re.search(pattern, generated)
-                if snapshot_count_st.group() == snapshot_count_gen.group():
+                if snapshot_count_st.group(0) == snapshot_count_gen.group(0):
                     stored = re.sub(pattern, "", stored, count=1)
                     generated = re.sub(pattern, "", generated, count=1)
                 stored = _filter_etcd_initial_cluster_args(stored)

--- a/kubemarine/kubernetes/components.py
+++ b/kubemarine/kubernetes/components.py
@@ -823,6 +823,16 @@ def compare_manifests(cluster: KubernetesCluster, *, with_inventory: bool) \
             stored = stored_manifest_results[i].stdout
             generated = generated_manifest_results[i].stdout
             if component == 'etcd':
+                # In some cases kubeadm puts ETCD options in non alphabetical order
+                # if `snapshot-count` options in stored version and generated are equal
+                # they should deleted to the following matching
+                # Watching the first overlap only
+                pattern = r"- --snapshot-count=\d+"
+                snapshot_count_st = re.search(pattern, stored)
+                snapshot_count_gen = re.search(pattern, generated)
+                if snapshot_count_st.group() == snapshot_count_gen.group():
+                    stored = re.sub(pattern, "", stored, count=1)
+                    generated = re.sub(pattern, "", generated, count=1)
                 stored = _filter_etcd_initial_cluster_args(stored)
                 generated = _filter_etcd_initial_cluster_args(generated)
 

--- a/kubemarine/kubernetes/components.py
+++ b/kubemarine/kubernetes/components.py
@@ -830,9 +830,18 @@ def compare_manifests(cluster: KubernetesCluster, *, with_inventory: bool) \
                 pattern = r"- --snapshot-count=\d+"
                 snapshot_count_st = re.search(pattern, stored)
                 snapshot_count_gen = re.search(pattern, generated)
-                if snapshot_count_st.group(0) == snapshot_count_gen.group(0):
-                    stored = re.sub(pattern, "", stored, count=1)
-                    generated = re.sub(pattern, "", generated, count=1)
+                if snapshot_count_st:
+                    result_st = snapshot_count_st.group(0)
+                else:
+                    result_st = ""
+                if snapshot_count_gen:
+                    result_gen = snapshot_count_gen.group(0)
+                else:
+                    result_gen = ""
+                if result_st and result_gen:
+                    if result_st == result_gen:
+                        stored = re.sub(pattern, "", stored, count=1)
+                        generated = re.sub(pattern, "", generated, count=1)
                 stored = _filter_etcd_initial_cluster_args(stored)
                 generated = _filter_etcd_initial_cluster_args(generated)
 

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -64,7 +64,10 @@ class _EtcdReconfigurationAction(Action):
                 cluster.log.info(
                     "etcd watch-progress-notify-interval is already configured on the cluster, skipping.")
 
-            options_dict: Dict[str, str] = {"auto-compaction-mode": "periodic", "auto-compaction-retention": "1h", "snapshot-count": "100000"}
+            options_dict: Dict[str, str] = {
+                    "auto-compaction-mode": "periodic",
+                    "auto-compaction-retention": "1h",
+                    "snapshot-count": "100000"}
             for name, value in options_dict.items():
                 if name not in existing_names:
                     etcd_local["extraArgs"].append({"name": name, "value": value})

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -19,11 +19,99 @@ and relate to the current Kubemarine version.
 The whole directory is automatically cleared and reset after new version of Kubemarine is released.
 """
 
+from textwrap import dedent
 from typing import List
 
-from kubemarine.core.patch import Patch
+from kubemarine.core.action import Action
+from kubemarine.core.patch import Patch, RegularPatch
+from kubemarine.core.resources import DynamicResources
+from kubemarine.core import utils
+from kubemarine.kubernetes import components, get_kubernetes_version
+
+_NEW_ARG = "watch-progress-notify-interval"
+_OLD_ARG = "experimental-watch-progress-notify-interval"
+_RENAME_VERSION = "1.34"
+
+class _EtcdReconfigurationAction(Action):
+    def __init__(self) -> None:
+        super().__init__("Add etcd watch-progress-notify-interval")
+
+    def run(self, res: DynamicResources) -> None:
+        cluster = res.cluster()
+        kubernetes_version = get_kubernetes_version(cluster.inventory)
+
+        if utils.version_key(kubernetes_version)[0:2] >= utils.minor_version_key(_RENAME_VERSION):
+            target_arg = _NEW_ARG
+            stale_arg = _OLD_ARG
+        else:
+            target_arg = _OLD_ARG
+            stale_arg = _NEW_ARG
+
+        def edit_etcd_args(cluster_config: dict) -> dict:
+            # cluster_config is the live ClusterConfiguration from the kubeadm-config ConfigMap.
+            etcd_local: dict = (cluster_config
+                                .setdefault("etcd", {})
+                                .setdefault("local", {}))
+            etcd_args = etcd_local.setdefault("extraArgs", [])
+        
+            existing_names = {entry["name"] for entry in etcd_args}
+    
+            # Skip if either variant is already present on the live cluster
+            if _NEW_ARG not in existing_names and _OLD_ARG not in existing_names:
+                # Remove stale arg (e.g. after k8s upgrade without re-running this patch)
+                etcd_local["extraArgs"] = [e for e in etcd_args if e["name"] != stale_arg]
+                etcd_local["extraArgs"].append({"name": target_arg, "value": "5m"})
+            else:
+                cluster.log.info(
+                    "etcd watch-progress-notify-interval is already configured on the cluster, skipping.")
+
+            if "auto-compaction-mode" not in existing_names:
+                etcd_local["extraArgs"].append({"name": "auto-compaction-mode", "value": "periodic"})
+            else:
+                cluster.log.info(
+                    "etcd auto-compaction-mode is already configured on the cluster, skipping.")
+
+            if "auto-compaction-retention" not in existing_names:
+                etcd_local["extraArgs"].append({"name": "auto-compaction-retention", "value": "1h"})
+            else:
+                cluster.log.info(
+                    "etcd auto-compaction-retention is already configured on the cluster, skipping.")
+
+            if "snapshot-count" not in existing_names:
+                etcd_local["extraArgs"].append({"name": "snapshot-count", "value": "100000"})
+            else:
+                cluster.log.info(
+                    "etcd snapshot-count is already configured on the cluster, skipping.")
+
+            return cluster_config
+
+        control_plane = cluster.nodes['control-plane']
+        control_plane.call(
+            components.reconfigure_components,
+            components=['etcd'],
+            edit_functions={'kubeadm-config': edit_etcd_args},
+        )
+
+
+class EtcdReconfigurationPatch(RegularPatch):
+    def __init__(self) -> None:
+        super().__init__("etcd_reconfiguration")
+
+    @property
+    def action(self) -> Action:
+        return _EtcdReconfigurationAction()
+
+    @property
+    def description(self) -> str:
+        return dedent("""\
+            Add watch-progress-notify-interval (or its experimental predecessor) to etcd extraArgs.
+            For Kubernetes >= 1.34: sets --watch-progress-notify-interval=5m
+            For Kubernetes <= 1.33: sets --experimental-watch-progress-notify-interval=5m
+            Skipped if either arg is already explicitly set in the inventory.
+            """.rstrip())
 
 patches: List[Patch] = [
+    EtcdReconfigurationPatch(),
 ]
 """
 List of patches that is sorted according to the Patch.priority() before execution.

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -20,7 +20,7 @@ The whole directory is automatically cleared and reset after new version of Kube
 """
 
 from textwrap import dedent
-from typing import List
+from typing import List, Dict
 
 from kubemarine.core.action import Action
 from kubemarine.core.patch import Patch, RegularPatch
@@ -56,7 +56,7 @@ class _EtcdReconfigurationAction(Action):
         
             existing_names = {entry["name"] for entry in etcd_args}
     
-            # Check if the option must be set
+            # Check if the options must be set
             if _NEW_ARG not in existing_names and _OLD_ARG not in existing_names:
                 etcd_local["extraArgs"] = [e for e in etcd_args if e["name"] != stale_arg]
                 etcd_local["extraArgs"].append({"name": target_arg, "value": "5m"})
@@ -64,23 +64,13 @@ class _EtcdReconfigurationAction(Action):
                 cluster.log.info(
                     "etcd watch-progress-notify-interval is already configured on the cluster, skipping.")
 
-            if "auto-compaction-mode" not in existing_names:
-                etcd_local["extraArgs"].append({"name": "auto-compaction-mode", "value": "periodic"})
-            else:
-                cluster.log.info(
-                    "etcd auto-compaction-mode is already configured on the cluster, skipping.")
-
-            if "auto-compaction-retention" not in existing_names:
-                etcd_local["extraArgs"].append({"name": "auto-compaction-retention", "value": "1h"})
-            else:
-                cluster.log.info(
-                    "etcd auto-compaction-retention is already configured on the cluster, skipping.")
-
-            if "snapshot-count" not in existing_names:
-                etcd_local["extraArgs"].append({"name": "snapshot-count", "value": "100000"})
-            else:
-                cluster.log.info(
-                    "etcd snapshot-count is already configured on the cluster, skipping.")
+            options_dict: Dict[str, str] = {"auto-compaction-mode": "periodic", "auto-compaction-retention": "1h", "snapshot-count": "100000"}
+            for name, value in options_dict.items():
+                if name not in existing_names:
+                    etcd_local["extraArgs"].append({"name": name, "value": value})
+                else:
+                    cluster.log.info(
+                        f"etcd {name} is already configured on the cluster, skipping.")
 
             return cluster_config
 

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -34,7 +34,7 @@ _RENAME_VERSION = "1.34"
 
 class _EtcdReconfigurationAction(Action):
     def __init__(self) -> None:
-        super().__init__("Add etcd watch-progress-notify-interval")
+        super().__init__("Add default etcd options")
 
     def run(self, res: DynamicResources) -> None:
         cluster = res.cluster()
@@ -96,10 +96,11 @@ class EtcdReconfigurationPatch(RegularPatch):
     @property
     def description(self) -> str:
         return dedent("""\
-            Add watch-progress-notify-interval (or its experimental predecessor) to etcd extraArgs.
+            Add auto-compaction-mode, auto-compaction-retention, snapshot-count, and
+            watch-progress-notify-interval (or its experimental predecessor) to etcd extraArgs.
             For Kubernetes >= 1.34: sets --watch-progress-notify-interval=5m
             For Kubernetes <= 1.33: sets --experimental-watch-progress-notify-interval=5m
-            Skipped if either arg is already explicitly set in the inventory.
+            The existing args in the inventory are skipped.
             """.rstrip())
 
 patches: List[Patch] = [

--- a/kubemarine/patches/__init__.py
+++ b/kubemarine/patches/__init__.py
@@ -48,7 +48,7 @@ class _EtcdReconfigurationAction(Action):
             stale_arg = _NEW_ARG
 
         def edit_etcd_args(cluster_config: dict) -> dict:
-            # cluster_config is the live ClusterConfiguration from the kubeadm-config ConfigMap.
+            # Get the config from the kubeadm-config ConfigMap.
             etcd_local: dict = (cluster_config
                                 .setdefault("etcd", {})
                                 .setdefault("local", {}))
@@ -56,9 +56,8 @@ class _EtcdReconfigurationAction(Action):
         
             existing_names = {entry["name"] for entry in etcd_args}
     
-            # Skip if either variant is already present on the live cluster
+            # Check if the option must be set
             if _NEW_ARG not in existing_names and _OLD_ARG not in existing_names:
-                # Remove stale arg (e.g. after k8s upgrade without re-running this patch)
                 etcd_local["extraArgs"] = [e for e in etcd_args if e["name"] != stale_arg]
                 etcd_local["extraArgs"].append({"name": target_arg, "value": "5m"})
             else:

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -125,13 +125,11 @@ def kubernetes_upgrade(cluster: KubernetesCluster) -> None:
         # experimental-watch-progress-notify-interval was renamed to watch-progress-notify-interval in k8s 1.34.
         def rename_etcd_watch_progress_arg(cluster_config: dict) -> dict:
             etcd_args = cluster_config.get("etcd", {}).get("local", {}).get("extraArgs", [])
-            cluster.log.info(f"ARGS1: {etcd_args}")
             old_arg = "experimental-watch-progress-notify-interval"
             new_arg = "watch-progress-notify-interval"
             for etcd_arg_item in etcd_args:
                 if etcd_arg_item['name'] == old_arg:
                     etcd_arg_item['name'] = new_arg
-            cluster.log.info(f"ARGS2: {etcd_args}")
             return cluster_config
 
         first_control_plane = cluster.nodes['control-plane'].get_first_member()

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -116,25 +116,29 @@ def kubernetes_upgrade(cluster: KubernetesCluster) -> None:
         preconfigure_components.append('kube-apiserver')
         preconfigure_functions['kubeadm-config'] = apply_kubelet_feature_gates
 
-    if utils.version_key(initial_kubernetes_version)[0:2] < utils.minor_version_key("v1.34") \
-            and utils.version_key(upgrade_version)[0:2] >= utils.minor_version_key("v1.34"):
-
-        # experimental-watch-progress-notify-interval was renamed to watch-progress-notify-interval in k8s 1.34.
-        # See kubernetes.enrich_inventory() / _enrich_etcd_watch_progress()
-        def rename_etcd_watch_progress_arg(cluster_config: dict) -> dict:
-            etcd_args = cluster_config.get("etcd", {}).get("local", {}).get("extraArgs", {})
-            old_arg = "experimental-watch-progress-notify-interval"
-            new_arg = "watch-progress-notify-interval"
-            if old_arg in etcd_args and new_arg not in etcd_args:
-                etcd_args[new_arg] = etcd_args.pop(old_arg)
-            return cluster_config
-
-        preconfigure_components.append('etcd')
-        preconfigure_functions['kubeadm-config'] = rename_etcd_watch_progress_arg
-
     if preconfigure_components:
         upgrade_group.call(kubernetes.components.reconfigure_components,
                            components=preconfigure_components, edit_functions=preconfigure_functions)
+
+    if utils.version_key(initial_kubernetes_version)[0:2] < utils.minor_version_key("v1.34") \
+            and utils.version_key(upgrade_version)[0:2] >= utils.minor_version_key("v1.34"):
+        # experimental-watch-progress-notify-interval was renamed to watch-progress-notify-interval in k8s 1.34.
+        def rename_etcd_watch_progress_arg(cluster_config: dict) -> dict:
+            etcd_args = cluster_config.get("etcd", {}).get("local", {}).get("extraArgs", [])
+            cluster.log.info(f"ARGS1: {etcd_args}")
+            old_arg = "experimental-watch-progress-notify-interval"
+            new_arg = "watch-progress-notify-interval"
+            for etcd_arg_item in etcd_args:
+                if etcd_arg_item['name'] == old_arg:
+                    etcd_arg_item['name'] = new_arg
+            cluster.log.info(f"ARGS2: {etcd_args}")
+            return cluster_config
+
+        first_control_plane = cluster.nodes['control-plane'].get_first_member()
+        kubeadm_config = kubernetes.components.KubeadmConfig(cluster)
+        if not kubeadm_config.is_loaded('kubeadm-config'):
+            kubeadm_config.load('kubeadm-config', first_control_plane, rename_etcd_watch_progress_arg)
+        kubeadm_config.apply('kubeadm-config', first_control_plane)
 
     drain_timeout = cluster.procedure_inventory.get('drain_timeout')
     grace_period = cluster.procedure_inventory.get('grace_period')

--- a/kubemarine/procedures/upgrade.py
+++ b/kubemarine/procedures/upgrade.py
@@ -116,6 +116,22 @@ def kubernetes_upgrade(cluster: KubernetesCluster) -> None:
         preconfigure_components.append('kube-apiserver')
         preconfigure_functions['kubeadm-config'] = apply_kubelet_feature_gates
 
+    if utils.version_key(initial_kubernetes_version)[0:2] < utils.minor_version_key("v1.34") \
+            and utils.version_key(upgrade_version)[0:2] >= utils.minor_version_key("v1.34"):
+
+        # experimental-watch-progress-notify-interval was renamed to watch-progress-notify-interval in k8s 1.34.
+        # See kubernetes.enrich_inventory() / _enrich_etcd_watch_progress()
+        def rename_etcd_watch_progress_arg(cluster_config: dict) -> dict:
+            etcd_args = cluster_config.get("etcd", {}).get("local", {}).get("extraArgs", {})
+            old_arg = "experimental-watch-progress-notify-interval"
+            new_arg = "watch-progress-notify-interval"
+            if old_arg in etcd_args and new_arg not in etcd_args:
+                etcd_args[new_arg] = etcd_args.pop(old_arg)
+            return cluster_config
+
+        preconfigure_components.append('etcd')
+        preconfigure_functions['kubeadm-config'] = rename_etcd_watch_progress_arg
+
     if preconfigure_components:
         upgrade_group.call(kubernetes.components.reconfigure_components,
                            components=preconfigure_components, edit_functions=preconfigure_functions)

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -89,7 +89,10 @@ services:
       extraVolumes: []
     etcd:
       local:
-        extraArgs: {}
+        extraArgs:
+          auto-compaction-mode: "periodic"
+          auto-compaction-retention: "1h"
+          watch-progress-notify-interval: "5m"
   kubeadm_patches:
     # bind-address flag for apiServer is set in the code
     apiServer: []

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -92,6 +92,7 @@ services:
         extraArgs:
           auto-compaction-mode: "periodic"
           auto-compaction-retention: "1h"
+          snapshot-count: 100000
 
   kubeadm_patches:
     # bind-address flag for apiServer is set in the code

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -92,7 +92,9 @@ services:
         extraArgs:
           auto-compaction-mode: "periodic"
           auto-compaction-retention: "1h"
-          watch-progress-notify-interval: "5m"
+          # TODO: implement watch-progress-notify-interval/experimental-watch-progress-notify-interval choice by the ETCD verssion
+          experimental-watch-progress-notify-interval: "5m"
+
   kubeadm_patches:
     # bind-address flag for apiServer is set in the code
     apiServer: []

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -92,8 +92,6 @@ services:
         extraArgs:
           auto-compaction-mode: "periodic"
           auto-compaction-retention: "1h"
-          # TODO: implement watch-progress-notify-interval/experimental-watch-progress-notify-interval choice by the ETCD verssion
-          experimental-watch-progress-notify-interval: "5m"
 
   kubeadm_patches:
     # bind-address flag for apiServer is set in the code

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -92,8 +92,7 @@ services:
         extraArgs:
           auto-compaction-mode: "periodic"
           auto-compaction-retention: "1h"
-          snapshot-count: 100000
-
+          snapshot-count: "100000"
   kubeadm_patches:
     # bind-address flag for apiServer is set in the code
     apiServer: []


### PR DESCRIPTION
### Description
* Change ETCD default options to reduce disk write rate

### Solution
* Add the following options as defaults:
```
--auto-compaction-mode=periodic
--auto-compaction-retention=1h
--snapshot-count=100000
```
* Add `--watch-progress-notify-interval=5m` option as default for k8s v1.34 and higher
* Add `--experimental-watch-progress-notify-interval=5m` option as default for k8s v1.33 and lower
* Add patch to add the options above to the existing cluster
* Change `experimental-watch-progress-notify-interval` to `watch-progress-notify-interval` in kubeadm_config before the upgrade from v1.33 to v1.34

### How to apply
* Run `kubemarine migrate_kubemarine` procedure


### Test Cases


**TestCase 1**

Check if the installation procedure works

Test Configuration:

- Hardware: 2CPU/4GB
- OS: Ubuntu 24.04
- Inventory: AllinOne

Steps:

1. Prepare cluster.yaml without `services.kubeadm.etcd` section
2. Run `kubemarine install` 

Results:

| Before | After |
| ------ | ------ |
| default options are in etcd.yaml manifest | target options are in the etcd.yaml manifest |

**TestCase 2**

Check if the migration procedure works

Test Configuration:

- Hardware: 2CPU/4GB
- OS: Ubuntu 24.04
- Inventory: AllinOne

Steps:

1. Get the k8s cluster that has been installed previously
2. Run `kubemarine migrate_kubemarine` 

Results:

| Before | After |
| ------ | ------ |
| not applicable | target options are in the etcd.yaml manifest |

**TestCase 3**

Check if the upgrade from v1.33 to v1.34 procedure works

Test Configuration:

- Hardware: 2CPU/4GB
- OS: Ubuntu 24.04
- Inventory: AllinOne

Steps:

1. Install k8s v1.33.6
3. Run `kubemarine upgrade` procedure to v1.34.2 

Results:

| Before | After |
| ------ | ------ |
| success | success |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no breaking changes, or migration patch is provided
- [x] Integration CI passed
- [x] There is no merge conflicts