### PR TITLE
[CPCAP-12214] Preserve X-Request-ID on Envoy

### DIFF
--- a/kubemarine/plugins/envoy_gateway.py
+++ b/kubemarine/plugins/envoy_gateway.py
@@ -177,6 +177,7 @@ def apply_cr_chart(cluster: KubernetesCluster) -> None:
                                     }
                                 ],
                             },
+                            "requestID": "PreserveOrGenerate",
                         },
                     },
                 },


### PR DESCRIPTION
### Description
By default Envoy Gateway generates new RequestID for each request, without preserving existing RequestID. This does not align with nginx behavior and causes problems with requests tracing

### Solution
* Added option to ClientTrafficPolicy to preserve or generate X-Request-ID

### Test Cases

**TestCase 1**

Steps:
1. Deploy Envoy Gateway plugin and use it as `target_backend`
2. Install httpbin application and expose it via HTTPRoute
    ```
    apiVersion: gateway.networking.k8s.io/v1
    kind: HTTPRoute
    metadata:
      name: httpbin-generated
      namespace: converter-test
    spec:
      hostnames:
        - httpbin.example.com
      parentRefs:
        - name: default-external-gateway
          namespace: gateway-system
      rules:
        - backendRefs:
            - name: httpbin
              port: 8080
          matches:
            - path:
                type: PathPrefix
                value: /
          timeouts:
            request: 0s
    ```
3. `curl` httpbin application passing custom X-Request-ID
    ```
    curl https://$LB_IP:443/headers  -kv -H "host: httpbin.example.com" -H "X-Request-Id: 123"
    ```
4. Verify `X-Request-Id` in response headers

Results:

| Before | After |
| ------ | ------ |
| New "X-Request-Id" is generated each time | Passed `123` "X-Request-Id" is returned |


### Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no breaking changes, or migration patch is provided
- [x] Integration CI passed
- [x] Unit tests. If Yes list of new/changed tests with brief description
- [x] There is no merge conflicts

