### PR TITLE
Add Rocky Linux 10.2 support

### DIFF
--- a/docs/public/Installation.md
+++ b/docs/public/Installation.md
@@ -171,7 +171,7 @@ For cluster machines, ensure the following requirements are met:
   * CentOS Stream 9
   * RHEL 8.4, 8.6, 8.7, 8.8, 8.9, 8.10, 9.2, 9.3, 9.4
   * Oracle Linux 8.4, 9.2
-  * RockyLinux 8.6, 8.7, 8.8, 9.2, 9.3, 9.4, 9.5, 9.6, 10.1
+  * RockyLinux 8.6, 8.7, 8.8, 9.2, 9.3, 9.4, 9.5, 9.6, 10.1, 10.2
   * Ubuntu 22.04.1, 24.04.1, 26.04
  
 **Note**: Ubuntu 20.04 is not supported for Kubernetes 1.35 and higher 

--- a/kubemarine/resources/configurations/globals.yaml
+++ b/kubemarine/resources/configurations/globals.yaml
@@ -361,6 +361,7 @@ compatibility_map:
       - os_family: 'rhel10'
         versions:
           - '10.1'
+          - '10.2'
     ubuntu:
       - os_family: 'debian'
         versions:


### PR DESCRIPTION
### Description
Add support for Rocky Linux 10.2 as a supported OS distribution.
* Rocky Linux 10.2 was not present in the list of supported distributive versions, so nodes running it were detected as `unknown` OS family and cluster installation/maintenance would fail.

Fixes # (issue)


### Solution
* Added `10.2` to the `rocky` → `os_family: rhel10` versions list in `kubemarine/resources/configurations/globals.yaml`, so that Rocky Linux 10.2 is recognized as the `rhel10` OS family (same as Rocky 10.1).
* Updated the list of supported operating systems in `docs/public/Installation.md` to include Rocky Linux 10.2.
* No new package/repository associations were needed: `haproxy`, `keepalived` and `containerd` versions for the `rhel10` family are already defined and are shared by all `rhel10` distributions (RHEL, Rocky, Oracle Linux), so Rocky 10.2 reuses the existing `rhel10` configuration.

### Test Cases

**TestCase 1**

Test Configuration:

- Hardware: 
- OS: Rocky Linux 10.2
- Inventory: default cluster.yaml with node(s) running Rocky Linux 10.2

Steps:

1. Prepare a node running Rocky Linux 10.2.
2. Run `kubemarine install` (or `kubemarine check_iaas`) against this node.

Results:

| Before | After |
| ------ | ------ |
| OS is detected as `unknown`/`unsupported` family, installation fails at OS compatibility check | OS is detected as `rhel10` family, installation proceeds normally |


### Checklist
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no breaking changes, or migration patch is provided
- [ ] Integration CI passed
- [ ] Unit tests. If Yes list of new/changed tests with brief description
- [ ] There is no merge conflicts


#### Unit tests
No unit tests added/changed.
