### PR TITLE
[CPCAP-14361] Increase Envoy Gateway expect timeout

### DIFF
--- a/kubemarine/__main__.py
+++ b/kubemarine/__main__.py
@@ -50,8 +50,8 @@ for ir in ruamel.yaml.resolver.implicit_resolvers:
     if (1, 1) in ir[0] and 'tag:yaml.org,2002:float' in ir[1]:
         float_patched_resolver = (ir[1], ir[2], ir[3])
         # Globally change behaviour of yaml.safe_load and yaml.dump
-        yaml.Dumper.add_implicit_resolver(*float_patched_resolver)  # type: ignore[no-untyped-call]
-        yaml.SafeLoader.add_implicit_resolver(*float_patched_resolver)  # type: ignore[no-untyped-call]
+        yaml.Dumper.add_implicit_resolver(*float_patched_resolver)  # type: ignore[no-untyped-call, unused-ignore]
+        yaml.SafeLoader.add_implicit_resolver(*float_patched_resolver)  # type: ignore[no-untyped-call, unused-ignore]
         break
 
 

--- a/kubemarine/resources/configurations/defaults.yaml
+++ b/kubemarine/resources/configurations/defaults.yaml
@@ -802,6 +802,8 @@ plugins:
             method: apply_cr_chart
         - expect:
             daemonsets:
+              retries: 150
+              list:
               - name: 'envoy-external-gateway'
                 namespace: '{{ plugins["envoy-gateway"].namespace }}'
             pods:


### PR DESCRIPTION
### Description
Sometimes Envoy Gateway pods termination could take a lot of time and standard daemonset timeout (~220s) is not enough. 

The reason for such long termination could be that envoy shutdown-manager container is not working properly due to readyOnlyFilesystem
```
1.7878946969850316e+09  info    shutdown-manager      envoy/shutdown_manager.go:244    total downstream connections: 1
1.7878946979873388e+09  info    shutdown-manager      envoy/shutdown_manager.go:244    total downstream connections: 1
1.787894697987368e+09   info    shutdown-manager      envoy/shutdown_manager.go:154    drain sequence timeout exceeded
1.7878946979873958e+09  error   shutdown-manager      envoy/shutdown_manager.go:166    error creating shutdown ready file     {"error": "open /tmp/shutdown-ready: read-only file system"}
1.787894698010273e+09   info    shutdown-manager      envoy/shutdown_manager.go:67     received terminated
```

Shutdown-manager fix should be implemented separately.

### Solution
* Increased timeout (via retries) to ~750s as used in other places

### Test Cases

1. Install KubeMarine with Envoy Gateway as HAProxy backend
2. Install httpbin application and create simple HTTPRoute for it
3. To reproduce the issue, it is required to simulate long-running connection. You can do it using below command
    ```
    curl 'https://$LB_IP:443/sse?duration=3000s&count=3000' -kv -H "Host: httpbin.example.com"
    ```
4. To reproduce the issue, it is also required to redeploy Envoy Gateway with new image. You can do it using below cluster.yaml configuration
    ```
    plugins:
      envoy-gateway:
        crValuesOverride:
          global:
            images:
              envoy:
                # default image version is v1.38.1, to reproduce multiple time switch between 1.38.1 and 1.38.0
                image: $REGISTRY/envoyproxy/envoy:distroless-v1.38.0
    ```
5. Run `install` procedure `deploy.plugins` task. External gateway pods should start terminating.
6. On previous KubeMarine version task fails with timeout, on new version increased timeout should be enough
